### PR TITLE
feat(snapshots): add raw event export behind include_raw_events flag

### DIFF
--- a/src/ghdcbot/config/models.py
+++ b/src/ghdcbot/config/models.py
@@ -214,6 +214,8 @@ class SnapshotConfig(BaseModel):
     repo_path: str = ""  # Format: "owner/repo" (e.g., "org/gitcord-data")
     # Optional: branch to write to (default: main/master)
     branch: str | None = None
+    # Optional: export raw ContributionEvent records to events.json (can be large)
+    include_raw_events: bool = False
 
 
 class BotConfig(BaseModel):

--- a/src/ghdcbot/engine/snapshots.py
+++ b/src/ghdcbot/engine/snapshots.py
@@ -114,6 +114,7 @@ def _write_snapshots(
         contribution_summaries=contribution_summaries,
         run_id=run_id,
         generated_at=now,
+        include_raw_events=getattr(snapshot_config, "include_raw_events", False),
     )
     
     # Write each snapshot file to GitHub
@@ -164,6 +165,7 @@ def _collect_snapshot_data(
     contribution_summaries: list[ContributionSummary] | None,
     run_id: str,
     generated_at: datetime,
+    include_raw_events: bool = False,
 ) -> dict[str, dict[str, Any]]:
     """Collect all snapshot data into structured dictionaries."""
     org = config.github.org
@@ -302,7 +304,7 @@ def _collect_snapshot_data(
         "data": notifications_data,
     }
     
-    return {
+    files: dict[str, dict[str, Any]] = {
         "meta.json": meta,
         "identities.json": identities,
         "scores.json": scores_snapshot,
@@ -311,6 +313,30 @@ def _collect_snapshot_data(
         "issue_requests.json": issue_requests,
         "notifications.json": notifications,
     }
+
+    if include_raw_events:
+        raw_events = storage.list_contributions(period_start)
+        events_data = [
+            {
+                "github_user": event.github_user,
+                "event_type": event.event_type,
+                "repo": event.repo,
+                "created_at": event.created_at.isoformat(),
+                "payload": event.payload,
+            }
+            for event in raw_events
+        ]
+        files["events.json"] = {
+            "schema_version": SCHEMA_VERSION,
+            "generated_at": generated_at.isoformat(),
+            "org": org,
+            "run_id": run_id,
+            "period_start": period_start.isoformat(),
+            "period_end": period_end.isoformat(),
+            "data": events_data,
+        }
+
+    return files
 
 
 def _parse_repo_path(repo_path: str) -> tuple[str, str]:

--- a/src/ghdcbot/engine/snapshots.py
+++ b/src/ghdcbot/engine/snapshots.py
@@ -114,7 +114,7 @@ def _write_snapshots(
         contribution_summaries=contribution_summaries,
         run_id=run_id,
         generated_at=now,
-        include_raw_events=getattr(snapshot_config, "include_raw_events", False),
+        include_raw_events=snapshot_config.include_raw_events,
     )
     
     # Write each snapshot file to GitHub
@@ -315,26 +315,27 @@ def _collect_snapshot_data(
     }
 
     if include_raw_events:
-        raw_events = storage.list_contributions(period_start)
-        events_data = [
-            {
-                "github_user": event.github_user,
-                "event_type": event.event_type,
-                "repo": event.repo,
-                "created_at": event.created_at.isoformat(),
-                "payload": event.payload,
+        list_contributions = getattr(storage, "list_contributions", None)
+        if callable(list_contributions):
+            events_data = [
+                {
+                    "github_user": event.github_user,
+                    "event_type": event.event_type,
+                    "repo": event.repo,
+                    "created_at": event.created_at.isoformat(),
+                    "payload": event.payload,
+                }
+                for event in list_contributions(period_start)
+            ]
+            files["events.json"] = {
+                "schema_version": SCHEMA_VERSION,
+                "generated_at": generated_at.isoformat(),
+                "org": org,
+                "run_id": run_id,
+                "period_start": period_start.isoformat(),
+                "period_end": period_end.isoformat(),
+                "data": events_data,
             }
-            for event in raw_events
-        ]
-        files["events.json"] = {
-            "schema_version": SCHEMA_VERSION,
-            "generated_at": generated_at.isoformat(),
-            "org": org,
-            "run_id": run_id,
-            "period_start": period_start.isoformat(),
-            "period_end": period_end.isoformat(),
-            "data": events_data,
-        }
 
     return files
 

--- a/src/ghdcbot/engine/snapshots.py
+++ b/src/ghdcbot/engine/snapshots.py
@@ -165,6 +165,7 @@ def _collect_snapshot_data(
     contribution_summaries: list[ContributionSummary] | None,
     run_id: str,
     generated_at: datetime,
+    *,
     include_raw_events: bool = False,
 ) -> dict[str, dict[str, Any]]:
     """Collect all snapshot data into structured dictionaries."""

--- a/src/ghdcbot/engine/snapshots.py
+++ b/src/ghdcbot/engine/snapshots.py
@@ -284,7 +284,7 @@ def _collect_snapshot_data(
     notifications_data = []
     list_notifications = getattr(storage, "list_recent_notifications", None)
     if callable(list_notifications):
-        recent_notifications = list_notifications(limit=1000)  # Last 1000 notifications
+        recent_notifications = list_notifications(1000)  # Last 1000 notifications
         for notif in recent_notifications:
             notifications_data.append({
                 "dedupe_key": notif.get("dedupe_key"),
@@ -327,6 +327,7 @@ def _collect_snapshot_data(
                     "payload": event.payload,
                 }
                 for event in list_contributions(period_start)
+                if event.created_at <= period_end
             ]
             files["events.json"] = {
                 "schema_version": SCHEMA_VERSION,

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -359,8 +359,8 @@ def _make_config(*, snapshots: "SnapshotConfig | None" = None) -> "BotConfig":
     )
 
 
-def test_raw_events_excluded_by_default() -> None:
-    """events.json is not written when include_raw_events is False (default)."""
+def test_raw_events_excluded_when_false() -> None:
+    """events.json is not written when include_raw_events is False."""
     storage = MockStorage()
     storage.contributions = [
         ContributionEvent(

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -18,7 +18,7 @@ from ghdcbot.config.models import (
     SnapshotConfig,
 )
 from ghdcbot.core.modes import RunMode
-from ghdcbot.core.models import ContributionSummary, Score
+from ghdcbot.core.models import ContributionEvent, ContributionSummary, Score
 from ghdcbot.engine.snapshots import (
     SCHEMA_VERSION,
     _collect_snapshot_data,
@@ -29,15 +29,19 @@ from ghdcbot.engine.snapshots import (
 
 class MockStorage:
     """Mock storage for testing."""
-    
+
     def __init__(self) -> None:
-        self.notifications = []
-    
+        self.notifications: list[dict] = []
+        self.contributions: list[ContributionEvent] = []
+
     def list_recent_notifications(self, limit: int = 1000) -> list[dict]:
         return self.notifications[:limit]
-    
+
     def list_pending_issue_requests(self) -> list[dict]:
         return []
+
+    def list_contributions(self, since: datetime) -> list[ContributionEvent]:
+        return [e for e in self.contributions if e.created_at >= since]
 
 
 class MockGitHubWriter:
@@ -334,3 +338,161 @@ def test_write_snapshots_handles_errors() -> None:
     
     # Should not have written files due to error
     assert len(github_writer.files_written) == 0
+
+
+def _make_config(*, snapshots: "SnapshotConfig | None" = None) -> "BotConfig":
+    return BotConfig(
+        runtime=RuntimeConfig(
+            mode=RunMode.DRY_RUN,
+            log_level="INFO",
+            data_dir="/tmp/test",
+            github_adapter="test",
+            discord_adapter="test",
+            storage_adapter="test",
+        ),
+        github=GitHubConfig(org="test-org", token="test", api_base="https://api.github.com", permissions=PermissionConfig()),
+        discord=DiscordConfig(guild_id="123", token="test", permissions=PermissionConfig()),
+        scoring=ScoringConfig(period_days=30, weights={}),
+        role_mappings=[RoleMappingConfig(discord_role="Contributor", min_score=10)],
+        assignments=AssignmentConfig(),
+        snapshots=snapshots,
+    )
+
+
+def test_raw_events_excluded_by_default() -> None:
+    """events.json is not written when include_raw_events is False (default)."""
+    storage = MockStorage()
+    storage.contributions = [
+        ContributionEvent(
+            github_user="alice",
+            event_type="pr_merged",
+            repo="org/repo",
+            created_at=datetime(2024, 1, 15, tzinfo=timezone.utc),
+            payload={"pr_number": 1},
+        )
+    ]
+    snapshots = _collect_snapshot_data(
+        storage=storage,
+        config=_make_config(),
+        identity_mappings=[],
+        scores=[],
+        member_roles={},
+        period_start=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        period_end=datetime(2024, 1, 31, tzinfo=timezone.utc),
+        contribution_summaries=None,
+        run_id="test-run",
+        generated_at=datetime(2024, 1, 31, 12, 0, 0, tzinfo=timezone.utc),
+        include_raw_events=False,
+    )
+    assert "events.json" not in snapshots
+
+
+def test_raw_events_included_when_enabled() -> None:
+    """events.json is written with correct structure when include_raw_events=True."""
+    storage = MockStorage()
+    storage.contributions = [
+        ContributionEvent(
+            github_user="alice",
+            event_type="pr_merged",
+            repo="org/repo",
+            created_at=datetime(2024, 1, 15, tzinfo=timezone.utc),
+            payload={"pr_number": 42},
+        ),
+        ContributionEvent(
+            github_user="bob",
+            event_type="issue_opened",
+            repo="org/repo",
+            created_at=datetime(2024, 1, 20, tzinfo=timezone.utc),
+            payload={"issue_number": 7},
+        ),
+    ]
+    snapshots = _collect_snapshot_data(
+        storage=storage,
+        config=_make_config(),
+        identity_mappings=[],
+        scores=[],
+        member_roles={},
+        period_start=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        period_end=datetime(2024, 1, 31, tzinfo=timezone.utc),
+        contribution_summaries=None,
+        run_id="test-run",
+        generated_at=datetime(2024, 1, 31, 12, 0, 0, tzinfo=timezone.utc),
+        include_raw_events=True,
+    )
+    assert "events.json" in snapshots
+    events_snapshot = snapshots["events.json"]
+    assert events_snapshot["schema_version"] == SCHEMA_VERSION
+    assert events_snapshot["org"] == "test-org"
+    assert len(events_snapshot["data"]) == 2
+    assert events_snapshot["data"][0]["github_user"] == "alice"
+    assert events_snapshot["data"][0]["event_type"] == "pr_merged"
+    assert events_snapshot["data"][0]["payload"] == {"pr_number": 42}
+    assert events_snapshot["data"][1]["github_user"] == "bob"
+
+
+def test_raw_events_respects_period_start() -> None:
+    """Only events at or after period_start are included in events.json."""
+    storage = MockStorage()
+    period_start = datetime(2024, 1, 10, tzinfo=timezone.utc)
+    storage.contributions = [
+        ContributionEvent(
+            github_user="alice",
+            event_type="pr_merged",
+            repo="org/repo",
+            created_at=datetime(2024, 1, 5, tzinfo=timezone.utc),  # before period_start
+            payload={},
+        ),
+        ContributionEvent(
+            github_user="bob",
+            event_type="pr_merged",
+            repo="org/repo",
+            created_at=datetime(2024, 1, 15, tzinfo=timezone.utc),  # within period
+            payload={},
+        ),
+    ]
+    snapshots = _collect_snapshot_data(
+        storage=storage,
+        config=_make_config(),
+        identity_mappings=[],
+        scores=[],
+        member_roles={},
+        period_start=period_start,
+        period_end=datetime(2024, 1, 31, tzinfo=timezone.utc),
+        contribution_summaries=None,
+        run_id="test-run",
+        generated_at=datetime(2024, 1, 31, 12, 0, 0, tzinfo=timezone.utc),
+        include_raw_events=True,
+    )
+    events_data = snapshots["events.json"]["data"]
+    assert len(events_data) == 1
+    assert events_data[0]["github_user"] == "bob"
+
+
+def test_write_snapshots_raw_events_via_config() -> None:
+    """include_raw_events=True in SnapshotConfig results in events.json being written."""
+    storage = MockStorage()
+    storage.contributions = [
+        ContributionEvent(
+            github_user="alice",
+            event_type="pr_merged",
+            repo="org/repo",
+            created_at=datetime(2024, 1, 15, tzinfo=timezone.utc),
+            payload={"pr_number": 1},
+        )
+    ]
+    config = _make_config(snapshots=SnapshotConfig(enabled=True, repo_path="org/repo", include_raw_events=True))
+    github_writer = MockGitHubWriter()
+
+    write_snapshots_to_github(
+        storage=storage,
+        config=config,
+        github_writer=github_writer,
+        identity_mappings=[],
+        scores=[],
+        member_roles={},
+        period_start=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        period_end=datetime(2024, 1, 31, tzinfo=timezone.utc),
+    )
+
+    written_paths = [path for _, _, path, _ in github_writer.files_written]
+    assert any("events.json" in p for p in written_paths)

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -1,6 +1,6 @@
 """Tests for GitHub snapshot writing."""
 
-from datetime import UTC, datetime, timezone
+from datetime import UTC, datetime
 from unittest.mock import MagicMock
 
 import pytest
@@ -99,8 +99,8 @@ def test_collect_snapshot_data() -> None:
     scores = [
         Score(
             github_user="alice",
-            period_start=datetime(2024, 1, 1, tzinfo=timezone.utc),
-            period_end=datetime(2024, 1, 31, tzinfo=timezone.utc),
+            period_start=datetime(2024, 1, 1, tzinfo=UTC),
+            period_end=datetime(2024, 1, 31, tzinfo=UTC),
             points=100,
         ),
     ]
@@ -110,10 +110,10 @@ def test_collect_snapshot_data() -> None:
         "456": ["Maintainer"],
     }
     
-    period_start = datetime(2024, 1, 1, tzinfo=timezone.utc)
-    period_end = datetime(2024, 1, 31, tzinfo=timezone.utc)
+    period_start = datetime(2024, 1, 1, tzinfo=UTC)
+    period_end = datetime(2024, 1, 31, tzinfo=UTC)
     run_id = "test-run-123"
-    generated_at = datetime(2024, 1, 31, 12, 0, 0, tzinfo=timezone.utc)
+    generated_at = datetime(2024, 1, 31, 12, 0, 0, tzinfo=UTC)
     
     snapshots = _collect_snapshot_data(
         storage=storage,
@@ -193,8 +193,8 @@ def test_collect_snapshot_data_with_contributors() -> None:
             prs_reviewed=2,
             comments=10,
             total_score=50,
-            period_start=datetime(2024, 1, 1, tzinfo=timezone.utc),
-            period_end=datetime(2024, 1, 31, tzinfo=timezone.utc),
+            period_start=datetime(2024, 1, 1, tzinfo=UTC),
+            period_end=datetime(2024, 1, 31, tzinfo=UTC),
         ),
     ]
     
@@ -204,11 +204,11 @@ def test_collect_snapshot_data_with_contributors() -> None:
         identity_mappings=[],
         scores=[],
         member_roles={},
-        period_start=datetime(2024, 1, 1, tzinfo=timezone.utc),
-        period_end=datetime(2024, 1, 31, tzinfo=timezone.utc),
+        period_start=datetime(2024, 1, 1, tzinfo=UTC),
+        period_end=datetime(2024, 1, 31, tzinfo=UTC),
         contribution_summaries=contribution_summaries,
         run_id="test-run",
-        generated_at=datetime(2024, 1, 31, 12, 0, 0, tzinfo=timezone.utc),
+        generated_at=datetime(2024, 1, 31, 12, 0, 0, tzinfo=UTC),
     )
     
     contributors = snapshots["contributors.json"]
@@ -246,8 +246,8 @@ def test_write_snapshots_disabled() -> None:
         identity_mappings=[],
         scores=[],
         member_roles={},
-        period_start=datetime(2024, 1, 1, tzinfo=timezone.utc),
-        period_end=datetime(2024, 1, 31, tzinfo=timezone.utc),
+        period_start=datetime(2024, 1, 1, tzinfo=UTC),
+        period_end=datetime(2024, 1, 31, tzinfo=UTC),
     )
     
     assert len(github_writer.files_written) == 0
@@ -283,8 +283,8 @@ def test_write_snapshots_enabled() -> None:
         ],
         scores=[],
         member_roles={},
-        period_start=datetime(2024, 1, 1, tzinfo=timezone.utc),
-        period_end=datetime(2024, 1, 31, tzinfo=timezone.utc),
+        period_start=datetime(2024, 1, 1, tzinfo=UTC),
+        period_end=datetime(2024, 1, 31, tzinfo=UTC),
     )
     
     # Should have written snapshot files
@@ -332,8 +332,8 @@ def test_write_snapshots_handles_errors() -> None:
         identity_mappings=[],
         scores=[],
         member_roles={},
-        period_start=datetime(2024, 1, 1, tzinfo=timezone.utc),
-        period_end=datetime(2024, 1, 31, tzinfo=timezone.utc),
+        period_start=datetime(2024, 1, 1, tzinfo=UTC),
+        period_end=datetime(2024, 1, 31, tzinfo=UTC),
     )
     
     # Should not have written files due to error
@@ -466,6 +466,44 @@ def test_raw_events_respects_period_start() -> None:
     events_data = snapshots["events.json"]["data"]
     assert len(events_data) == 1
     assert events_data[0]["github_user"] == "bob"
+
+
+def test_raw_events_respects_period_end() -> None:
+    """Only events at or before period_end are included in events.json."""
+    storage = MockStorage()
+    period_end = datetime(2024, 1, 31, tzinfo=UTC)
+    storage.contributions = [
+        ContributionEvent(
+            github_user="alice",
+            event_type="pr_merged",
+            repo="org/repo",
+            created_at=datetime(2024, 1, 15, tzinfo=UTC),  # within period
+            payload={},
+        ),
+        ContributionEvent(
+            github_user="bob",
+            event_type="pr_merged",
+            repo="org/repo",
+            created_at=datetime(2024, 2, 5, tzinfo=UTC),  # after period_end
+            payload={},
+        ),
+    ]
+    snapshots = _collect_snapshot_data(
+        storage=storage,
+        config=_make_config(),
+        identity_mappings=[],
+        scores=[],
+        member_roles={},
+        period_start=datetime(2024, 1, 1, tzinfo=UTC),
+        period_end=period_end,
+        contribution_summaries=None,
+        run_id="test-run",
+        generated_at=datetime(2024, 1, 31, 12, 0, 0, tzinfo=UTC),
+        include_raw_events=True,
+    )
+    events_data = snapshots["events.json"]["data"]
+    assert len(events_data) == 1
+    assert events_data[0]["github_user"] == "alice"
 
 
 def test_write_snapshots_raw_events_via_config() -> None:

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -1,6 +1,6 @@
 """Tests for GitHub snapshot writing."""
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime, timezone
 from unittest.mock import MagicMock
 
 import pytest
@@ -367,7 +367,7 @@ def test_raw_events_excluded_when_false() -> None:
             github_user="alice",
             event_type="pr_merged",
             repo="org/repo",
-            created_at=datetime(2024, 1, 15, tzinfo=timezone.utc),
+            created_at=datetime(2024, 1, 15, tzinfo=UTC),
             payload={"pr_number": 1},
         )
     ]
@@ -377,11 +377,11 @@ def test_raw_events_excluded_when_false() -> None:
         identity_mappings=[],
         scores=[],
         member_roles={},
-        period_start=datetime(2024, 1, 1, tzinfo=timezone.utc),
-        period_end=datetime(2024, 1, 31, tzinfo=timezone.utc),
+        period_start=datetime(2024, 1, 1, tzinfo=UTC),
+        period_end=datetime(2024, 1, 31, tzinfo=UTC),
         contribution_summaries=None,
         run_id="test-run",
-        generated_at=datetime(2024, 1, 31, 12, 0, 0, tzinfo=timezone.utc),
+        generated_at=datetime(2024, 1, 31, 12, 0, 0, tzinfo=UTC),
         include_raw_events=False,
     )
     assert "events.json" not in snapshots
@@ -395,14 +395,14 @@ def test_raw_events_included_when_enabled() -> None:
             github_user="alice",
             event_type="pr_merged",
             repo="org/repo",
-            created_at=datetime(2024, 1, 15, tzinfo=timezone.utc),
+            created_at=datetime(2024, 1, 15, tzinfo=UTC),
             payload={"pr_number": 42},
         ),
         ContributionEvent(
             github_user="bob",
             event_type="issue_opened",
             repo="org/repo",
-            created_at=datetime(2024, 1, 20, tzinfo=timezone.utc),
+            created_at=datetime(2024, 1, 20, tzinfo=UTC),
             payload={"issue_number": 7},
         ),
     ]
@@ -412,11 +412,11 @@ def test_raw_events_included_when_enabled() -> None:
         identity_mappings=[],
         scores=[],
         member_roles={},
-        period_start=datetime(2024, 1, 1, tzinfo=timezone.utc),
-        period_end=datetime(2024, 1, 31, tzinfo=timezone.utc),
+        period_start=datetime(2024, 1, 1, tzinfo=UTC),
+        period_end=datetime(2024, 1, 31, tzinfo=UTC),
         contribution_summaries=None,
         run_id="test-run",
-        generated_at=datetime(2024, 1, 31, 12, 0, 0, tzinfo=timezone.utc),
+        generated_at=datetime(2024, 1, 31, 12, 0, 0, tzinfo=UTC),
         include_raw_events=True,
     )
     assert "events.json" in snapshots
@@ -433,20 +433,20 @@ def test_raw_events_included_when_enabled() -> None:
 def test_raw_events_respects_period_start() -> None:
     """Only events at or after period_start are included in events.json."""
     storage = MockStorage()
-    period_start = datetime(2024, 1, 10, tzinfo=timezone.utc)
+    period_start = datetime(2024, 1, 10, tzinfo=UTC)
     storage.contributions = [
         ContributionEvent(
             github_user="alice",
             event_type="pr_merged",
             repo="org/repo",
-            created_at=datetime(2024, 1, 5, tzinfo=timezone.utc),  # before period_start
+            created_at=datetime(2024, 1, 5, tzinfo=UTC),  # before period_start
             payload={},
         ),
         ContributionEvent(
             github_user="bob",
             event_type="pr_merged",
             repo="org/repo",
-            created_at=datetime(2024, 1, 15, tzinfo=timezone.utc),  # within period
+            created_at=datetime(2024, 1, 15, tzinfo=UTC),  # within period
             payload={},
         ),
     ]
@@ -457,10 +457,10 @@ def test_raw_events_respects_period_start() -> None:
         scores=[],
         member_roles={},
         period_start=period_start,
-        period_end=datetime(2024, 1, 31, tzinfo=timezone.utc),
+        period_end=datetime(2024, 1, 31, tzinfo=UTC),
         contribution_summaries=None,
         run_id="test-run",
-        generated_at=datetime(2024, 1, 31, 12, 0, 0, tzinfo=timezone.utc),
+        generated_at=datetime(2024, 1, 31, 12, 0, 0, tzinfo=UTC),
         include_raw_events=True,
     )
     events_data = snapshots["events.json"]["data"]
@@ -476,7 +476,7 @@ def test_write_snapshots_raw_events_via_config() -> None:
             github_user="alice",
             event_type="pr_merged",
             repo="org/repo",
-            created_at=datetime(2024, 1, 15, tzinfo=timezone.utc),
+            created_at=datetime(2024, 1, 15, tzinfo=UTC),
             payload={"pr_number": 1},
         )
     ]
@@ -490,9 +490,34 @@ def test_write_snapshots_raw_events_via_config() -> None:
         identity_mappings=[],
         scores=[],
         member_roles={},
-        period_start=datetime(2024, 1, 1, tzinfo=timezone.utc),
-        period_end=datetime(2024, 1, 31, tzinfo=timezone.utc),
+        period_start=datetime(2024, 1, 1, tzinfo=UTC),
+        period_end=datetime(2024, 1, 31, tzinfo=UTC),
     )
 
     written_paths = [path for _, _, path, _ in github_writer.files_written]
     assert any("events.json" in p for p in written_paths)
+
+
+def test_raw_events_graceful_when_storage_missing_method() -> None:
+    """events.json is omitted gracefully if storage lacks list_contributions."""
+    class MinimalStorage:
+        def list_recent_notifications(self, limit: int = 1000) -> list[dict]:
+            return []
+        def list_pending_issue_requests(self) -> list[dict]:
+            return []
+
+    storage = MinimalStorage()
+    snapshots = _collect_snapshot_data(
+        storage=storage,
+        config=_make_config(),
+        identity_mappings=[],
+        scores=[],
+        member_roles={},
+        period_start=datetime(2024, 1, 1, tzinfo=UTC),
+        period_end=datetime(2024, 1, 31, tzinfo=UTC),
+        contribution_summaries=None,
+        run_id="test-run",
+        generated_at=datetime(2024, 1, 31, 12, 0, 0, tzinfo=UTC),
+        include_raw_events=True,
+    )
+    assert "events.json" not in snapshots

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -501,7 +501,7 @@ def test_write_snapshots_raw_events_via_config() -> None:
 def test_raw_events_graceful_when_storage_missing_method() -> None:
     """events.json is omitted gracefully if storage lacks list_contributions."""
     class MinimalStorage:
-        def list_recent_notifications(self, limit: int = 1000) -> list[dict]:
+        def list_recent_notifications(self, _limit: int = 1000) -> list[dict]:
             return []
         def list_pending_issue_requests(self) -> list[dict]:
             return []


### PR DESCRIPTION
## What this does

Adds a `include_raw_events` flag to `SnapshotConfig` that, when enabled, writes a `events.json` file alongside the other snapshot files in each snapshot directory.

The flag defaults to `False`, so existing deployments are unaffected.

## Changes

**`config/models.py`**
- Added `include_raw_events: bool = False` to `SnapshotConfig`

**`engine/snapshots.py`**
- Passes `include_raw_events` from config down to `_collect_snapshot_data`
- In `_collect_snapshot_data`, uses `getattr(storage, "list_contributions", None)` + `callable()` guard, consistent with how other optional storage methods are called in this module
- When enabled, writes `events.json` with the same envelope schema as other snapshot files (`schema_version`, `generated_at`, `org`, `run_id`, `period_start`, `period_end`, `data`)

**`tests/test_snapshots.py`**
- Added `list_contributions` to `MockStorage` and a `contributions` list for test data
- Four new tests:
  - `test_raw_events_excluded_when_false` - flag off, no `events.json`
  - `test_raw_events_included_when_enabled` - flag on, `events.json` present with correct fields
  - `test_raw_events_respects_period_start` - only events at or after `period_start` appear
  - `test_write_snapshots_raw_events_via_config` - end-to-end: config flag triggers file write via `github_writer`

## Why the getattr guard

The call to `storage.list_contributions` is guarded the same way `list_pending_issue_requests` and `list_recent_notifications` are guarded elsewhere in this file. The snapshot module accepts `storage: Any` and is designed to degrade gracefully if a storage adapter does not implement a given method.

## Testing

```
pytest tests/test_snapshots.py  # 11 passed
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Snapshot export can optionally include raw contribution events. When enabled, an events.json is produced with event metadata, timestamps, and run/org info; it respects the snapshot period (filters out older events) and is omitted gracefully if the backend cannot provide events.

* **Tests**
  * Added coverage for events.json inclusion/exclusion, content structure and ordering, period filtering, and backend-absence behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->