### PR TITLE
Fix identity relink status after unlink

### DIFF
--- a/QUICK_START_GUIDE.txt
+++ b/QUICK_START_GUIDE.txt
@@ -1,0 +1,52 @@
+GITCORD BOT - QUICK START GUIDE
+================================
+
+1. LINK YOUR GITHUB ACCOUNT (Required First Step)
+---------------------------------------------------
+Type in Discord: /link
+• Bot will DM you a verification code
+• Comment that code on any GitHub issue/PR
+• Return to Discord and type: /verify-link
+
+2. AVAILABLE COMMANDS
+-------------------
+/link               - Start GitHub identity linking
+/verify-link        - Complete identity verification  
+/unlink             - Remove your GitHub link
+/status             - Check your linked GitHub account
+/metrics            - View your contribution stats
+/request-issue      - Request an issue assignment (needs mentor approval)
+/assign-issue       - Directly assign yourself to an issue (mentors only)
+/sync               - Manually sync data (mentors only)
+/issue-requests     - View pending issue requests (mentors only)
+
+3. HOW TO REQUEST AN ISSUE
+--------------------------
+1. Find an issue on GitHub you want to work on
+2. Copy the issue URL
+3. In Discord type: /request-issue <paste-url>
+4. A mentor will review and approve your request
+5. Once approved, the issue is assigned to you on GitHub
+
+4. FOR MENTORS
+--------------
+• /assign-issue <url> - Instantly assign issue to yourself or others
+• /sync - Refresh all data and apply pending changes
+• /issue-requests - View all pending requests from contributors
+
+5. HOW SCORING WORKS
+--------------------
+• PR merged = +10 points (base)
+• Difficulty labels adjust score (easy/medium/hard)
+• Quality bonuses: PR review (+2), helpful comment (+1)
+• Quality penalties: Reverted PR (-5), failed CI merge (-3)
+• Top contributors get Discord roles automatically
+
+6. TIPS
+-------
+• Must be verified (/link + /verify-link) to use most commands
+• Use /metrics to track your progress
+• Request issues early - they're assigned on first-come basis
+• Stay active to maintain contributor roles
+
+Need help? Type /status to check your verification status.

--- a/TECHNICAL_DOCUMENTATION.md
+++ b/TECHNICAL_DOCUMENTATION.md
@@ -852,12 +852,17 @@ class MutationPolicy:
 - `GET /repos/{owner}/{repo}/commits` - Commit history (for PR context)
 
 **Event Types Ingested:**
-- `issue_opened` - New issue created
-- `issue_assigned` - Issue assigned to user
-- `pr_opened` - New PR created
-- `pr_merged` - PR merged
+- `issue_opened` - New issue created (ingested for reports, not scored)
+- `issue_assigned` - Issue assigned to user (triggers notification)
+- `pr_opened` - New PR created (ingested for reports, not scored)
+- `pr_merged` - PR merged (**only event that affects scores** - merge-only scoring)
 - `pr_reviewed` - PR review submitted (approved/changes_requested/comment)
-- `comment` - Comment on issue/PR
+- `comment` - Comment on issue/PR (ingested for reports, not scored)
+- `pr_reverted` - Reverted PR (quality penalty if configured)
+- `pr_merged_with_failed_ci` - PR merged with failing CI (quality penalty if configured)
+- `helpful_comment` - Comment marked as helpful (quality bonus if configured)
+
+**Note on Scoring:** Gitcord uses merge-only scoring. Only `pr_merged` events contribute to contributor scores. Other events (issue_opened, pr_opened, comment) are ingested for audit trails and activity reports but do not affect scoring. This prevents spam and gaming while keeping the system simple and mentor-approved.
 
 **Incremental Ingestion:**
 - Uses `cursors` table to track last-seen timestamp
@@ -1137,6 +1142,10 @@ runtime:
   github_adapter: "ghdcbot.adapters.github.rest:GitHubRestAdapter"
   discord_adapter: "ghdcbot.adapters.discord.api:DiscordApiAdapter"
   storage_adapter: "ghdcbot.adapters.storage.sqlite:SqliteStorage"
+  # Optional: Disable scoring while keeping ingestion (default: true)
+  enable_scoring: true
+  # Optional: Disable Discord role updates while keeping notifications (default: true)
+  enable_discord_role_updates: true
 
 github:
   org: "example-org"
@@ -1145,6 +1154,14 @@ github:
   permissions:
     read: true
     write: true
+  # Optional: If true, fallback to user repos when org access fails (default: false)
+  user_fallback: false
+  # Optional: Filter repos to include/exclude
+  repos:
+    mode: "allow"  # or "deny"
+    names:
+      - "repo-a"
+      - "repo-b"
 
 discord:
   guild_id: "123456789"
@@ -1152,22 +1169,56 @@ discord:
   permissions:
     read: true
     write: true
+  # Optional: Channel ID for activity feed summary (default: null)
+  activity_channel_id: null
+  # Optional: Channel names where PR URLs trigger passive preview (requires message content intent)
+  pr_preview_channels: []
+  # Optional: Per-command permission rules (if omitted, falls back to assignments.issue_assignees)
+  command_permissions:
+    assign-issue:
+      role_ids: []
+      role_names: ["Mentor"]
+      allow_discord_administrators: true
+    issue-requests:
+      role_ids: []
+      role_names: ["Mentor"]
+      allow_discord_administrators: true
+    sync:
+      role_ids: []
+      role_names: ["Mentor"]
+      allow_discord_administrators: true
+  # TESTING ONLY: Allow any guild member to run restricted commands (default: false)
+  unrestricted_slash_commands: false
   notifications:
     enabled: true
     issue_assignment: true
     pr_review_requested: true
     pr_review_result: true
     pr_merged: true
-    channel_id: null
+    # Optional: CodeRabbit reminder for old review comments
+    coderabbit_reminders: false
+    coderabbit_reminder_after_hours: 48
+    coderabbit_bot_logins: ["coderabbitai", "coderabbitai[bot]"]
+    channel_id: null  # null = DM; set to channel ID to post there
 
 scoring:
   period_days: 30
+  # Note: Only "pr_merged" events affect scores (merge-only scoring to prevent spam)
   weights:
-    issue_opened: 3
-    pr_opened: 5
-    pr_reviewed: 2
-    comment: 1
     pr_merged: 10
+  # Optional: Difficulty-aware scoring via PR labels (e.g., "easy", "medium", "hard")
+  difficulty_weights:
+    easy: 5
+    medium: 10
+    hard: 20
+  # Optional: Quality adjustments (penalties and bonuses)
+  quality_adjustments:
+    penalties:
+      reverted_pr: 5
+      failed_ci_merge: 3
+    bonuses:
+      pr_review: 2
+      helpful_comment: 1
 
 role_mappings:
   - discord_role: "Contributor"
@@ -1175,11 +1226,28 @@ role_mappings:
   - discord_role: "Maintainer"
     min_score: 40
 
+assignments:
+  review_roles:
+    - "Maintainer"
+  issue_assignees:
+    - "Mentor"
+  # Optional: Roles required for issue request eligibility (empty = any verified user)
+  issue_request_eligible_roles: []
+
 merge_role_rules:
   enabled: true
   rules:
     - discord_role: "apprentice"
       min_merged_prs: 1
+
+# Optional: Grant Discord roles when contributor has PR merged in specific repo
+repo_contributor_roles:
+  repo-name: "discord-role-name"
+
+# Optional: Identity linking settings
+identity:
+  unlink_cooldown_hours: 24
+  verified_max_age_days: null  # null = no stale check; or set days (e.g., 90)
 
 snapshots:
   enabled: true
@@ -1193,13 +1261,16 @@ snapshots:
 
 - **Adapter:** Plugin component (GitHub reader/writer, Discord reader/writer, Storage)
 - **Claim:** Pending identity link (before verification)
-- **Contribution Event:** Raw GitHub activity (issue_opened, pr_opened, etc.)
+- **Contribution Event:** Raw GitHub activity ingested (issue_opened, pr_opened, pr_merged, pr_reviewed, comment, pr_reverted, pr_merged_with_failed_ci, helpful_comment). Note: Only `pr_merged` events affect scores (merge-only scoring); others are tracked for reports and audit.
 - **Cursor:** Timestamp tracking for incremental ingestion
 - **Deduplication:** Preventing duplicate operations (assignments, notifications)
 - **Identity Mapping:** Verified Discord ↔ GitHub link
+- **Merge-Only Scoring:** Score calculation uses only `pr_merged` events to prevent spam and gaming. Other events are ingested but don't contribute to scores.
 - **Mutation:** Write operation (role change, issue assignment)
 - **Orchestrator:** Core execution engine for `run-once` cycle
 - **Plan:** Precomputed change (role add/remove, issue assignment)
+- **Quality Adjustments:** Optional scoring bonuses/penalties for PR reviews, helpful comments, reverted PRs, and failed CI merges.
+- **Repo Contributor Roles:** Discord roles granted when a user has a PR merged in a specific repository.
 - **Snapshot:** GitHub-backed JSON state export
 - **Verified User:** Discord user with verified GitHub link
 

--- a/config/aussie.yaml
+++ b/config/aussie.yaml
@@ -36,7 +36,7 @@ discord:
     read: true
     write: true
   # TESTING: set false in production — when true, any server member may use /assign-issue, /issue-requests, /sync.
-  unrestricted_slash_commands: true
+  unrestricted_slash_commands: false
   # Per-command slash access (role_ids stable; role_names optional). Admins may use these when enabled below.
   command_permissions:
     assign-issue:

--- a/docs/IDENTITY_VERIFICATION.md
+++ b/docs/IDENTITY_VERIFICATION.md
@@ -1,0 +1,679 @@
+# Identity Verification: `/link` and `/verify-link`
+
+This document explains the Gitcord identity verification system end to end: what happens when a Discord user runs `/link`, how `/verify-link` proves GitHub ownership, where the data is stored, and which code paths implement the flow.
+
+## What This System Solves
+
+Gitcord needs a trusted mapping between a Discord user and a GitHub username. That mapping is used later for contribution summaries, role planning, issue assignment, PR context mentions, and other features that depend on knowing which GitHub account belongs to which Discord member.
+
+The project uses a lightweight verification-code flow instead of OAuth:
+
+1. A Discord user runs `/link github_username`.
+2. Gitcord creates a short-lived verification code and stores a pending claim.
+3. The user puts that code in their GitHub profile bio or a public gist.
+4. The user clicks the **Verify** button in the ephemeral `/link` message.
+5. Gitcord checks public GitHub data for the code.
+6. If the code is found, Gitcord marks the Discord-to-GitHub mapping as verified.
+
+The older `/verify-link github_username` command remains available and uses the same verification logic.
+
+## Main Files
+
+| File | Purpose |
+| --- | --- |
+| `src/ghdcbot/bot.py` | Discord slash commands and identity verification buttons: `/link`, `/verify-link`, `/verify`, `/status`, `/unlink`, `/identity status`. |
+| `src/ghdcbot/engine/identity_linking.py` | Business logic for creating claims, verifying claims, generating codes, audit events, and unlinking. |
+| `src/ghdcbot/adapters/github/identity.py` | Read-only GitHub adapter that searches the user's bio and public gists for the code. |
+| `src/ghdcbot/adapters/storage/sqlite.py` | SQLite schema and persistence for pending and verified identity links. |
+| `src/ghdcbot/cli.py` | CLI version of the same `link` and `verify-link` workflow. |
+| `tests/test_identity_linking.py` | Tests covering code generation, verification, impersonation protection, stale refresh, unlinking, and status. |
+
+## High-Level Flow
+
+```text
+Discord user
+  |
+  | /link github_username
+  v
+bot.py link_cmd()
+  |
+  v
+IdentityLinkService.create_claim()
+  |
+  | generate 10-character code
+  | create pending identity_links row
+  | write identity_claim_created audit event
+  v
+User puts code in GitHub bio or public gist
+  |
+  | click Verify
+  v
+bot.py IdentityVerificationView.verify_identity()
+  |
+  v
+IdentityLinkService.verify_claim()
+  |
+  | load pending claim from SQLite
+  | reject expired claim
+  | search GitHub bio and public gists
+  v
+GitHubIdentityReader.search_verification_code()
+  |
+  v
+If found:
+  mark row verified=1
+  clear verification_code and expires_at
+  set verified_at
+  write identity_verified audit event
+```
+
+## Discord Command Setup
+
+When the bot starts, it builds shared storage, GitHub identity reader, and identity service instances:
+
+```python
+storage = build_adapter(
+    config.runtime.storage_adapter,
+    data_dir=config.runtime.data_dir,
+)
+storage.init_schema()
+github_identity = GitHubIdentityReader(
+    token=config.github.token,
+    api_base=str(config.github.api_base),
+)
+service = IdentityLinkService(storage=storage, github_identity=github_identity)
+```
+
+This means the Discord bot and CLI both use the same SQLite storage and the same verification service.
+
+## `/link`: Create a Pending Claim and Button UI
+
+The `/link` slash command lives in `src/ghdcbot/bot.py`.
+
+```python
+@tree.command(
+    name="link",
+    description="Link your Discord account to a GitHub account (you get a verification code)",
+    guild=discord.Object(id=guild_id),
+)
+@app_commands.describe(github_username="Your GitHub username")
+async def link_cmd(interaction: discord.Interaction, github_username: str) -> None:
+    await interaction.response.defer(ephemeral=True)
+    discord_user_id = str(interaction.user.id)
+    max_age_days = None
+    if getattr(config, "identity", None) is not None:
+        max_age_days = getattr(config.identity, "verified_max_age_days", None)
+    try:
+        claim = service.create_claim(discord_user_id, github_username, max_age_days=max_age_days)
+    except ValueError as e:
+        await interaction.followup.send(
+            f"Cannot create link: {e}",
+            ephemeral=True,
+        )
+        return
+    embed = build_identity_verification_embed(claim)
+    view = IdentityVerificationView(
+        service=service,
+        storage=storage,
+        discord_user_id=discord_user_id,
+        github_user=github_username,
+    )
+    await interaction.followup.send(embed=embed, view=view, ephemeral=True)
+```
+
+Important behavior:
+
+- The reply is ephemeral, so only the user sees the verification code and buttons.
+- The Discord user ID comes from `interaction.user.id`; users cannot provide someone else's Discord ID through the slash command.
+- The command calls `IdentityLinkService.create_claim()`.
+- If a duplicate, impersonation, or already-verified case is detected, the command sends the `ValueError` message back to the user.
+- The Verify button calls the same `IdentityLinkService.verify_claim()` method used by `/verify-link`.
+
+The embed is built from the stored claim:
+
+```python
+def build_identity_verification_embed(claim: LinkClaim) -> discord.Embed:
+    embed = discord.Embed(
+        title="Verify GitHub Account",
+        description=(
+            "1. Copy this code.\n"
+            "2. Paste it into your GitHub bio or public gist.\n"
+            "3. Click Verify."
+        ),
+        color=0x2563EB,
+    )
+    embed.add_field(name="GitHub Account", value=claim.github_user, inline=False)
+    embed.add_field(name="Verification Code", value=f"`{claim.verification_code}`", inline=False)
+    embed.add_field(name="Expires At (UTC)", value=claim.expires_at.isoformat(), inline=False)
+    return embed
+```
+
+## Verify and Cancel Buttons
+
+`IdentityVerificationView` owns the two buttons shown under the `/link` embed:
+
+```python
+verify_button = discord.ui.Button(label="Verify", style=discord.ButtonStyle.success)
+verify_button.callback = self.verify_identity
+self.add_item(verify_button)
+
+cancel_button = discord.ui.Button(label="Cancel", style=discord.ButtonStyle.secondary)
+cancel_button.callback = self.cancel_verification
+self.add_item(cancel_button)
+```
+
+The Verify button:
+
+1. Uses `interaction.user.id` to identify the Discord user who clicked.
+2. Loads the saved identity row from SQLite.
+3. Reads the GitHub username from that row.
+4. Calls `IdentityLinkService.verify_claim(discord_user_id, github_user)`.
+
+It does not duplicate GitHub lookup, expiry handling, storage updates, or audit behavior.
+
+If the code is not found, the button sends an ephemeral failure message and leaves the original Verify button active so the user can fix their bio/gist and try again.
+
+The Cancel button edits the original ephemeral message to:
+
+```text
+Verification cancelled.
+```
+
+and disables the buttons.
+
+## Claim Creation Logic
+
+The service creates a `LinkClaim` with a generated code and expiration time:
+
+```python
+@dataclass(frozen=True)
+class LinkClaim:
+    discord_user_id: str
+    github_user: str
+    verification_code: str
+    expires_at: datetime
+```
+
+```python
+def create_claim(self, discord_user_id: str, github_user: str, *, max_age_days: int | None = None) -> LinkClaim:
+    code = _generate_verification_code()
+    expires_at = datetime.now(timezone.utc) + self._ttl
+    self._storage.create_identity_claim(
+        discord_user_id=discord_user_id,
+        github_user=github_user,
+        verification_code=code,
+        expires_at=expires_at,
+        max_age_days=max_age_days,
+    )
+    append_audit = getattr(self._storage, "append_audit_event", None)
+    if callable(append_audit):
+        append_audit({
+            "actor_type": "discord_user",
+            "actor_id": discord_user_id,
+            "event_type": "identity_claim_created",
+            "context": {"github_user": github_user, "expires_at": expires_at.isoformat()},
+        })
+    return LinkClaim(
+        discord_user_id=discord_user_id,
+        github_user=github_user,
+        verification_code=code,
+        expires_at=expires_at,
+    )
+```
+
+The verification code is 10 characters long and uses uppercase letters plus digits:
+
+```python
+def _generate_verification_code(length: int = 10) -> str:
+    alphabet = string.ascii_uppercase + string.digits
+    return "".join(secrets.choice(alphabet) for _ in range(length))
+```
+
+By default, claims live for 10 minutes because `IdentityLinkService` sets `ttl_minutes: int = 10`.
+
+## SQLite Storage
+
+Identity links are stored in the `identity_links` table:
+
+```sql
+CREATE TABLE IF NOT EXISTS identity_links (
+    discord_user_id TEXT NOT NULL,
+    github_user TEXT NOT NULL,
+    verified INTEGER NOT NULL DEFAULT 0,
+    verification_code TEXT,
+    expires_at TEXT,
+    created_at TEXT NOT NULL,
+    verified_at TEXT,
+    PRIMARY KEY (discord_user_id, github_user)
+);
+```
+
+The schema also adds:
+
+- `unlinked_at TEXT`, so unlinking preserves history instead of deleting rows.
+- `github_user_normalized TEXT`, so GitHub username comparisons are case-insensitive.
+- A unique index on `(discord_user_id, github_user_normalized)`.
+- Indexes for `github_user` and `verified`.
+
+`create_identity_claim()` protects against impersonation and accidental duplicate linking:
+
+```python
+def create_identity_claim(
+    self,
+    discord_user_id: str,
+    github_user: str,
+    verification_code: str,
+    expires_at: datetime,
+    *,
+    max_age_days: int | None = None,
+) -> None:
+    """Create or refresh an identity claim for (discord_user_id, github_user).
+
+    Impersonation protection:
+    - If github_user is already verified for a different discord_user_id, reject.
+    - If an unexpired claim exists for github_user under a different discord_user_id, reject.
+    - If an expired claim exists for github_user under a different discord_user_id, replace it.
+
+    Stale refresh:
+    - If already verified for same pair and stale (per max_age_days), allow creating new claim to refresh.
+    """
+```
+
+Key storage rules:
+
+- One GitHub username cannot be verified by two Discord users.
+- One active pending GitHub username claim cannot be held by two Discord users.
+- One Discord user cannot verify two different GitHub users.
+- Expired pending claims from other users can be cleaned up and replaced.
+- A verified mapping can be refreshed only when it is stale according to `identity.verified_max_age_days`.
+
+## `/verify-link`: Backward-Compatible Manual Verification
+
+The `/verify-link` slash command still lives in `src/ghdcbot/bot.py` and remains fully functional.
+
+```python
+@tree.command(
+    name="verify-link",
+    description="Verify your GitHub link after adding the code to your bio or a gist",
+    guild=discord.Object(id=guild_id),
+)
+@app_commands.describe(github_username="Your GitHub username")
+async def verify_link_cmd(interaction: discord.Interaction, github_username: str) -> None:
+    await interaction.response.defer(ephemeral=True)
+    discord_user_id = str(interaction.user.id)
+    try:
+        ok, location = service.verify_claim(discord_user_id, github_username)
+    except ValueError as e:
+        await interaction.followup.send(
+            f"Verification failed: {e}",
+            ephemeral=True,
+        )
+        return
+    if ok:
+        if location == "already-verified":
+            await interaction.followup.send(
+                f"Your account is already linked to **{github_username}**.",
+                ephemeral=True,
+            )
+        else:
+            await interaction.followup.send(
+                f"Verified: **{github_username}** <-> your Discord (found in {location}).",
+                ephemeral=True,
+            )
+    else:
+        if location == "expired":
+            await interaction.followup.send(
+                "Verification code expired. Run `/link` again to get a new code.",
+                ephemeral=True,
+            )
+        else:
+            await interaction.followup.send(
+                "Code not found yet. Add the code to your GitHub bio or a public gist, then run `/verify-link` again.",
+                ephemeral=True,
+            )
+```
+
+Possible outcomes:
+
+| Result | Meaning | User message |
+| --- | --- | --- |
+| `True, "already-verified"` | The mapping was already verified. | Already linked. |
+| `True, "bio"` | The code was found in the GitHub profile bio. | Verified. |
+| `True, "gist:<id>:description"` | The code was found in a public gist description. | Verified. |
+| `True, "gist:<id>:<filename>"` | The code was found in a public gist file. | Verified. |
+| `False, "expired"` | The pending claim expired. | Run `/link` again. |
+| `False, None` | The code was not found yet. | Add the code and retry. |
+| `ValueError` | There is no matching claim or the claim data is invalid. | Verification failed. |
+
+## Verification Logic
+
+`IdentityLinkService.verify_claim()` is the core of `/verify-link`:
+
+```python
+def verify_claim(self, discord_user_id: str, github_user: str) -> tuple[bool, str | None]:
+    row = self._storage.get_identity_link(discord_user_id, github_user)
+    if not row:
+        raise ValueError("No identity claim found for this Discord user and GitHub user")
+    if int(row.get("verified") or 0) == 1:
+        return True, "already-verified"
+
+    code = row.get("verification_code")
+    expires_at_raw = row.get("expires_at")
+    if not code or not expires_at_raw:
+        raise ValueError("Identity claim is missing verification_code or expires_at")
+
+    expires_at = datetime.fromisoformat(expires_at_raw)
+    if expires_at.tzinfo is None:
+        expires_at = expires_at.replace(tzinfo=timezone.utc)
+    expires_at = expires_at.astimezone(timezone.utc)
+
+    now = datetime.now(timezone.utc)
+    if expires_at <= now:
+        return False, "expired"
+
+    match: VerificationMatch = self._github.search_verification_code(github_user, code)
+    if not match.found:
+        return False, None
+
+    self._storage.mark_identity_verified(discord_user_id, github_user)
+    return True, match.location
+```
+
+The full implementation also writes audit events for these cases:
+
+- `identity_verification_expired`
+- `identity_verification_not_found`
+- `identity_verified`
+
+## GitHub Code Search
+
+`GitHubIdentityReader` is intentionally read-only. It does not decide whether a claim should be accepted; it only fetches public GitHub data and searches for the code.
+
+```python
+@dataclass(frozen=True)
+class VerificationMatch:
+    found: bool
+    location: str | None = None
+```
+
+```python
+def search_verification_code(self, github_user: str, code: str) -> VerificationMatch:
+    """Search for code in GitHub bio or public gists."""
+    bio = self._fetch_bio(github_user)
+    if bio and code in bio:
+        return VerificationMatch(found=True, location="bio")
+
+    for match in self._search_public_gists(github_user, code):
+        return match
+
+    return VerificationMatch(found=False, location=None)
+```
+
+The lookup order is:
+
+1. `GET /users/{github_user}` and check the `bio` field.
+2. `GET /users/{github_user}/gists?per_page=20&page=1`.
+3. Check each gist description.
+4. Fetch gist details with `GET /gists/{gist_id}`.
+5. Fetch each file `raw_url` and search the raw text for the code.
+
+If GitHub returns `401`, `403`, or `404`, the adapter logs a warning and returns no match for that request.
+
+## Marking a Link Verified
+
+When the code is found, storage marks the row verified:
+
+```python
+def mark_identity_verified(self, discord_user_id: str, github_user: str) -> None:
+    now = datetime.now(timezone.utc).isoformat()
+    gh_norm = github_user.strip().lower()
+    with self._connect() as conn:
+        conn.execute(
+            """
+            UPDATE identity_links
+            SET verified = 1,
+                verified_at = ?,
+                verification_code = NULL,
+                expires_at = NULL,
+                unlinked_at = NULL
+            WHERE discord_user_id = ? AND github_user_normalized = ?
+            """,
+            (now, discord_user_id, gh_norm),
+        )
+```
+
+After this update:
+
+- `verified = 1`
+- `verified_at` is set to the current UTC time
+- `verification_code` is cleared
+- `expires_at` is cleared
+- `unlinked_at` is cleared, which makes relinks active again
+
+Verified mappings are loaded by other parts of the engine through:
+
+```python
+def list_verified_identity_mappings(self) -> list[IdentityMapping]:
+    """Return verified identity mappings for engine usage."""
+    with self._connect() as conn:
+        rows = conn.execute(
+            """
+            SELECT discord_user_id, github_user
+            FROM identity_links
+            WHERE verified = 1
+            ORDER BY discord_user_id ASC
+            """
+        ).fetchall()
+    return [
+        IdentityMapping(github_user=row["github_user"], discord_user_id=row["discord_user_id"])
+        for row in rows
+    ]
+```
+
+## Status and Stale Verification
+
+The user can check status through:
+
+- `/verify`
+- `/status`
+- `/identity status`
+- `ghdcbot identity status --discord-user-id <id>`
+
+`get_identity_status()` returns one of:
+
+- `verified`
+- `verified_stale`
+- `pending`
+- `not_linked`
+
+```python
+def get_identity_status(self, discord_user_id: str, max_age_days: int | None = None) -> dict:
+    with self._connect() as conn:
+        row = conn.execute(
+            """
+            SELECT discord_user_id, github_user, verified, verified_at
+            FROM identity_links
+            WHERE discord_user_id = ? AND (unlinked_at IS NULL)
+            ORDER BY verified DESC, created_at DESC
+            LIMIT 1
+            """,
+            (discord_user_id,),
+        ).fetchone()
+    if not row:
+        return {"github_user": None, "status": "not_linked", "verified_at": None, "is_stale": False}
+    if int(row["verified"] or 0) == 1:
+        verified_at_raw = row["verified_at"]
+        is_stale = False
+        status = "verified"
+        if verified_at_raw and max_age_days is not None and max_age_days > 0:
+            verified_at = _parse_utc(verified_at_raw)
+            age_days = (datetime.now(timezone.utc) - verified_at).days
+            if age_days >= max_age_days:
+                is_stale = True
+                status = "verified_stale"
+        return {
+            "github_user": row["github_user"],
+            "status": status,
+            "verified_at": verified_at_raw,
+            "is_stale": is_stale,
+        }
+    return {
+        "github_user": row["github_user"],
+        "status": "pending",
+        "verified_at": None,
+        "is_stale": False,
+    }
+```
+
+Stale verification is soft. It warns the user and allows a refresh claim for the same Discord/GitHub pair, but it does not automatically unlink the user.
+
+Configure it with:
+
+```yaml
+identity:
+  verified_max_age_days: 30
+```
+
+## Unlink and Relink
+
+`/unlink` uses the same service and calls `service.unlink(discord_user_id, cooldown)`.
+
+Storage does not delete rows. It sets `verified = 0` and records `unlinked_at`.
+
+```python
+UPDATE identity_links
+SET verified = 0, unlinked_at = ?
+WHERE discord_user_id = ? AND github_user = ?
+```
+
+Unlinking has a cooldown after verification. The default is 24 hours:
+
+```yaml
+identity:
+  unlink_cooldown_hours: 24
+```
+
+After unlinking, `get_identity_links_for_discord_user()` hides the unlinked row from active status views because it filters with `unlinked_at IS NULL`.
+
+## CLI Commands
+
+The CLI mirrors the Discord flow and is useful for testing or admin workflows.
+
+Create a claim:
+
+```bash
+ghdcbot --config config/config.yaml link --discord-user-id 123456789 octocat
+```
+
+The CLI prints:
+
+```text
+Verification steps:
+1) Put this code in your GitHub bio OR in a public GitHub gist: <CODE>
+2) Re-run verification:
+   ghdcbot --config config/config.yaml verify-link --discord-user-id 123456789 octocat
+Expires at (UTC): <timestamp>
+```
+
+Verify the claim:
+
+```bash
+ghdcbot --config config/config.yaml verify-link --discord-user-id 123456789 octocat
+```
+
+Check status:
+
+```bash
+ghdcbot --config config/config.yaml identity status --discord-user-id 123456789
+```
+
+List verified contributors:
+
+```bash
+ghdcbot --config config/config.yaml identity list
+```
+
+## Audit Events
+
+Identity verification writes append-only audit events to:
+
+```text
+<data_dir>/audit_events.jsonl
+```
+
+Events used by this system include:
+
+- `identity_claim_created`
+- `identity_verification_expired`
+- `identity_verification_not_found`
+- `identity_verified`
+- `identity_unlinked`
+
+An `identity_verified` event stores the GitHub user and the location where the code was found:
+
+```json
+{
+  "actor_type": "discord_user",
+  "actor_id": "123456789",
+  "event_type": "identity_verified",
+  "context": {
+    "github_user": "octocat",
+    "location": "bio"
+  }
+}
+```
+
+## Tested Behavior
+
+`tests/test_identity_linking.py` verifies the important behavior:
+
+- Verification codes are generated and stored.
+- Already verified GitHub users cannot be claimed by another Discord user.
+- Duplicate pending claims for the same GitHub user are rejected.
+- Verified rows clear `verification_code` and `expires_at`.
+- The Verify button marks a claim verified through `IdentityLinkService.verify_claim()`.
+- The Verify button reports expired claims.
+- The Verify button reports missing codes without disabling retry.
+- The Cancel button disables the view.
+- Unverified mappings are ignored by role planning.
+- Unlinking removes active verified mappings without deleting history.
+- Relinking works after unlinking.
+- Status reports `not_linked`, `pending`, `verified`, and `verified_stale`.
+- Stale verified users can refresh their claim.
+- Non-stale verified users cannot create a duplicate refresh claim.
+
+Run the focused tests with:
+
+```bash
+pytest tests/test_identity_linking.py
+```
+
+## Practical User Workflow
+
+In Discord:
+
+```text
+/link github_username:octocat
+```
+
+Gitcord replies privately with a code.
+
+The user adds the code to one of these public GitHub locations:
+
+- GitHub profile bio
+- Public gist description
+- Public gist file content
+
+Then the user runs:
+
+```text
+Click Verify
+```
+
+If the code is visible to the GitHub API and has not expired, Gitcord replies privately that the account is verified. From that point, the user appears in `list_verified_identity_mappings()` and can be used by contribution summaries, role planning, issue assignment, and other identity-aware features.
+
+The manual fallback remains:
+
+```text
+/verify-link github_username:octocat
+```

--- a/src/ghdcbot/adapters/storage/sqlite.py
+++ b/src/ghdcbot/adapters/storage/sqlite.py
@@ -423,7 +423,8 @@ class SqliteStorage:
                     verification_code = excluded.verification_code,
                     expires_at = excluded.expires_at,
                     created_at = excluded.created_at,
-                    verified_at = NULL
+                    verified_at = NULL,
+                    unlinked_at = NULL
                 """,
                 (
                     discord_user_id,
@@ -460,7 +461,8 @@ class SqliteStorage:
                 SET verified = 1,
                     verified_at = ?,
                     verification_code = NULL,
-                    expires_at = NULL
+                    expires_at = NULL,
+                    unlinked_at = NULL
                 WHERE discord_user_id = ? AND github_user_normalized = ?
                 """,
                 (now, discord_user_id, gh_norm),
@@ -549,7 +551,7 @@ class SqliteStorage:
                 SELECT discord_user_id, github_user, verified, verification_code,
                        expires_at, created_at, verified_at, unlinked_at
                 FROM identity_links
-                WHERE discord_user_id = ?
+                WHERE discord_user_id = ? AND unlinked_at IS NULL
                 ORDER BY verified DESC, created_at DESC
                 """,
                 (discord_user_id,),

--- a/src/ghdcbot/bot.py
+++ b/src/ghdcbot/bot.py
@@ -14,7 +14,7 @@ from discord import app_commands
 from ghdcbot.adapters.github.identity import GitHubIdentityReader
 from ghdcbot.config.loader import load_config
 from ghdcbot.core.errors import ConfigError
-from ghdcbot.engine.identity_linking import IdentityLinkService
+from ghdcbot.engine.identity_linking import IdentityLinkService, LinkClaim
 from ghdcbot.engine.metrics import (
     format_metrics_summary,
     get_contribution_metrics,
@@ -59,6 +59,118 @@ from ghdcbot.discord_command_permissions import (
 SLASH_CMD_ASSIGN_ISSUE = "assign-issue"
 SLASH_CMD_ISSUE_REQUESTS = "issue-requests"
 SLASH_CMD_SYNC = "sync"
+
+
+def build_identity_verification_embed(claim: LinkClaim) -> discord.Embed:
+    """Build the ephemeral /link verification instructions embed."""
+    embed = discord.Embed(
+        title="Verify GitHub Account",
+        description=(
+            "1. Copy this code.\n"
+            "2. Paste it into your GitHub bio or public gist.\n"
+            "3. Click Verify."
+        ),
+        color=0x2563EB,
+    )
+    embed.add_field(name="GitHub Account", value=claim.github_user, inline=False)
+    embed.add_field(name="Verification Code", value=f"`{claim.verification_code}`", inline=False)
+    embed.add_field(name="Expires At (UTC)", value=claim.expires_at.isoformat(), inline=False)
+    return embed
+
+
+class IdentityVerificationView(discord.ui.View):
+    """Ephemeral /link buttons that reuse IdentityLinkService.verify_claim()."""
+
+    def __init__(
+        self,
+        *,
+        service: IdentityLinkService,
+        storage: Any,
+        discord_user_id: str,
+        github_user: str,
+        timeout: float = 600.0,
+    ) -> None:
+        super().__init__(timeout=timeout)
+        self.service = service
+        self.storage = storage
+        self.discord_user_id = discord_user_id
+        self.github_user = github_user
+
+        verify_button = discord.ui.Button(label="Verify", style=discord.ButtonStyle.success)
+        verify_button.callback = self.verify_identity
+        self.add_item(verify_button)
+
+        cancel_button = discord.ui.Button(label="Cancel", style=discord.ButtonStyle.secondary)
+        cancel_button.callback = self.cancel_verification
+        self.add_item(cancel_button)
+
+    def _disable(self) -> None:
+        for item in self.children:
+            item.disabled = True
+
+    def _pending_github_user(self, discord_user_id: str) -> str:
+        get_link = getattr(self.storage, "get_identity_link", None)
+        if not callable(get_link):
+            raise ValueError("Identity link status is unavailable.")
+        row = get_link(discord_user_id, self.github_user)
+        if not row:
+            raise ValueError("No identity claim found for this Discord user and GitHub user")
+        return str(row.get("github_user") or self.github_user)
+
+    async def _edit_response(self, interaction: discord.Interaction, content: str) -> None:
+        self._disable()
+        await interaction.response.edit_message(content=content, embed=None, view=self)
+
+    async def verify_identity(self, interaction: discord.Interaction) -> None:
+        clicker_id = str(interaction.user.id)
+        if clicker_id != self.discord_user_id:
+            await interaction.response.send_message(
+                "This verification button belongs to another Discord user.",
+                ephemeral=True,
+            )
+            return
+
+        try:
+            github_user = self._pending_github_user(clicker_id)
+            ok, location = self.service.verify_claim(clicker_id, github_user)
+        except ValueError as e:
+            await self._edit_response(interaction, f"Verification failed: {e}")
+            return
+
+        if ok:
+            await self._edit_response(
+                interaction,
+                (
+                    "✅ Successfully verified GitHub account\n\n"
+                    f"GitHub: {github_user}\n\n"
+                    "Status: Verified"
+                ),
+            )
+            return
+
+        if location == "expired":
+            await self._edit_response(
+                interaction,
+                "❌ Verification expired.\n\nRun /link again to generate a new verification code.",
+            )
+            return
+
+        await interaction.response.send_message(
+            (
+                "❌ Verification code not found.\n\n"
+                "Please ensure the code is present in your GitHub bio or public gist and try again."
+            ),
+            ephemeral=True,
+        )
+
+    async def cancel_verification(self, interaction: discord.Interaction) -> None:
+        if str(interaction.user.id) != self.discord_user_id:
+            await interaction.response.send_message(
+                "This verification button belongs to another Discord user.",
+                ephemeral=True,
+            )
+            return
+        await self._edit_response(interaction, "Verification cancelled.")
 
 
 def run_bot(config_path: str) -> None:
@@ -140,13 +252,14 @@ def run_bot(config_path: str) -> None:
                 ephemeral=True,
             )
             return
-        msg = (
-            f"**Verification code:** `{claim.verification_code}`\n\n"
-            "1. Put this code in your **GitHub profile bio** or in a **public gist**.\n"
-            f"2. Run `/verify-link` with `{github_username}` here.\n\n"
-            f"Code expires at (UTC): {claim.expires_at.isoformat()}"
+        embed = build_identity_verification_embed(claim)
+        view = IdentityVerificationView(
+            service=service,
+            storage=storage,
+            discord_user_id=discord_user_id,
+            github_user=github_username,
         )
-        await interaction.followup.send(msg, ephemeral=True)
+        await interaction.followup.send(embed=embed, view=view, ephemeral=True)
 
     @tree.command(
         name="verify-link",

--- a/tests/test_identity_linking.py
+++ b/tests/test_identity_linking.py
@@ -334,6 +334,9 @@ def test_relink_works_after_unlink(tmp_path: Path) -> None:
     mappings = storage.list_verified_identity_mappings()
     assert len(mappings) == 1
     assert mappings[0].github_user == "octocat" and mappings[0].discord_user_id == "d1"
+    status = storage.get_identity_status("d1")
+    assert status["status"] == "verified"
+    assert status["github_user"] == "octocat"
 
 
 # --- Identity status (read-only) ---
@@ -395,6 +398,19 @@ def test_identity_status_not_linked_after_unlink(tmp_path: Path) -> None:
     status = storage.get_identity_status("d1")
     assert status["status"] == "not_linked"
     assert status["github_user"] is None
+
+
+def test_unlinked_identity_hidden_from_active_link_list(tmp_path: Path) -> None:
+    storage = SqliteStorage(data_dir=str(tmp_path))
+    storage.init_schema()
+    svc = IdentityLinkService(storage=storage, github_identity=_GitHubIdentityAlways(True, "bio"))
+    svc.create_claim("d1", "octocat")
+    svc.verify_claim("d1", "octocat")
+    svc.unlink("d1", cooldown_hours=0)
+
+    links = storage.get_identity_links_for_discord_user("d1")
+
+    assert links == []
 
 
 def test_cli_identity_status_output_contains_correct_fields(
@@ -605,4 +621,3 @@ def _parse_utc(value: str) -> datetime:
     if parsed.tzinfo is None:
         return parsed.replace(tzinfo=timezone.utc)
     return parsed.astimezone(timezone.utc)
-

--- a/tests/test_identity_linking.py
+++ b/tests/test_identity_linking.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
 from ghdcbot.adapters.github.identity import VerificationMatch
 from ghdcbot.adapters.storage.sqlite import SqliteStorage
+from ghdcbot.bot import IdentityVerificationView, build_identity_verification_embed
 from ghdcbot.config.models import (
     AssignmentConfig,
     BotConfig,
@@ -57,6 +60,23 @@ def test_impersonation_attempt_fails_when_github_user_already_verified(tmp_path:
 
     with pytest.raises(ValueError):
         svc.create_claim("d2", "octocat")
+
+
+def test_duplicate_pending_claim_for_same_github_user_is_rejected(tmp_path: Path) -> None:
+    storage = SqliteStorage(data_dir=str(tmp_path))
+    storage.init_schema()
+    svc = IdentityLinkService(storage=storage, github_identity=_GitHubIdentityAlways(False))
+
+    first_claim = svc.create_claim("d1", "shubham_5080")
+
+    with pytest.raises(ValueError, match="active pending claim"):
+        svc.create_claim("d2", "shubham_5080")
+
+    original_row = storage.get_identity_link("d1", "shubham_5080")
+    duplicate_row = storage.get_identity_link("d2", "shubham_5080")
+    assert original_row is not None
+    assert original_row["verification_code"] == first_claim.verification_code
+    assert duplicate_row is None
 
 
 def test_create_claim_rejects_already_verified_same_pair(tmp_path: Path) -> None:
@@ -613,6 +633,133 @@ def test_create_claim_rejects_refresh_when_not_stale(tmp_path: Path) -> None:
     # Should reject creating new claim when not stale
     with pytest.raises(ValueError, match="already verified"):
         svc.create_claim("d1", "alice", max_age_days=30)
+
+
+class _FakeInteractionResponse:
+    def __init__(self) -> None:
+        self.edits: list[dict] = []
+        self.messages: list[dict] = []
+
+    async def edit_message(self, **kwargs) -> None:  # noqa: ANN003
+        self.edits.append(kwargs)
+
+    async def send_message(self, content: str, *, ephemeral: bool = False) -> None:
+        self.messages.append({"content": content, "ephemeral": ephemeral})
+
+
+class _FakeButtonInteraction:
+    def __init__(self, discord_user_id: str) -> None:
+        self.user = SimpleNamespace(id=discord_user_id)
+        self.response = _FakeInteractionResponse()
+
+
+def _view_children_disabled(view: IdentityVerificationView) -> bool:
+    return all(bool(getattr(item, "disabled", False)) for item in view.children)
+
+
+def test_identity_verify_button_marks_claim_verified(tmp_path: Path) -> None:
+    storage = SqliteStorage(data_dir=str(tmp_path))
+    storage.init_schema()
+    svc = IdentityLinkService(storage=storage, github_identity=_GitHubIdentityAlways(True, "bio"))
+    claim = svc.create_claim("d1", "octocat")
+    embed = build_identity_verification_embed(claim)
+    view = IdentityVerificationView(
+        service=svc,
+        storage=storage,
+        discord_user_id="d1",
+        github_user="octocat",
+    )
+    interaction = _FakeButtonInteraction("d1")
+
+    asyncio.run(view.verify_identity(interaction))
+
+    row = storage.get_identity_link("d1", "octocat")
+    assert row is not None
+    assert row["verified"] == 1
+    assert row["verification_code"] is None
+    assert interaction.response.edits[0]["content"] == (
+        "✅ Successfully verified GitHub account\n\n"
+        "GitHub: octocat\n\n"
+        "Status: Verified"
+    )
+    assert interaction.response.edits[0]["embed"] is None
+    assert interaction.response.edits[0]["view"] is view
+    assert embed.to_dict()["fields"][0]["value"] == "octocat"
+    assert _view_children_disabled(view)
+
+
+def test_identity_verify_button_reports_expired_claim(tmp_path: Path) -> None:
+    storage = SqliteStorage(data_dir=str(tmp_path))
+    storage.init_schema()
+    svc = IdentityLinkService(
+        storage=storage,
+        github_identity=_GitHubIdentityAlways(True, "bio"),
+        ttl_minutes=-1,
+    )
+    svc.create_claim("d1", "octocat")
+    view = IdentityVerificationView(
+        service=svc,
+        storage=storage,
+        discord_user_id="d1",
+        github_user="octocat",
+    )
+    interaction = _FakeButtonInteraction("d1")
+
+    asyncio.run(view.verify_identity(interaction))
+
+    row = storage.get_identity_link("d1", "octocat")
+    assert row is not None
+    assert row["verified"] == 0
+    assert interaction.response.edits[0]["content"] == (
+        "❌ Verification expired.\n\n"
+        "Run /link again to generate a new verification code."
+    )
+    assert _view_children_disabled(view)
+
+
+def test_identity_verify_button_reports_code_not_found(tmp_path: Path) -> None:
+    storage = SqliteStorage(data_dir=str(tmp_path))
+    storage.init_schema()
+    svc = IdentityLinkService(storage=storage, github_identity=_GitHubIdentityAlways(False))
+    svc.create_claim("d1", "octocat")
+    view = IdentityVerificationView(
+        service=svc,
+        storage=storage,
+        discord_user_id="d1",
+        github_user="octocat",
+    )
+    interaction = _FakeButtonInteraction("d1")
+
+    asyncio.run(view.verify_identity(interaction))
+
+    row = storage.get_identity_link("d1", "octocat")
+    assert row is not None
+    assert row["verified"] == 0
+    assert interaction.response.messages[0]["content"] == (
+        "❌ Verification code not found.\n\n"
+        "Please ensure the code is present in your GitHub bio or public gist and try again."
+    )
+    assert interaction.response.messages[0]["ephemeral"] is True
+    assert not _view_children_disabled(view)
+
+
+def test_identity_verify_cancel_button_disables_view() -> None:
+    svc = SimpleNamespace()
+    storage = SimpleNamespace()
+    view = IdentityVerificationView(
+        service=svc,
+        storage=storage,
+        discord_user_id="d1",
+        github_user="octocat",
+    )
+    interaction = _FakeButtonInteraction("d1")
+
+    asyncio.run(view.cancel_verification(interaction))
+
+    assert interaction.response.edits[0]["content"] == "Verification cancelled."
+    assert interaction.response.edits[0]["embed"] is None
+    assert interaction.response.edits[0]["view"] is view
+    assert _view_children_disabled(view)
 
 
 def _parse_utc(value: str) -> datetime:


### PR DESCRIPTION
## Summary
- Clear `unlinked_at` when an identity claim is recreated or verified again.
- Hide unlinked historical identity rows from active link/status reads.
- Add regression coverage for unlink -> relink flows.

## Why
After a user unlinked their GitHub identity and then linked the same account again, the old `unlinked_at` timestamp could remain on the reused row. That made the identity look historical/unlinked even after successful verification.

## Testing
- `.venv/bin/pytest`

Result:
- `202 passed, 1 warning`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Quick Start Guide for linking/verifying accounts, commands, issue request flow, scoring rules, and contributor tips; expanded technical docs with detailed configuration, scoring, and glossary updates.

* **New Features**
  * Interactive ephemeral verification UI for the account linking flow.

* **Bug Fixes**
  * Identity linking now clears and filters out unlinked accounts so only active links are returned.

* **Tests**
  * Expanded identity-linking tests covering claim creation, relink/unlink behavior, and verification UI flows.

* **Chores**
  * Disabled unrestricted slash command access in the active runtime configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->