### PR TITLE
ci: run sync-pr-labels on pull_request_target only

### DIFF
--- a/.github/workflows/sync-pr-labels.yml
+++ b/.github/workflows/sync-pr-labels.yml
@@ -1,8 +1,9 @@
 name: Sync PR Labels
 
+# Use pull_request_target only: fork PRs get a read-only GITHUB_TOKEN on
+# pull_request, so issues.addLabels returns 403. This job only calls the API
+# (no checkout of PR code), which is the safe pattern for pull_request_target.
 on:
-  pull_request:
-    types: [opened, reopened, synchronize, edited]
   pull_request_target:
     types: [opened, reopened, synchronize, edited]
 


### PR DESCRIPTION
## Summary

Restrict **Sync PR Labels** to **`pull_request_target`** so fork PRs can add labels without **403 Resource not accessible by integration**.

## Problem

The workflow listened to both **`pull_request`** and **`pull_request_target`**. For PRs from **forks**, GitHub gives **`GITHUB_TOKEN`** **read-only** access on `pull_request`, so calls like `issues.addLabels` fail with **403**, even after approving the workflow.

## Solution

Trigger only on **`pull_request_target`**, which provides a token that can label PRs on the base repository.

This workflow only uses **`github-script`** and the REST API (it does **not** check out the PR branch), which is the safe pattern for `pull_request_target`.

## Test plan

- [ ] Merge this PR.
- [ ] Open or push to a PR from a **fork** and confirm **Sync PR Labels** completes (e.g. `no-issue-linked` and file-based labels apply).
- [ ] Spot-check a **same-repo** PR if you use them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pull request workflow configuration to improve token permission handling for external contributions, ensuring streamlined processing of pull requests from forks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->