### PR TITLE
Improve /link identity verification UX

### DIFF
--- a/src/ghdcbot/bot.py
+++ b/src/ghdcbot/bot.py
@@ -60,21 +60,31 @@ SLASH_CMD_ASSIGN_ISSUE = "assign-issue"
 SLASH_CMD_ISSUE_REQUESTS = "issue-requests"
 SLASH_CMD_SYNC = "sync"
 
-GITHUB_PROFILE_SETTINGS_URL = "https://github.com/settings/profile"
-
 VERIFICATION_CODE_REMOVAL_NOTE = (
     "You may now safely remove the verification code from your GitHub bio. "
     "It was only required to prove ownership during the verification process."
 )
 
 
-def build_identity_verification_embed(claim: LinkClaim) -> discord.Embed:
+def github_profile_settings_url(api_base: str) -> str:
+    """Derive the GitHub web profile settings URL from config.github.api_base."""
+    base = api_base.rstrip("/")
+    if base in ("https://api.github.com", "http://api.github.com"):
+        return "https://github.com/settings/profile"
+    if base.endswith("/api/v3"):
+        return f"{base[: -len('/api/v3')]}/settings/profile"
+    if base.endswith("/api"):
+        return f"{base[: -len('/api')]}/settings/profile"
+    return f"{base}/settings/profile"
+
+
+def build_identity_verification_embed(claim: LinkClaim, *, profile_settings_url: str) -> discord.Embed:
     """Build the ephemeral /link verification instructions embed."""
     embed = discord.Embed(
         title="Verify GitHub Account",
         description=(
             "1. Copy the verification code below.\n"
-            f"2. Open GitHub profile settings:\n   {GITHUB_PROFILE_SETTINGS_URL}\n"
+            f"2. Open GitHub profile settings:\n   {profile_settings_url}\n"
             "3. Paste the code into your GitHub bio.\n"
             "4. Return here and click Verify."
         ),
@@ -96,6 +106,7 @@ class IdentityVerificationView(discord.ui.View):
         storage: Any,
         discord_user_id: str,
         github_user: str,
+        profile_settings_url: str,
         timeout: float = 600.0,
     ) -> None:
         super().__init__(timeout=timeout)
@@ -107,7 +118,7 @@ class IdentityVerificationView(discord.ui.View):
         github_button = discord.ui.Button(
             label="Open GitHub Profile",
             style=discord.ButtonStyle.link,
-            url=GITHUB_PROFILE_SETTINGS_URL,
+            url=profile_settings_url,
         )
         self.add_item(github_button)
 
@@ -216,6 +227,7 @@ def run_bot(config_path: str) -> None:
         api_base=str(config.github.api_base),
     )
     service = IdentityLinkService(storage=storage, github_identity=github_identity)
+    profile_settings_url = github_profile_settings_url(str(config.github.api_base))
     discord_reader = build_adapter(
         config.runtime.discord_adapter,
         token=config.discord.token,
@@ -268,12 +280,13 @@ def run_bot(config_path: str) -> None:
                 ephemeral=True,
             )
             return
-        embed = build_identity_verification_embed(claim)
+        embed = build_identity_verification_embed(claim, profile_settings_url=profile_settings_url)
         view = IdentityVerificationView(
             service=service,
             storage=storage,
             discord_user_id=discord_user_id,
             github_user=github_username,
+            profile_settings_url=profile_settings_url,
         )
         await interaction.followup.send(embed=embed, view=view, ephemeral=True)
 

--- a/src/ghdcbot/bot.py
+++ b/src/ghdcbot/bot.py
@@ -60,15 +60,23 @@ SLASH_CMD_ASSIGN_ISSUE = "assign-issue"
 SLASH_CMD_ISSUE_REQUESTS = "issue-requests"
 SLASH_CMD_SYNC = "sync"
 
+GITHUB_PROFILE_SETTINGS_URL = "https://github.com/settings/profile"
+
+VERIFICATION_CODE_REMOVAL_NOTE = (
+    "You may now safely remove the verification code from your GitHub bio. "
+    "It was only required to prove ownership during the verification process."
+)
+
 
 def build_identity_verification_embed(claim: LinkClaim) -> discord.Embed:
     """Build the ephemeral /link verification instructions embed."""
     embed = discord.Embed(
         title="Verify GitHub Account",
         description=(
-            "1. Copy this code.\n"
-            "2. Paste it into your GitHub bio or public gist.\n"
-            "3. Click Verify."
+            "1. Copy the verification code below.\n"
+            f"2. Open GitHub profile settings:\n   {GITHUB_PROFILE_SETTINGS_URL}\n"
+            "3. Paste the code into your GitHub bio.\n"
+            "4. Return here and click Verify."
         ),
         color=0x2563EB,
     )
@@ -95,6 +103,13 @@ class IdentityVerificationView(discord.ui.View):
         self.storage = storage
         self.discord_user_id = discord_user_id
         self.github_user = github_user
+
+        github_button = discord.ui.Button(
+            label="Open GitHub Profile",
+            style=discord.ButtonStyle.link,
+            url=GITHUB_PROFILE_SETTINGS_URL,
+        )
+        self.add_item(github_button)
 
         verify_button = discord.ui.Button(label="Verify", style=discord.ButtonStyle.success)
         verify_button.callback = self.verify_identity
@@ -143,7 +158,8 @@ class IdentityVerificationView(discord.ui.View):
                 (
                     "✅ Successfully verified GitHub account\n\n"
                     f"GitHub: {github_user}\n\n"
-                    "Status: Verified"
+                    f"Status: Verified\n\n"
+                    f"{VERIFICATION_CODE_REMOVAL_NOTE}"
                 ),
             )
             return
@@ -286,7 +302,10 @@ def run_bot(config_path: str) -> None:
                 )
             else:
                 await interaction.followup.send(
-                    f"Verified: **{github_username}** ↔ your Discord (found in {location}).",
+                    (
+                        f"Verified: **{github_username}** ↔ your Discord (found in {location}).\n\n"
+                        f"{VERIFICATION_CODE_REMOVAL_NOTE}"
+                    ),
                     ephemeral=True,
                 )
         else:

--- a/tests/test_identity_linking.py
+++ b/tests/test_identity_linking.py
@@ -10,10 +10,10 @@ import pytest
 from ghdcbot.adapters.github.identity import VerificationMatch
 from ghdcbot.adapters.storage.sqlite import SqliteStorage
 from ghdcbot.bot import (
-    GITHUB_PROFILE_SETTINGS_URL,
     IdentityVerificationView,
     VERIFICATION_CODE_REMOVAL_NOTE,
     build_identity_verification_embed,
+    github_profile_settings_url,
 )
 from ghdcbot.config.models import (
     AssignmentConfig,
@@ -662,32 +662,46 @@ def _view_children_disabled(view: IdentityVerificationView) -> bool:
     return all(bool(getattr(item, "disabled", False)) for item in view.children)
 
 
+def test_github_profile_settings_url_from_api_base() -> None:
+    assert (
+        github_profile_settings_url("https://api.github.com")
+        == "https://github.com/settings/profile"
+    )
+    assert (
+        github_profile_settings_url("https://ghes.example.com/api/v3")
+        == "https://ghes.example.com/settings/profile"
+    )
+
+
 def test_identity_verification_embed_includes_github_profile_settings_link(tmp_path: Path) -> None:
     storage = SqliteStorage(data_dir=str(tmp_path))
     storage.init_schema()
     svc = IdentityLinkService(storage=storage, github_identity=_GitHubIdentityAlways(True, "bio"))
     claim = svc.create_claim("d1", "octocat")
+    profile_settings_url = github_profile_settings_url("https://api.github.com")
 
-    embed = build_identity_verification_embed(claim)
+    embed = build_identity_verification_embed(claim, profile_settings_url=profile_settings_url)
     description = embed.to_dict()["description"]
 
-    assert GITHUB_PROFILE_SETTINGS_URL in description
+    assert profile_settings_url in description
     assert "Copy the verification code below" in description
     assert "Paste the code into your GitHub bio" in description
 
 
 def test_identity_verification_view_includes_github_profile_button() -> None:
+    profile_settings_url = github_profile_settings_url("https://api.github.com")
     view = IdentityVerificationView(
         service=SimpleNamespace(),
         storage=SimpleNamespace(),
         discord_user_id="d1",
         github_user="octocat",
+        profile_settings_url=profile_settings_url,
     )
     link_buttons = [
         item
         for item in view.children
         if getattr(item, "label", None) == "Open GitHub Profile"
-        and getattr(item, "url", None) == GITHUB_PROFILE_SETTINGS_URL
+        and getattr(item, "url", None) == profile_settings_url
     ]
     assert len(link_buttons) == 1
 
@@ -697,12 +711,14 @@ def test_identity_verify_button_marks_claim_verified(tmp_path: Path) -> None:
     storage.init_schema()
     svc = IdentityLinkService(storage=storage, github_identity=_GitHubIdentityAlways(True, "bio"))
     claim = svc.create_claim("d1", "octocat")
-    embed = build_identity_verification_embed(claim)
+    profile_settings_url = github_profile_settings_url("https://api.github.com")
+    embed = build_identity_verification_embed(claim, profile_settings_url=profile_settings_url)
     view = IdentityVerificationView(
         service=svc,
         storage=storage,
         discord_user_id="d1",
         github_user="octocat",
+        profile_settings_url=profile_settings_url,
     )
     interaction = _FakeButtonInteraction("d1")
 
@@ -738,6 +754,7 @@ def test_identity_verify_button_reports_expired_claim(tmp_path: Path) -> None:
         storage=storage,
         discord_user_id="d1",
         github_user="octocat",
+        profile_settings_url=github_profile_settings_url("https://api.github.com"),
     )
     interaction = _FakeButtonInteraction("d1")
 
@@ -763,6 +780,7 @@ def test_identity_verify_button_reports_code_not_found(tmp_path: Path) -> None:
         storage=storage,
         discord_user_id="d1",
         github_user="octocat",
+        profile_settings_url=github_profile_settings_url("https://api.github.com"),
     )
     interaction = _FakeButtonInteraction("d1")
 
@@ -787,6 +805,7 @@ def test_identity_verify_cancel_button_disables_view() -> None:
         storage=storage,
         discord_user_id="d1",
         github_user="octocat",
+        profile_settings_url=github_profile_settings_url("https://api.github.com"),
     )
     interaction = _FakeButtonInteraction("d1")
 

--- a/tests/test_identity_linking.py
+++ b/tests/test_identity_linking.py
@@ -9,7 +9,12 @@ import pytest
 
 from ghdcbot.adapters.github.identity import VerificationMatch
 from ghdcbot.adapters.storage.sqlite import SqliteStorage
-from ghdcbot.bot import IdentityVerificationView, build_identity_verification_embed
+from ghdcbot.bot import (
+    GITHUB_PROFILE_SETTINGS_URL,
+    IdentityVerificationView,
+    VERIFICATION_CODE_REMOVAL_NOTE,
+    build_identity_verification_embed,
+)
 from ghdcbot.config.models import (
     AssignmentConfig,
     BotConfig,
@@ -657,6 +662,36 @@ def _view_children_disabled(view: IdentityVerificationView) -> bool:
     return all(bool(getattr(item, "disabled", False)) for item in view.children)
 
 
+def test_identity_verification_embed_includes_github_profile_settings_link(tmp_path: Path) -> None:
+    storage = SqliteStorage(data_dir=str(tmp_path))
+    storage.init_schema()
+    svc = IdentityLinkService(storage=storage, github_identity=_GitHubIdentityAlways(True, "bio"))
+    claim = svc.create_claim("d1", "octocat")
+
+    embed = build_identity_verification_embed(claim)
+    description = embed.to_dict()["description"]
+
+    assert GITHUB_PROFILE_SETTINGS_URL in description
+    assert "Copy the verification code below" in description
+    assert "Paste the code into your GitHub bio" in description
+
+
+def test_identity_verification_view_includes_github_profile_button() -> None:
+    view = IdentityVerificationView(
+        service=SimpleNamespace(),
+        storage=SimpleNamespace(),
+        discord_user_id="d1",
+        github_user="octocat",
+    )
+    link_buttons = [
+        item
+        for item in view.children
+        if getattr(item, "label", None) == "Open GitHub Profile"
+        and getattr(item, "url", None) == GITHUB_PROFILE_SETTINGS_URL
+    ]
+    assert len(link_buttons) == 1
+
+
 def test_identity_verify_button_marks_claim_verified(tmp_path: Path) -> None:
     storage = SqliteStorage(data_dir=str(tmp_path))
     storage.init_schema()
@@ -680,7 +715,8 @@ def test_identity_verify_button_marks_claim_verified(tmp_path: Path) -> None:
     assert interaction.response.edits[0]["content"] == (
         "✅ Successfully verified GitHub account\n\n"
         "GitHub: octocat\n\n"
-        "Status: Verified"
+        f"Status: Verified\n\n"
+        f"{VERIFICATION_CODE_REMOVAL_NOTE}"
     )
     assert interaction.response.edits[0]["embed"] is None
     assert interaction.response.edits[0]["view"] is view


### PR DESCRIPTION
## Summary

- Add GitHub profile settings link (`https://github.com/settings/profile`) to the `/link` embed instructions
- Add **Open GitHub Profile** button on the verification view
- Update success messages after verification (Verify button and `/verify-link`) to tell users they can remove the verification code from their GitHub bio
- Add tests for the profile link, button URL, and updated success messaging

## Test plan

- [x] `pytest tests/test_identity_linking.py` — 32 passed
- [x] Run `/link <github_username>` in Discord and confirm 4-step instructions + **Open GitHub Profile** button
- [x] Complete verification and confirm success message mentions removing the code from bio
- [x] Confirm `/verify-link` still works and shows the same removal note on success

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Open GitHub Profile" button within the identity verification interface for quick access
  * Introduced helpful instructions for removing verification code from your GitHub bio
  * Updated verification success messages to include code removal guidance
  * Enhanced verification prompts with direct GitHub profile settings link

<!-- end of auto-generated comment: release notes by coderabbit.ai -->