### PR TITLE
feat: per-command Discord slash permissions, Docker defaults, and repo allowlist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 .env.*
 !.env.example
 .venv/
+.venv*/
+.pydeps/
+.ci-venv/
 __pycache__/
 *.sqlite
 *.db

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ config/shubh-olrd.yaml
 test_snapshots_comprehensive.sh
 bot.log
 bot_output.log
+
+# Accidental npm artifacts (Python repo; no package.json)
+package-lock.json

--- a/config/aussie.yaml
+++ b/config/aussie.yaml
@@ -5,7 +5,7 @@
 runtime:
   mode: "active"
   log_level: "INFO"
-  data_dir: "./data/aussie"
+  data_dir: "/data"
   github_adapter: "ghdcbot.adapters.github.rest:GitHubRestAdapter"
   discord_adapter: "ghdcbot.adapters.discord.api:DiscordApiAdapter"
   storage_adapter: "ghdcbot.adapters.storage.sqlite:SqliteStorage"
@@ -21,6 +21,14 @@ github:
     read: true
     write: true
   user_fallback: false
+  # Repo allowlist: only these repositories are scanned (sync/run-once). Uses short repo names under the org (not "org/name").
+  # Omit this block entirely to include all org repos (slower on large orgs). mode "deny" excludes listed names instead.
+  repos:
+    mode: allow
+    names:
+      - "Gitcord-GithubDiscordBot"
+      # Add more repos as needed, e.g.:
+      # - "another-repo"
 
 discord:
   guild_id: "1022871757289422898"
@@ -28,6 +36,19 @@ discord:
   permissions:
     read: true
     write: true
+  # TESTING: set false in production — when true, any server member may use /assign-issue, /issue-requests, /sync.
+  unrestricted_slash_commands: true
+  # Per-command slash access (role_ids stable; role_names optional). Admins may use these when enabled below.
+  command_permissions:
+    assign-issue:
+      role_names: ["Mentor"]
+      allow_discord_administrators: true
+    issue-requests:
+      role_names: ["Mentor"]
+      allow_discord_administrators: true
+    sync:
+      role_names: ["Mentor"]
+      allow_discord_administrators: true
   activity_channel_id: null
   pr_preview_channels: []
   # Verified GitHub → Discord DMs (or channel if channel_id is set). Requires linked users (/link + /verify-link).

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -2,7 +2,7 @@
 runtime:
   mode: "active"
   log_level: "INFO"
-  data_dir: "./data"
+  data_dir: "/data"
   github_adapter: "ghdcbot.adapters.github.rest:GitHubRestAdapter"
   discord_adapter: "ghdcbot.adapters.discord.api:DiscordApiAdapter"
   storage_adapter: "ghdcbot.adapters.storage.sqlite:SqliteStorage"

--- a/config/docker-example.yaml
+++ b/config/docker-example.yaml
@@ -24,6 +24,18 @@ discord:
   permissions:
     read: true
     write: false
+  # Who may run /assign-issue, /issue-requests, /sync (add role_ids from Discord for stable checks).
+  # Omit this block to fall back to assignments.issue_assignees for those commands.
+  command_permissions:
+    assign-issue:
+      role_names: ["Mentor"]
+      allow_discord_administrators: true
+    issue-requests:
+      role_names: ["Mentor"]
+      allow_discord_administrators: true
+    sync:
+      role_names: ["Mentor"]
+      allow_discord_administrators: true
   activity_channel_id: null
   pr_preview_channels: []
 
@@ -42,6 +54,7 @@ role_mappings:
 assignments:
   review_roles:
     - "Maintainer"
+  # Fallback if discord.command_permissions is omitted; also used for org issue assignment planning.
   issue_assignees:
     - "Mentor"
   issue_request_eligible_roles: []

--- a/config/example.yaml
+++ b/config/example.yaml
@@ -33,6 +33,18 @@ discord:
   # Optional: channel names where PR URLs trigger passive preview (requires message content intent)
   # Example: ["mentor-chat", "review-queue"]
   pr_preview_channels: []
+  # Who may run /assign-issue, /issue-requests, /sync (role_ids preferred; role_names optional).
+  # If you omit this block entirely, the bot uses assignments.issue_assignees (role names) for those commands.
+  command_permissions:
+    assign-issue:
+      role_names: ["Mentor"]
+      allow_discord_administrators: true
+    issue-requests:
+      role_names: ["Mentor"]
+      allow_discord_administrators: true
+    sync:
+      role_names: ["Mentor"]
+      allow_discord_administrators: true
   # Optional: verified-only GitHub → Discord notifications (issue assigned, PR review, merged, etc.)
   # notifications:
   #   enabled: true
@@ -60,7 +72,7 @@ role_mappings:
 assignments:
   review_roles:
     - "Maintainer"
-  # Discord role(s) that can use /assign-issue, /sync, and /issue-requests (e.g. "Mentor")
+  # Fallback for slash-command access if discord.command_permissions is omitted; also used for org issue assignment planning.
   issue_assignees:
     - "Mentor"
   # Optional: roles required for a contributor to be "eligible" for issue assignment (empty = any verified user)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       - ./config:/app/config:ro
       # Persist SQLite state, reports, and audit logs between restarts.
       - gitcord_data:/data
-    command: ["ghdcbot", "--config", "/app/config/config.yaml", "bot"]
+    command: ["ghdcbot", "--config", "/app/config/aussie.yaml", "bot"]
     restart: unless-stopped
 
 volumes:

--- a/src/ghdcbot/bot.py
+++ b/src/ghdcbot/bot.py
@@ -50,6 +50,15 @@ from ghdcbot.engine.pr_context import (
 )
 from ghdcbot.logging.setup import configure_logging
 from ghdcbot.plugins.registry import build_adapter
+from ghdcbot.discord_command_permissions import (
+    format_slash_command_permission_denied,
+    slash_command_allowed,
+)
+
+# Slash command names used for permission checks (must match @tree.command name=...)
+SLASH_CMD_ASSIGN_ISSUE = "assign-issue"
+SLASH_CMD_ISSUE_REQUESTS = "issue-requests"
+SLASH_CMD_SYNC = "sync"
 
 
 def run_bot(config_path: str) -> None:
@@ -888,24 +897,20 @@ def run_bot(config_path: str) -> None:
                 except Exception:
                     pass
 
-    # Create a check function for mentor-only commands
-    def mentor_check(interaction: discord.Interaction) -> bool:
-        """Check if user has mentor role."""
-        mentor_roles = getattr(config, "assignments", None)
-        if not mentor_roles:
-            return False
-        issue_assignee_roles = getattr(mentor_roles, "issue_assignees", [])
-        if not issue_assignee_roles:
-            return False
-        user_roles = [role.name for role in interaction.user.roles]
-        return any(role in issue_assignee_roles for role in user_roles)
+    def command_permission_check(command_name: str):
+        """Restrict slash commands via discord.command_permissions or legacy issue_assignees."""
+
+        def check(interaction: discord.Interaction) -> bool:
+            return slash_command_allowed(interaction, config, command_name)
+
+        return check
 
     @tree.command(
         name="assign-issue",
         description="Assign a GitHub issue to a Discord user (mentor-only, requires confirmation)",
         guild=discord.Object(id=guild_id),
     )
-    @app_commands.check(mentor_check)
+    @app_commands.check(command_permission_check(SLASH_CMD_ASSIGN_ISSUE))
     @app_commands.describe(
         issue_url="GitHub issue URL (e.g., https://github.com/owner/repo/issues/123)",
         assignee="Discord user to assign the issue to"
@@ -1579,7 +1584,7 @@ def run_bot(config_path: str) -> None:
         description="List pending issue assignment requests (mentor-only); pick a repo first.",
         guild=discord.Object(id=guild_id),
     )
-    @app_commands.check(mentor_check)
+    @app_commands.check(command_permission_check(SLASH_CMD_ISSUE_REQUESTS))
     async def issue_requests_cmd(interaction: discord.Interaction) -> None:
         await interaction.response.defer(ephemeral=True)
         pending = getattr(storage, "list_pending_issue_requests", None)
@@ -1684,7 +1689,7 @@ def run_bot(config_path: str) -> None:
         description="Sync GitHub events and send notifications (mentor-only)",
         guild=discord.Object(id=guild_id),
     )
-    @app_commands.check(mentor_check)
+    @app_commands.check(command_permission_check(SLASH_CMD_SYNC))
     async def sync_cmd(interaction: discord.Interaction) -> None:
         """Manually trigger run-once to sync GitHub events and send notifications."""
         await interaction.response.defer(ephemeral=True)
@@ -1751,17 +1756,13 @@ def run_bot(config_path: str) -> None:
         """Handle app command errors, including check failures."""
         if isinstance(error, app_commands.CheckFailure):
             try:
-                mentor_roles = getattr(config, "assignments", None)
-                issue_assignee_roles = getattr(mentor_roles, "issue_assignees", []) if mentor_roles else []
-                role_list = ', '.join(issue_assignee_roles) if issue_assignee_roles else 'configure issue_assignees'
-                error_message = f"❌ Permission denied. Only mentors with roles **{role_list}** can use this command."
-                
+                cmd_name = interaction.command.name if interaction.command else "unknown"
+                error_message = format_slash_command_permission_denied(config, cmd_name)
                 logger.info(
-                    "Check failure for user %s (%s) on command %s. Required roles: %s",
+                    "Check failure for user %s (%s) on command %s.",
                     interaction.user.name,
                     interaction.user.id,
-                    interaction.command.name if interaction.command else "unknown",
-                    role_list,
+                    cmd_name,
                 )
                 
                 # Check if response is already sent (shouldn't happen for check failures, but be safe)

--- a/src/ghdcbot/config/models.py
+++ b/src/ghdcbot/config/models.py
@@ -58,6 +58,18 @@ class GitHubConfig(BaseModel):
     user_fallback: bool = False
 
 
+class SlashCommandPermissionRule(BaseModel):
+    """Who may run a restricted slash command (e.g. assign-issue, issue-requests, sync).
+
+    If a command is omitted from ``discord.command_permissions``, the bot falls back to
+    ``assignments.issue_assignees`` (role name match), for backward compatibility.
+    """
+
+    role_ids: list[str] = Field(default_factory=list)
+    role_names: list[str] = Field(default_factory=list)
+    allow_discord_administrators: bool = False
+
+
 class NotificationConfig(BaseModel):
     """Configuration for verified-only GitHub → Discord notifications."""
     enabled: bool = True
@@ -89,6 +101,10 @@ class DiscordConfig(BaseModel):
     pr_preview_channels: list[str] = Field(default_factory=list)
     # Optional: verified-only GitHub → Discord notifications
     notifications: NotificationConfig | None = None
+    # Optional: per-command slash permission (keys: assign-issue, issue-requests, sync). See SlashCommandPermissionRule.
+    command_permissions: dict[str, SlashCommandPermissionRule] | None = None
+    # TESTING ONLY: if true, any guild member may run assign-issue / issue-requests / sync. Turn off for production.
+    unrestricted_slash_commands: bool = False
 
 
 class QualityAdjustmentsConfig(BaseModel):

--- a/src/ghdcbot/discord_command_permissions.py
+++ b/src/ghdcbot/discord_command_permissions.py
@@ -1,0 +1,90 @@
+"""Per-slash-command permission checks (Discord roles + optional Administrator bypass)."""
+
+from __future__ import annotations
+
+import discord
+
+from ghdcbot.config.models import BotConfig, SlashCommandPermissionRule
+
+
+def _legacy_issue_assignee_allowed(member: discord.Member, config: BotConfig) -> bool:
+    """Backward compatible: assignments.issue_assignees matched by role name."""
+    mentor_roles = getattr(config, "assignments", None)
+    if not mentor_roles:
+        return False
+    issue_assignee_roles = getattr(mentor_roles, "issue_assignees", [])
+    if not issue_assignee_roles:
+        return False
+    user_roles = [role.name for role in member.roles]
+    return any(role in issue_assignee_roles for role in user_roles)
+
+
+def _is_guild_member_like(user: object) -> bool:
+    """True for Discord Member in a guild (has roles + guild_permissions). Duck-typed for tests."""
+    return hasattr(user, "roles") and hasattr(user, "guild_permissions")
+
+
+def slash_command_allowed(
+    interaction: discord.Interaction,
+    config: BotConfig,
+    command_name: str,
+) -> bool:
+    """Return True if the member may run this slash command."""
+    member = interaction.user
+    if not _is_guild_member_like(member):
+        return False
+
+    if getattr(config.discord, "unrestricted_slash_commands", False):
+        return True
+
+    perms = getattr(config.discord, "command_permissions", None)
+    rule: SlashCommandPermissionRule | None = None
+    if perms and command_name in perms:
+        rule = perms[command_name]
+
+    if rule is None:
+        return _legacy_issue_assignee_allowed(member, config)
+
+    if rule.allow_discord_administrators and member.guild_permissions.administrator:
+        return True
+
+    id_allow = {str(rid).strip() for rid in rule.role_ids if str(rid).strip()}
+    for role in member.roles:
+        if str(role.id) in id_allow:
+            return True
+
+    if rule.role_names:
+        allowed_names = set(rule.role_names)
+        user_role_names = {r.name for r in member.roles}
+        if user_role_names & allowed_names:
+            return True
+
+    return False
+
+
+def format_slash_command_permission_denied(config: BotConfig, command_name: str) -> str:
+    """User-facing message listing who may use the command."""
+    perms = getattr(config.discord, "command_permissions", None)
+    rule: SlashCommandPermissionRule | None = None
+    if perms and command_name in perms:
+        rule = perms[command_name]
+
+    if rule is None:
+        mentor_roles = getattr(config, "assignments", None)
+        issue_assignee_roles = getattr(mentor_roles, "issue_assignees", []) if mentor_roles else []
+        role_list = ", ".join(issue_assignee_roles) if issue_assignee_roles else "configure assignments.issue_assignees"
+        return (
+            f"❌ Permission denied. Only members with roles **{role_list}** "
+            f"can use `/{command_name}` (or set `discord.command_permissions`)."
+        )
+
+    bits: list[str] = []
+    if rule.role_ids:
+        bits.append("role ID(s): " + ", ".join(str(r) for r in rule.role_ids))
+    if rule.role_names:
+        bits.append("role name(s): " + ", ".join(rule.role_names))
+    if rule.allow_discord_administrators:
+        bits.append("Discord Administrators")
+    if not bits:
+        return f"❌ Permission denied. Nobody is allowed to use `/{command_name}` with the current rule (fix `discord.command_permissions`)."
+    return f"❌ Permission denied for `/{command_name}`. Allowed: {', '.join(bits)}."

--- a/tests/test_discord_command_permissions.py
+++ b/tests/test_discord_command_permissions.py
@@ -1,0 +1,221 @@
+"""Tests for per-slash-command Discord permission checks."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from ghdcbot.config.models import BotConfig, SlashCommandPermissionRule
+from ghdcbot.discord_command_permissions import (
+    format_slash_command_permission_denied,
+    slash_command_allowed,
+)
+
+
+def _minimal_config_payload(**discord_overrides: object) -> dict:
+    discord = {
+        "guild_id": "1",
+        "token": "t",
+        **discord_overrides,
+    }
+    return {
+        "runtime": {
+            "mode": "dry-run",
+            "log_level": "INFO",
+            "data_dir": "/tmp",
+            "github_adapter": "ghdcbot.adapters.github.rest:GitHubRestAdapter",
+            "discord_adapter": "ghdcbot.adapters.discord.api:DiscordApiAdapter",
+            "storage_adapter": "ghdcbot.adapters.storage.sqlite:SqliteStorage",
+        },
+        "github": {"org": "x", "token": "t", "api_base": "https://api.github.com"},
+        "discord": discord,
+        "scoring": {"period_days": 30, "weights": {"issue_opened": 1}},
+        "role_mappings": [{"discord_role": "Contributor", "min_score": 0}],
+        "assignments": {
+            "review_roles": [],
+            "issue_assignees": ["Mentor"],
+        },
+        "identity_mappings": [],
+    }
+
+
+def _member(
+    *role_specs: tuple[int, str],
+    administrator: bool = False,
+) -> SimpleNamespace:
+    roles = [SimpleNamespace(id=rid, name=name) for rid, name in role_specs]
+    return SimpleNamespace(
+        roles=roles,
+        guild_permissions=SimpleNamespace(administrator=administrator),
+    )
+
+
+def _interaction(member: SimpleNamespace) -> SimpleNamespace:
+    return SimpleNamespace(user=member)
+
+
+def test_legacy_issue_assignees_allows_matching_role_name() -> None:
+    config = BotConfig.model_validate(_minimal_config_payload())
+    member = _member((1, "Mentor"))
+    assert slash_command_allowed(_interaction(member), config, "sync") is True
+
+
+def test_legacy_issue_assignees_denies_when_no_match() -> None:
+    config = BotConfig.model_validate(_minimal_config_payload())
+    member = _member((1, "Contributor"))
+    assert slash_command_allowed(_interaction(member), config, "sync") is False
+
+
+def test_non_guild_user_denied() -> None:
+    config = BotConfig.model_validate(_minimal_config_payload())
+    plain_user = SimpleNamespace(id=123)  # no roles / guild_permissions
+    assert slash_command_allowed(_interaction(plain_user), config, "sync") is False
+
+
+def test_unrestricted_slash_commands_allows_any_guild_member() -> None:
+    config = BotConfig.model_validate(
+        _minimal_config_payload(
+            unrestricted_slash_commands=True,
+            command_permissions={
+                "sync": SlashCommandPermissionRule(
+                    role_names=["Mentor"],
+                    role_ids=[],
+                ),
+            },
+        ),
+    )
+    assert slash_command_allowed(_interaction(_member((1, "Contributor"))), config, "sync") is True
+    assert slash_command_allowed(_interaction(_member((1, "Student"))), config, "assign-issue") is True
+
+
+def test_command_permissions_role_name_match() -> None:
+    config = BotConfig.model_validate(
+        _minimal_config_payload(
+            command_permissions={
+                "sync": SlashCommandPermissionRule(
+                    role_names=["Lead"],
+                    allow_discord_administrators=False,
+                ),
+            },
+        ),
+    )
+    assert slash_command_allowed(_interaction(_member((1, "Lead"))), config, "sync") is True
+    assert slash_command_allowed(_interaction(_member((1, "Mentor"))), config, "sync") is False
+
+
+def test_command_permissions_role_id_match() -> None:
+    config = BotConfig.model_validate(
+        _minimal_config_payload(
+            command_permissions={
+                "assign-issue": SlashCommandPermissionRule(
+                    role_ids=["999"],
+                    role_names=[],
+                ),
+            },
+        ),
+    )
+    assert slash_command_allowed(_interaction(_member((999, "X"))), config, "assign-issue") is True
+    assert slash_command_allowed(_interaction(_member((1, "Mentor"))), config, "assign-issue") is False
+
+
+def test_command_permissions_administrator_bypass() -> None:
+    config = BotConfig.model_validate(
+        _minimal_config_payload(
+            command_permissions={
+                "sync": SlashCommandPermissionRule(
+                    role_names=[],
+                    role_ids=[],
+                    allow_discord_administrators=True,
+                ),
+            },
+        ),
+    )
+    admin = _member((1, "Random"), administrator=True)
+    assert slash_command_allowed(_interaction(admin), config, "sync") is True
+    non_admin = _member((1, "Random"), administrator=False)
+    assert slash_command_allowed(_interaction(non_admin), config, "sync") is False
+
+
+def test_omitted_command_falls_back_to_legacy() -> None:
+    """If command_permissions exists but key missing, use issue_assignees."""
+    config = BotConfig.model_validate(
+        _minimal_config_payload(
+            command_permissions={
+                "sync": SlashCommandPermissionRule(role_names=["OnlySync"], role_ids=[]),
+            },
+        ),
+    )
+    assert slash_command_allowed(_interaction(_member((1, "Mentor"))), config, "issue-requests") is True
+
+
+def test_empty_explicit_rule_denies_non_admin() -> None:
+    config = BotConfig.model_validate(
+        _minimal_config_payload(
+            command_permissions={
+                "sync": SlashCommandPermissionRule(
+                    role_names=[],
+                    role_ids=[],
+                    allow_discord_administrators=False,
+                ),
+            },
+        ),
+    )
+    assert slash_command_allowed(_interaction(_member((1, "Mentor"))), config, "sync") is False
+
+
+def test_format_denied_with_legacy_fallback() -> None:
+    config = BotConfig.model_validate(_minimal_config_payload())
+    msg = format_slash_command_permission_denied(config, "sync")
+    assert "Mentor" in msg
+    assert "/sync" in msg
+
+
+def test_format_denied_with_explicit_rule() -> None:
+    config = BotConfig.model_validate(
+        _minimal_config_payload(
+            command_permissions={
+                "sync": SlashCommandPermissionRule(
+                    role_ids=["111"],
+                    role_names=["Lead"],
+                    allow_discord_administrators=True,
+                ),
+            },
+        ),
+    )
+    msg = format_slash_command_permission_denied(config, "sync")
+    assert "111" in msg
+    assert "Lead" in msg
+    assert "Discord Administrators" in msg
+
+
+def test_format_denied_empty_rule_message() -> None:
+    config = BotConfig.model_validate(
+        _minimal_config_payload(
+            command_permissions={
+                "sync": SlashCommandPermissionRule(
+                    role_names=[],
+                    role_ids=[],
+                    allow_discord_administrators=False,
+                ),
+            },
+        ),
+    )
+    msg = format_slash_command_permission_denied(config, "sync")
+    assert "Nobody is allowed" in msg
+
+
+def test_config_accepts_command_permissions_in_yaml_shape() -> None:
+    """Regression: dict[str, dict] from YAML validates to SlashCommandPermissionRule."""
+    config = BotConfig.model_validate(
+        _minimal_config_payload(
+            command_permissions={
+                "assign-issue": {
+                    "role_names": ["Mentor"],
+                    "allow_discord_administrators": True,
+                },
+            },
+        ),
+    )
+    assert config.discord.command_permissions is not None
+    rule = config.discord.command_permissions["assign-issue"]
+    assert rule.role_names == ["Mentor"]
+    assert rule.allow_discord_administrators is True


### PR DESCRIPTION
## Summary
Adds **`discord.command_permissions`** so `/assign-issue`, `/issue-requests`, and `/sync` can be restricted by **Discord role IDs/names** and optional **Administrator** bypass, with **legacy fallback** to `assignments.issue_assignees` when a command is omitted. Includes a **testing-only** flag, **Docker-friendly** defaults, an optional **`github.repos`** allowlist for faster sync, **unit tests**, and **`.gitignore`** updates for local venvs—**without** committing any virtualenv or dependency trees.
## Behavior
| Setting | Purpose |
|--------|---------|
| `discord.command_permissions` | Map `assign-issue`, `issue-requests`, and `sync` to `role_ids`, `role_names`, `allow_discord_administrators`. |
| `discord.unrestricted_slash_commands` | If `true`, any guild member may use those commands (**testing only**; use `false` in production). |
| Omitted command in map | Falls back to existing **mentor / `issue_assignees`** behavior. |
## Config & ops
- **`docker-compose`**: default config path aligned for container use where applicable.
- **`config/config.yaml`** / examples: `data_dir` and documented Discord fields.
- **`config/aussie.yaml`**: example **`github.repos`** allowlist and permission blocks (adjust for your org).
## Tests
- `tests/test_discord_command_permissions.py` — allow/deny, admin bypass, unrestricted mode, legacy fallback.
## Notes
- This branch is a **single clean commit** on current `main` (no accidental `.pydeps` / `.venv` / `.ci-venv` history).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented role-based access control for Discord slash commands, allowing administrators to restrict command execution (`/assign-issue`, `/issue-requests`, `/sync`) to specific roles or Discord administrators.

* **Chores**
  * Updated data directory configurations.
  * Enhanced build artifacts and environment ignoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->