### PR TITLE
Week 3: GitHub ingestion resilience, observability, and /link UX improvements

### DIFF
--- a/observability_design.md
+++ b/observability_design.md
@@ -1,0 +1,147 @@
+# Observability Design — Gitcord Sync Logging
+
+> **Status:** Implemented (Week 3 Day 4).
+
+---
+
+## Current State (before)
+
+- `JsonFormatter` emitted only `ts`, `level`, `logger`, `message`
+- `extra={"repo": "..."}` fields were **dropped** from JSON output
+- No correlation ID across a single `run-once` or `/sync` execution
+- Limited visibility into cursor movement, API volume, per-repo timing, or event-type breakdown
+
+---
+
+## Improvements
+
+| Feature | Purpose |
+|---------|---------|
+| **JsonFormatter fix** | Preserve all custom `extra` fields in JSON logs |
+| **sync_id** | Correlate every log line from one sync run |
+| **Sync lifecycle events** | `github_sync_started` / `completed` / `failed` |
+| **API request counting** | `github_request_summary` per sync |
+| **Repo-level logs** | `repo_ingestion_started` / `completed` with timing |
+| **Event summary** | `github_event_summary` with counts by event type |
+| **Cursor visibility** | `cursor_before` / `cursor_after` on sync lifecycle logs |
+
+---
+
+## sync_id
+
+Format: `sync_YYYYMMDD_HHMMSS_ab12`
+
+Generated at the start of each `Orchestrator.run_once()` (CLI `run-once` or Discord `/sync`).
+
+Propagation:
+
+- `contextvars.ContextVar` set by `SyncSession`
+- `SyncContextFilter` attaches `sync_id` to every log record during the run
+- Lifecycle events also include `sync_id` explicitly in `extra`
+
+---
+
+## Example Log Stream
+
+```text
+github_sync_started
+    sync_id, cursor_before, repos_total
+    ↓
+repo_ingestion_started
+    repo, sync_id (via filter)
+    ↓
+github_request_retry          (if transient failure)
+    path, attempt, sleep_seconds, sync_id
+    ↓
+repo_ingestion_completed
+    repo, events, duration_ms, sync_id
+    ↓
+github_event_summary
+    issue_opened, pr_merged, …, sync_id
+    ↓
+github_request_summary
+    requests_total, sync_id
+    ↓
+github_sync_completed
+    cursor_before, cursor_after, repos_processed, events_fetched, duration_ms
+```
+
+On failure:
+
+```text
+github_sync_failed
+    sync_id, error, duration_ms
+```
+
+---
+
+## Structured Events
+
+### Sync lifecycle (`ghdcbot.logging.sync_context.SyncSession`)
+
+| Event | Key fields |
+|-------|------------|
+| `github_sync_started` | `sync_id`, `cursor_before`, `repos_total` |
+| `github_sync_completed` | `sync_id`, `cursor_before`, `cursor_after`, `repos_processed`, `events_fetched`, `duration_ms` |
+| `github_sync_failed` | `sync_id`, `error`, `duration_ms` |
+
+### GitHub adapter (`GitHubRestAdapter`)
+
+| Event | Key fields |
+|-------|------------|
+| `repo_ingestion_started` | `repo` |
+| `repo_ingestion_completed` | `repo`, `events`, `duration_ms` |
+| `github_request_summary` | `requests_total` (logged by orchestrator via `SyncSession`) |
+
+### Event summary
+
+| Event | Key fields |
+|-------|------------|
+| `github_event_summary` | `issue_opened`, `issue_closed`, `pr_opened`, `pr_merged`, `pr_reviewed` (0 if absent) |
+
+---
+
+## Implementation Map
+
+| File | Responsibility |
+|------|----------------|
+| `src/ghdcbot/logging/setup.py` | `JsonFormatter` extra merge; `SyncContextFilter` on handler |
+| `src/ghdcbot/logging/sync_context.py` | `sync_id` generation, `SyncSession` lifecycle logs |
+| `src/ghdcbot/engine/orchestrator.py` | Wrap `run_once` in `SyncSession`; emit start/complete/fail |
+| `src/ghdcbot/adapters/github/rest.py` | Request counting, repo cache, repo ingestion logs |
+
+---
+
+## Example JSON Lines
+
+```json
+{"ts": "...", "level": "INFO", "message": "Repository ingestion started", "repo": "AOSSIE/Gitcord", "event": "repo_ingestion_started", "sync_id": "sync_20260618_142300_ab12"}
+```
+
+```json
+{"ts": "...", "level": "INFO", "message": "GitHub sync completed", "event": "github_sync_completed", "sync_id": "sync_20260618_142300_ab12", "cursor_before": "2026-06-01T00:00:00+00:00", "cursor_after": "2026-06-18T14:23:00+00:00", "repos_processed": 12, "events_fetched": 240, "duration_ms": 28451}
+```
+
+---
+
+## Testing
+
+```bash
+pytest tests/test_observability.py -v
+```
+
+Covers:
+
+- `JsonFormatter` preserves `extra` fields
+- `sync_id` attached via filter
+- `github_sync_started` / `github_sync_completed` field presence
+- Orchestrator integration with mock GitHub reader
+
+---
+
+## Future Enhancements
+
+- Propagate `sync_id` to Discord notification audit events
+- Per-repo `requests_total` breakdown
+- OpenTelemetry / metrics export from the same counters
+- Include `sync_id` in `/sync` Discord ephemeral response for mentor cross-reference

--- a/request_flow.md
+++ b/request_flow.md
@@ -1,0 +1,171 @@
+# GitHubRestAdapter._request() — Request Flow
+
+> Documents `src/ghdcbot/adapters/github/rest.py` as of Week 3 Day 3 (retry + rate-limit recovery).
+
+---
+
+## Signature
+
+```python
+def _request(self, method: str, path: str, params: dict) -> httpx.Response | None
+```
+
+| Argument | Type | Description |
+|----------|------|-------------|
+| `method` | `str` | HTTP method (`"GET"`, `"POST"`, etc.) |
+| `path` | `str` | GitHub REST path relative to `api_base` (e.g. `/repos/owner/repo/issues`) |
+| `params` | `dict` | Query parameters passed to `httpx.Client.request()` |
+
+## Return value
+
+| Return | Meaning |
+|--------|---------|
+| `httpx.Response` | Request succeeded (after retries / rate-limit recovery if needed). Caller checks `status_code` (typically `200`). |
+| `None` | Request failed permanently, exhausted retries, unrecoverable rate limit, or permission/not-found status. |
+
+`_request_with_status()` shares the same retry layer (`_execute_request_with_retries`) but **returns the response** for 401/403/404 instead of converting to `None` — used by org repo listing to detect 401/403 for user-fallback.
+
+---
+
+## Execution flow (current)
+
+```text
+_request(method, path, params)
+    │
+    ▼
+_execute_request_with_retries()     ← transient retry loop (max 4 attempts)
+    │
+    ├─ inner while (rate-limit recovery — does NOT consume transient attempts)
+    │     ├─ client.request()
+    │     ├─ 403 + Remaining == 0 ?
+    │     │     ├─ missing/malformed X-RateLimit-Reset → log, return None
+    │     │     ├─ sleep until reset_timestamp - now (clamp negative → 0)
+    │     │     └─ retry same request (same transient attempt)
+    │     └─ break when response is not rate-limit exhausted
+    │
+    ├─ httpx.TimeoutException / ConnectError
+    │     → transient retry with backoff (1s, 2s, 4s + jitter) or return None
+    │
+    ├─ HTTP 502 / 503 / 504
+    │     → transient retry with backoff or return None
+    │
+    ├─ other httpx.HTTPError
+    │     → log warning, return None (no retry)
+    │
+    └─ other status codes (incl. permission 403)
+          → return response to _request()
+    │
+    ▼
+_request() post-processing
+    │
+    ├─ response is None → return None
+    ├─ rate limit remaining <= 1 → log warning (no sleep)
+    ├─ 401 → log permission issue, return None
+    ├─ 403 (permission) → log permission issue, return None
+    ├─ 404 → log not found, return None
+    └─ else → return response
+```
+
+---
+
+## 403 handling flow
+
+```text
+HTTP 403 received
+    │
+    ▼
+_parse_rate_limit(headers)
+    │
+    ├─ X-RateLimit-Remaining == 0 ?
+    │     │
+    │     YES ──► Rate limit exhausted (in _execute_request_with_retries)
+    │     │         ├─ X-RateLimit-Reset valid?
+    │     │         │     NO  → event: github_rate_limit_missing_reset → return None
+    │     │         │     YES → sleep_seconds = reset_ts - now (min 0)
+    │     │         │           event: github_rate_limit_exhausted
+    │     │         │           sleep(sleep_seconds)
+    │     │         │           event: github_rate_limit_recovered
+    │     │         │           retry same request (same transient attempt)
+    │     │
+    │     NO ──► Permission / visibility issue
+    │               return response to _request()
+    │               _log_permission_issue() → return None
+    │
+    └─ Remaining is None on 403 → treated as permission issue (not rate limit)
+```
+
+### Rate-limit vs permission 403
+
+| Signal | Classification | Behavior |
+|--------|----------------|----------|
+| `403` + `Remaining == 0` | Rate limit exhausted | Sleep until `X-RateLimit-Reset`, retry (no transient attempt consumed) |
+| `403` + `Remaining > 0` | Permission / visibility | `_log_permission_issue()`, return `None` via `_request()` |
+| `403` + `Remaining` missing | Permission (not exhausted) | Same as permission |
+| `403` + `Remaining == 0` + bad/missing reset | Unrecoverable | `github_rate_limit_missing_reset`, return `None` |
+
+### Header parsing
+
+`_parse_rate_limit()` reads:
+
+- `X-RateLimit-Remaining` — integer; `None` if missing/non-digit
+- `X-RateLimit-Reset` — Unix timestamp; parsed to UTC `datetime`
+
+`_rate_limit_sleep_seconds()` computes `reset_timestamp - time.time()`, clamping negative values to `0.0`.
+
+---
+
+## Failure handling summary
+
+| Condition | Behavior |
+|-----------|----------|
+| `TimeoutException` / `ConnectError` | Transient retry up to 4× with backoff |
+| HTTP 502/503/504 | Transient retry up to 4× with backoff |
+| HTTP 403 + `Remaining == 0` | Rate-limit sleep + retry (separate from transient budget) |
+| HTTP 403 + `Remaining != 0` | Permission log → `None` |
+| HTTP 401 | Permission log → `None` |
+| HTTP 404 | Not-found log → `None` |
+| Other `HTTPError` | Log → `None` |
+
+---
+
+## Callers that depend on `None`
+
+When `_request()` returns `None`, callers stop processing that path. Key dependents:
+
+| Caller | File | Behavior on `None` |
+|--------|------|-------------------|
+| `_paginate()` | `rest.py` | Stops pagination for that endpoint |
+| `_paginate_from_page()` | `rest.py` | Stops pagination |
+| `_list_repos_from_path()` | `rest.py` | Returns `[], None` — no repos discovered |
+| `get_pull_request()` | `rest.py` | Returns `None` |
+| `get_issue()` | `rest.py` | Returns `None` |
+| `get_pull_request_check_runs()` | `rest.py` | Returns `[]` |
+| `write_file()` | `rest.py` | Falls back to default branch or fails update |
+
+Rate-limit recovery reduces partial-ingestion failures that previously stopped pagination mid-sync when GitHub returned `403` with exhausted quota.
+
+---
+
+## Related functions
+
+| Function | Purpose |
+|----------|---------|
+| `_execute_request_with_retries()` | Transient retry loop + rate-limit recovery inner loop |
+| `_is_rate_limit_exhausted()` | `403` + `Remaining == 0` |
+| `_rate_limit_sleep_seconds()` | Compute sleep from `X-RateLimit-Reset` |
+| `_rate_limit_reset_timestamp()` | Parse reset header as Unix timestamp |
+| `_request_with_status()` | Same retry layer; preserves 401/403/404 responses |
+| `_log_github_rate_limit_exhausted()` | `event=github_rate_limit_exhausted` |
+| `_log_github_rate_limit_recovered()` | `event=github_rate_limit_recovered` |
+| `_log_github_rate_limit_missing_reset()` | `event=github_rate_limit_missing_reset` |
+| `_log_github_request_retry()` | Transient retry log |
+| `_log_github_request_failed()` | Transient retry exhaustion log |
+| `_log_permission_issue()` | 401/403 permission logging |
+| `_log_not_found()` | 404 logging |
+| `_parse_rate_limit()` | Parses rate-limit headers |
+
+---
+
+## Direct `_client` bypasses (not covered)
+
+Some mutation helpers in `rest.py` call `self._client.post/get` directly. These do **not** use `_request()` and have no retry or rate-limit recovery — future refactor candidate.

--- a/retry_design.md
+++ b/retry_design.md
@@ -1,0 +1,213 @@
+# Retry Design — GitHub REST Ingestion
+
+> **Status:** Implemented in `GitHubRestAdapter._execute_request_with_retries()` (Week 3 Day 2–3).
+
+See also: `request_flow.md` for caller behavior, 403 flow, and `None` semantics.
+
+---
+
+## Goal
+
+Transient GitHub API failures should not interrupt ingestion. Permanent failures should fail immediately. Rate-limit exhaustion should recover automatically instead of aborting pagination.
+
+---
+
+## What retries? (transient)
+
+| Condition | Retries? | Max attempts | Backoff |
+|-----------|----------|--------------|---------|
+| `httpx.TimeoutException` | **Yes** | 4 | 1s → 2s → 4s + jitter |
+| `httpx.ConnectError` | **Yes** | 4 | 1s → 2s → 4s + jitter |
+| HTTP **502** Bad Gateway | **Yes** | 4 | 1s → 2s → 4s + jitter |
+| HTTP **503** Service Unavailable | **Yes** | 4 | 1s → 2s → 4s + jitter |
+| HTTP **504** Gateway Timeout | **Yes** | 4 | 1s → 2s → 4s + jitter |
+
+### Backoff schedule
+
+| Attempt | Delay before this attempt |
+|---------|---------------------------|
+| 1 | Immediate |
+| 2 | 1 second + jitter (0–0.5s) |
+| 3 | 2 seconds + jitter (0–0.5s) |
+| 4 | 4 seconds + jitter (0–0.5s) |
+
+Jitter: `random.uniform(0, 0.5)` added to base delay.
+
+---
+
+## What does NOT retry? (transient layer)
+
+| Condition | Behavior | Why |
+|-----------|----------|-----|
+| HTTP **401** Unauthorized | Log permission issue → `None` | Bad/expired token |
+| HTTP **404** Not Found | Log not found → `None` | Resource missing |
+| HTTP **403** (permission, `Remaining > 0`) | Log permission issue → `None` | Missing scope / visibility |
+| HTTP **403** + `Remaining == 0` + bad reset header | `github_rate_limit_missing_reset` → `None` | Cannot compute sleep |
+| Other `httpx.HTTPError` | Log → `None` | Non-transport client errors |
+
+---
+
+## Rate-limit recovery strategy
+
+### Why?
+
+Partial ingestion caused by rate limits can advance cursors and skip events. When pagination hits `403` with exhausted quota, the sync previously returned `None` and stopped — leaving later repos/pages un-fetched.
+
+### Flow
+
+```text
+GitHub Rate Limit (403 + Remaining == 0)
+    ↓
+Detect exhaustion (_is_rate_limit_exhausted)
+    ↓
+Read X-RateLimit-Reset
+    ↓
+sleep_seconds = reset_timestamp - now  (clamp negative → 0)
+    ↓
+Log github_rate_limit_exhausted
+    ↓
+sleep(sleep_seconds)
+    ↓
+Log github_rate_limit_recovered
+    ↓
+Retry same request (same transient attempt — does NOT consume backoff budget)
+```
+
+### Separate from transient retries
+
+| Aspect | Transient retry | Rate-limit recovery |
+|--------|-----------------|---------------------|
+| Triggers | Timeout, ConnectError, 502/503/504 | 403 + `Remaining == 0` |
+| Backoff | 1s → 2s → 4s + jitter | Sleep until `X-RateLimit-Reset` |
+| Attempt budget | Max 4 transient attempts | Unlimited waits within same attempt |
+| Logging | `github_request_retry` | `github_rate_limit_exhausted` / `recovered` |
+
+### Structured logging
+
+**Rate limit hit:**
+
+```json
+{
+  "event": "github_rate_limit_exhausted",
+  "remaining": 0,
+  "reset_timestamp": 123456789,
+  "sleep_seconds": 183,
+  "path": "/repos/AOSSIE/Gitcord/issues"
+}
+```
+
+**Rate limit recovery:**
+
+```json
+{
+  "event": "github_rate_limit_recovered",
+  "path": "/repos/AOSSIE/Gitcord/issues",
+  "attempt": 2
+}
+```
+
+**Missing/malformed reset header:**
+
+```json
+{
+  "event": "github_rate_limit_missing_reset",
+  "path": "/repos/AOSSIE/Gitcord/issues",
+  "reset_header": null
+}
+```
+
+---
+
+## Implementation overview
+
+```text
+_execute_request_with_retries(method, path, params)
+    for attempt in 1..4:
+        while rate_limit_exhausted:
+            sleep until reset (or return None if header invalid)
+            retry request
+        if Timeout/ConnectError → transient backoff, continue
+        if 502/503/504 → transient backoff, continue
+        return response
+    return None
+
+_request() wraps above:
+    401/403-permission/404 → log + return None
+    else → return response
+```
+
+---
+
+## Example flows
+
+### Rate limit recovery
+
+```text
+GET /repos/org/repo/issues
+  → 403, Remaining=0, Reset=now+120
+  → log github_rate_limit_exhausted, sleep 120s
+  → log github_rate_limit_recovered
+  → 200 ✓
+```
+
+### Permission 403 (no sleep)
+
+```text
+GET /repos/org/private-repo/issues
+  → 403, Remaining=4521
+  → _log_permission_issue, return None (1 request)
+```
+
+### Transient 503
+
+```text
+GET /repos/org/repo/issues
+  → 503 → retry backoff
+  → 503 → retry backoff
+  → 200 ✓
+```
+
+---
+
+## Testing
+
+**Transient retries** — `tests/test_github_retry.py`:
+
+| Scenario | Expected |
+|----------|----------|
+| 503, 503, 200 | Success; 3 requests |
+| Timeout, Timeout, 200 | Success; retries logged |
+| 404 / 401 | No retry; 1 request |
+| 503 × 4 | Failure after 4 attempts |
+| 403 permission | No sleep; permission log |
+
+**Rate-limit recovery** — `tests/test_github_rate_limit.py`:
+
+| Scenario | Expected |
+|----------|----------|
+| 403 Remaining=0 Reset=now+2, then 200 | Sleep called; success |
+| 403 Remaining=0, missing reset | Failure; `missing_reset` log |
+| 403 Remaining=5 | Permission flow; no sleep |
+| 403 Remaining=0, malformed reset | Failure; `missing_reset` log |
+
+Run:
+
+```bash
+pytest tests/test_github_retry.py tests/test_github_rate_limit.py -v
+```
+
+---
+
+## Out of scope
+
+- `Retry-After` header for secondary/abuse rate limits
+- `tenacity` library (inline loop used)
+- Discord API rate limits
+- Direct `_client` mutation bypasses
+- Per-repo cursor recovery on partial pagination failure
+
+---
+
+## Mentor talking point
+
+> "I implemented resilient GitHub request handling with exponential backoff for transient failures, plus sleep-until-reset recovery for primary rate limits. Permission 403s still fail immediately. Rate-limit waits are separate from the transient retry budget so we don't burn attempts on quota resets."

--- a/src/ghdcbot/adapters/github/rest.py
+++ b/src/ghdcbot/adapters/github/rest.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import logging
+import random
 import re
+import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Iterable, Iterator, Sequence
@@ -19,11 +21,55 @@ class RateLimitStatus:
     reset_at: datetime | None
 
 
+_GITHUB_RETRY_MAX_ATTEMPTS = 4
+_GITHUB_RETRY_BACKOFF_SECONDS = (1.0, 2.0, 4.0)
+_GITHUB_TRANSIENT_STATUS_CODES = frozenset({502, 503, 504})
+
+
+def _github_retry_sleep_seconds(failed_attempt: int) -> float:
+    """Backoff before the next attempt after failed_attempt (1-indexed)."""
+    if 1 <= failed_attempt <= len(_GITHUB_RETRY_BACKOFF_SECONDS):
+        base = _GITHUB_RETRY_BACKOFF_SECONDS[failed_attempt - 1]
+    else:
+        base = _GITHUB_RETRY_BACKOFF_SECONDS[-1]
+    return base + random.uniform(0, 0.5)
+
+
+def _is_rate_limit_exhausted(response: httpx.Response) -> bool:
+    if response.status_code != 403:
+        return False
+    rate_limit = _parse_rate_limit(response.headers)
+    return rate_limit.remaining == 0
+
+
+def _rate_limit_reset_timestamp(headers: dict) -> int | None:
+    reset = headers.get("X-RateLimit-Reset")
+    if reset is None:
+        return None
+    reset_str = str(reset).strip()
+    if not reset_str.isdigit():
+        return None
+    return int(reset_str)
+
+
+def _rate_limit_sleep_seconds(headers: dict) -> float | None:
+    reset_ts = _rate_limit_reset_timestamp(headers)
+    if reset_ts is None:
+        return None
+    sleep_seconds = reset_ts - time.time()
+    if sleep_seconds < 0:
+        return 0.0
+    return sleep_seconds
+
+
 class GitHubRestAdapter:
     def __init__(self, token: str, org: str, api_base: str) -> None:
         self._logger = logging.getLogger(self.__class__.__name__)
         self._org = org
         self._last_repo_count: int | None = None
+        self._sync_cached_repos: list[dict] | None = None
+        self._sync_request_count = 0
+        self._sync_repos_processed = 0
         self._client = httpx.Client(
             base_url=api_base,
             headers={
@@ -42,13 +88,43 @@ class GitHubRestAdapter:
     def __exit__(self, *args: object) -> None:
         self.close()
 
+    @property
+    def sync_request_count(self) -> int:
+        return self._sync_request_count
+
+    @property
+    def sync_repos_processed(self) -> int:
+        return self._sync_repos_processed
+
+    def peek_repos_for_sync(self) -> int:
+        self._ensure_sync_repos_cached()
+        return len(self._sync_cached_repos or [])
+
+    def _ensure_sync_repos_cached(self) -> None:
+        if self._sync_cached_repos is None:
+            self._sync_cached_repos = list(self._list_repos())
+
+    def _reset_sync_tracking(self) -> None:
+        self._sync_request_count = 0
+        self._sync_repos_processed = 0
+
+    def _increment_sync_request_count(self) -> None:
+        self._sync_request_count += 1
+
     def list_contributions(self, since: datetime) -> Iterable[ContributionEvent]:
+        self._reset_sync_tracking()
+        self._ensure_sync_repos_cached()
+        repos = self._sync_cached_repos or []
         self._logger.info(
             "Starting GitHub ingestion",
-            extra={"org": self._org, "since": since.isoformat()},
+            extra={"org": self._org, "since": since.isoformat(), "repos_total": len(repos)},
         )
-        for repo in self._list_repos():
-            yield from self._ingest_repo(repo, since)
+        try:
+            for repo in repos:
+                yield from self._ingest_repo(repo, since)
+                self._sync_repos_processed += 1
+        finally:
+            self._sync_cached_repos = None
 
     def list_open_issues(self) -> Iterable[dict]:
         for repo in self._list_repos():
@@ -404,7 +480,11 @@ class GitHubRestAdapter:
         repo_name = repo["name"]
         owner = repo["owner"]["login"]
         full_name = repo["full_name"]
-        self._logger.info("Ingesting repository", extra={"repo": full_name})
+        started = time.monotonic()
+        self._logger.info(
+            "Repository ingestion started",
+            extra={"event": "repo_ingestion_started", "repo": full_name},
+        )
 
         issue_events, issue_numbers, issue_authors = self._collect_issue_events(
             owner, repo_name, since
@@ -426,20 +506,22 @@ class GitHubRestAdapter:
                 issue_authors=issue_authors, pr_authors=pr_authors,
             )
         )
+        repo_events = (
+            issue_events
+            + issue_comment_events
+            + pr_events
+            + pr_comment_events
+            + helpful_comment_events
+        )
         self._logger.info(
-            "Ingestion results",
+            "Repository ingestion completed",
             extra={
+                "event": "repo_ingestion_completed",
                 "repo": full_name,
-                "issue_events": len(issue_events),
-                "pr_events": len(pr_events),
-                "comment_events": len(issue_comment_events) + len(pr_comment_events),
+                "events": len(repo_events),
+                "duration_ms": int((time.monotonic() - started) * 1000),
             },
         )
-        if pr_opened_count:
-            self._logger.info(
-                "Emitted pr_opened event",
-                extra={"repo": full_name, "count": pr_opened_count},
-            )
         yield from issue_events
         yield from issue_comment_events
         yield from pr_events
@@ -1062,11 +1144,80 @@ class GitHubRestAdapter:
                 return
             page += 1
 
+    def _execute_request_with_retries(
+        self, method: str, path: str, params: dict
+    ) -> httpx.Response | None:
+        last_reason = "unknown"
+        for attempt in range(1, _GITHUB_RETRY_MAX_ATTEMPTS + 1):
+            response: httpx.Response | None = None
+            transport_error: str | None = None
+
+            while True:
+                try:
+                    self._increment_sync_request_count()
+                    response = self._client.request(method, path, params=params)
+                    transport_error = None
+                except httpx.TimeoutException:
+                    transport_error = "Timeout"
+                    break
+                except httpx.ConnectError:
+                    transport_error = "ConnectError"
+                    break
+                except httpx.HTTPError as exc:
+                    self._logger.warning("GitHub request failed", extra={"path": path, "error": str(exc)})
+                    return None
+
+                if response is not None and _is_rate_limit_exhausted(response):
+                    sleep_seconds = _rate_limit_sleep_seconds(response.headers)
+                    reset_timestamp = _rate_limit_reset_timestamp(response.headers)
+                    if sleep_seconds is None:
+                        self._log_github_rate_limit_missing_reset(
+                            path, response.headers.get("X-RateLimit-Reset")
+                        )
+                        return None
+                    self._log_github_rate_limit_exhausted(
+                        path, 0, reset_timestamp, sleep_seconds
+                    )
+                    time.sleep(sleep_seconds)
+                    self._log_github_rate_limit_recovered(path, attempt)
+                    continue
+
+                break
+
+            if transport_error is not None:
+                last_reason = transport_error
+                if attempt >= _GITHUB_RETRY_MAX_ATTEMPTS:
+                    self._log_github_request_failed(path, attempt, last_reason)
+                    return None
+                sleep_seconds = _github_retry_sleep_seconds(attempt)
+                self._log_github_request_retry(
+                    path, attempt + 1, _GITHUB_RETRY_MAX_ATTEMPTS, last_reason, sleep_seconds
+                )
+                time.sleep(sleep_seconds)
+                continue
+
+            if response is None:
+                return None
+
+            if response.status_code in _GITHUB_TRANSIENT_STATUS_CODES:
+                last_reason = f"{response.status_code} {response.reason_phrase}"
+                if attempt >= _GITHUB_RETRY_MAX_ATTEMPTS:
+                    self._log_github_request_failed(path, attempt, last_reason)
+                    return None
+                sleep_seconds = _github_retry_sleep_seconds(attempt)
+                self._log_github_request_retry(
+                    path, attempt + 1, _GITHUB_RETRY_MAX_ATTEMPTS, last_reason, sleep_seconds
+                )
+                time.sleep(sleep_seconds)
+                continue
+
+            return response
+
+        return None
+
     def _request(self, method: str, path: str, params: dict) -> httpx.Response | None:
-        try:
-            response = self._client.request(method, path, params=params)
-        except httpx.HTTPError as exc:
-            self._logger.warning("GitHub request failed", extra={"path": path, "error": str(exc)})
+        response = self._execute_request_with_retries(method, path, params)
+        if response is None:
             return None
 
         rate_limit = _parse_rate_limit(response.headers)
@@ -1082,6 +1233,9 @@ class GitHubRestAdapter:
                 },
             )
 
+        if response.status_code == 401:
+            self._log_permission_issue(path, response)
+            return None
         if response.status_code == 403:
             self._log_permission_issue(path, response)
             return None
@@ -1092,10 +1246,8 @@ class GitHubRestAdapter:
         return response
 
     def _request_with_status(self, method: str, path: str, params: dict) -> httpx.Response | None:
-        try:
-            response = self._client.request(method, path, params=params)
-        except httpx.HTTPError as exc:
-            self._logger.warning("GitHub request failed", extra={"path": path, "error": str(exc)})
+        response = self._execute_request_with_retries(method, path, params)
+        if response is None:
             return None
 
         rate_limit = _parse_rate_limit(response.headers)
@@ -1116,6 +1268,75 @@ class GitHubRestAdapter:
         if response.status_code == 404:
             self._log_not_found(path, response)
         return response
+
+    def _log_github_request_retry(
+        self,
+        path: str,
+        attempt: int,
+        max_attempts: int,
+        reason: str,
+        sleep_seconds: float,
+    ) -> None:
+        self._logger.warning(
+            "GitHub request retry",
+            extra={
+                "event": "github_request_retry",
+                "path": path,
+                "attempt": attempt,
+                "max_attempts": max_attempts,
+                "reason": reason,
+                "sleep_seconds": sleep_seconds,
+            },
+        )
+
+    def _log_github_request_failed(self, path: str, attempts: int, reason: str) -> None:
+        self._logger.warning(
+            "GitHub request failed after retries",
+            extra={
+                "event": "github_request_failed",
+                "path": path,
+                "attempts": attempts,
+                "reason": reason,
+            },
+        )
+
+    def _log_github_rate_limit_exhausted(
+        self,
+        path: str,
+        remaining: int,
+        reset_timestamp: int | None,
+        sleep_seconds: float,
+    ) -> None:
+        self._logger.warning(
+            "GitHub rate limit exhausted",
+            extra={
+                "event": "github_rate_limit_exhausted",
+                "path": path,
+                "remaining": remaining,
+                "reset_timestamp": reset_timestamp,
+                "sleep_seconds": sleep_seconds,
+            },
+        )
+
+    def _log_github_rate_limit_recovered(self, path: str, attempt: int) -> None:
+        self._logger.warning(
+            "GitHub rate limit recovered",
+            extra={
+                "event": "github_rate_limit_recovered",
+                "path": path,
+                "attempt": attempt,
+            },
+        )
+
+    def _log_github_rate_limit_missing_reset(self, path: str, reset_header: str | None) -> None:
+        self._logger.warning(
+            "GitHub rate limit missing or malformed reset header",
+            extra={
+                "event": "github_rate_limit_missing_reset",
+                "path": path,
+                "reset_header": reset_header,
+            },
+        )
 
     def _log_permission_issue(self, path: str, response: httpx.Response) -> None:
         self._logger.warning(

--- a/src/ghdcbot/adapters/github/rest.py
+++ b/src/ghdcbot/adapters/github/rest.py
@@ -24,6 +24,8 @@ class RateLimitStatus:
 _GITHUB_RETRY_MAX_ATTEMPTS = 4
 _GITHUB_RETRY_BACKOFF_SECONDS = (1.0, 2.0, 4.0)
 _GITHUB_TRANSIENT_STATUS_CODES = frozenset({502, 503, 504})
+_GITHUB_MAX_RATE_LIMIT_RECOVERIES = 10
+_GITHUB_MIN_RATE_LIMIT_SLEEP_SECONDS = 1.0
 
 
 def _github_retry_sleep_seconds(failed_attempt: int) -> float:
@@ -58,8 +60,8 @@ def _rate_limit_sleep_seconds(headers: dict) -> float | None:
         return None
     sleep_seconds = reset_ts - time.time()
     if sleep_seconds < 0:
-        return 0.0
-    return sleep_seconds
+        sleep_seconds = 0.0
+    return max(sleep_seconds, _GITHUB_MIN_RATE_LIMIT_SLEEP_SECONDS)
 
 
 class GitHubRestAdapter:
@@ -1152,6 +1154,7 @@ class GitHubRestAdapter:
             response: httpx.Response | None = None
             transport_error: str | None = None
 
+            rate_limit_recovery_count = 0
             while True:
                 try:
                     self._increment_sync_request_count()
@@ -1168,6 +1171,24 @@ class GitHubRestAdapter:
                     return None
 
                 if response is not None and _is_rate_limit_exhausted(response):
+                    if rate_limit_recovery_count >= _GITHUB_MAX_RATE_LIMIT_RECOVERIES:
+                        reset_timestamp = _rate_limit_reset_timestamp(response.headers)
+                        self._log_github_rate_limit_exhausted(
+                            path,
+                            0,
+                            reset_timestamp,
+                            0.0,
+                        )
+                        self._logger.warning(
+                            "GitHub rate limit recovery cap exceeded",
+                            extra={
+                                "event": "github_rate_limit_recovery_exhausted",
+                                "path": path,
+                                "recoveries": rate_limit_recovery_count,
+                                "max_recoveries": _GITHUB_MAX_RATE_LIMIT_RECOVERIES,
+                            },
+                        )
+                        return None
                     sleep_seconds = _rate_limit_sleep_seconds(response.headers)
                     reset_timestamp = _rate_limit_reset_timestamp(response.headers)
                     if sleep_seconds is None:
@@ -1175,6 +1196,7 @@ class GitHubRestAdapter:
                             path, response.headers.get("X-RateLimit-Reset")
                         )
                         return None
+                    rate_limit_recovery_count += 1
                     self._log_github_rate_limit_exhausted(
                         path, 0, reset_timestamp, sleep_seconds
                     )

--- a/src/ghdcbot/engine/orchestrator.py
+++ b/src/ghdcbot/engine/orchestrator.py
@@ -22,6 +22,7 @@ from ghdcbot.engine.planning import plan_discord_roles
 from ghdcbot.engine.reporting import write_reports, write_activity_report
 from ghdcbot.engine.scoring import WeightedScoreStrategy
 from ghdcbot.engine.snapshots import write_snapshots_to_github
+from ghdcbot.logging.sync_context import SyncSession
 
 
 @dataclass(frozen=True)
@@ -35,6 +36,14 @@ class Orchestrator:
 
     def run_once(self) -> None:
         logger = logging.getLogger("Orchestrator")
+        with SyncSession() as sync:
+            try:
+                self._run_once_body(logger, sync)
+            except Exception as exc:
+                sync.log_failed(str(exc))
+                raise
+
+    def _run_once_body(self, logger: logging.Logger, sync: SyncSession) -> None:
         self.storage.init_schema()
 
         period_end = datetime.now(timezone.utc)
@@ -43,12 +52,18 @@ class Orchestrator:
         identity_mappings = _resolve_identity_mappings(self.storage, self.config.identity_mappings)
 
         prior_cursor = self.storage.get_cursor("github") or period_start
+        peek_repos = getattr(self.github_reader, "peek_repos_for_sync", None)
+        repos_total = peek_repos() if callable(peek_repos) else 0
+        sync.log_started(prior_cursor, repos_total)
+
         contributions = list(self.github_reader.list_contributions(prior_cursor))
         stored = self.storage.record_contributions(contributions)
+        cursor_after = prior_cursor
         if contributions:
             new_cursor = max(event.created_at for event in contributions)
             if new_cursor > prior_cursor:
                 self.storage.set_cursor("github", new_cursor)
+                cursor_after = new_cursor
         logger.info("Stored GitHub contributions", extra={"count": stored})
 
         recent = self.storage.list_contributions(period_start)
@@ -276,6 +291,16 @@ class Orchestrator:
         except Exception as exc:
             # Never block run-once completion
             logger.warning("Snapshot writing failed (non-blocking)", exc_info=True, extra={"error": str(exc)})
+
+        repos_processed = int(getattr(self.github_reader, "sync_repos_processed", repos_total))
+        requests_total = int(getattr(self.github_reader, "sync_request_count", 0))
+        sync.log_event_summary(contributions)
+        sync.log_completed(
+            cursor_after,
+            repos_processed=repos_processed,
+            events_fetched=len(contributions),
+            requests_total=requests_total,
+        )
 
     def close(self) -> None:
         for adapter in {self.github_reader, self.github_writer, self.discord_reader, self.discord_writer}:

--- a/src/ghdcbot/logging/setup.py
+++ b/src/ghdcbot/logging/setup.py
@@ -5,6 +5,32 @@ import logging
 from datetime import datetime, timezone
 from typing import Any
 
+from ghdcbot.logging.sync_context import SyncContextFilter
+
+_BUILTIN_LOG_RECORD_ATTRS = frozenset(
+    logging.LogRecord(
+        name="",
+        level=logging.INFO,
+        pathname="",
+        lineno=0,
+        msg="",
+        args=(),
+        exc_info=None,
+    ).__dict__
+)
+
+
+def _json_safe(value: Any) -> Any:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    if isinstance(value, dict):
+        return {str(k): _json_safe(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(item) for item in value]
+    return str(value)
+
 
 class JsonFormatter(logging.Formatter):
     def format(self, record: logging.LogRecord) -> str:
@@ -14,6 +40,10 @@ class JsonFormatter(logging.Formatter):
             "logger": record.name,
             "message": record.getMessage(),
         }
+        for key, value in record.__dict__.items():
+            if key in _BUILTIN_LOG_RECORD_ATTRS or key in payload:
+                continue
+            payload[key] = _json_safe(value)
         if record.exc_info:
             payload["exc_info"] = self.formatException(record.exc_info)
         if record.stack_info:
@@ -24,6 +54,7 @@ class JsonFormatter(logging.Formatter):
 def configure_logging(level: str) -> None:
     handler = logging.StreamHandler()
     handler.setFormatter(JsonFormatter())
+    handler.addFilter(SyncContextFilter())
     root = logging.getLogger()
     root.handlers.clear()
     root.setLevel(level)

--- a/src/ghdcbot/logging/sync_context.py
+++ b/src/ghdcbot/logging/sync_context.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import contextvars
+import logging
+import secrets
+import time
+from collections import Counter
+from contextlib import AbstractContextManager
+from datetime import datetime, timezone
+from typing import Any
+
+_sync_id_var: contextvars.ContextVar[str | None] = contextvars.ContextVar("sync_id", default=None)
+
+
+def generate_sync_id() -> str:
+    now = datetime.now(timezone.utc)
+    suffix = secrets.token_hex(2)
+    return f"sync_{now.strftime('%Y%m%d_%H%M%S')}_{suffix}"
+
+
+def get_sync_id() -> str | None:
+    return _sync_id_var.get()
+
+
+class SyncContextFilter(logging.Filter):
+    """Attach the active sync_id to every log record in the current context."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        sync_id = _sync_id_var.get()
+        if sync_id is not None:
+            record.sync_id = sync_id
+        return True
+
+
+class SyncSession(AbstractContextManager["SyncSession"]):
+    """Lifecycle logging for a single run-once or /sync execution."""
+
+    _EVENT_SUMMARY_TYPES = (
+        "issue_opened",
+        "issue_closed",
+        "pr_opened",
+        "pr_merged",
+        "pr_reviewed",
+    )
+
+    def __init__(self) -> None:
+        self.sync_id = generate_sync_id()
+        self._token: contextvars.Token[str | None] | None = None
+        self._started_monotonic = time.monotonic()
+        self._logger = logging.getLogger("Orchestrator")
+        self.cursor_before: str | None = None
+        self.cursor_after: str | None = None
+
+    def __enter__(self) -> SyncSession:
+        self._token = _sync_id_var.set(self.sync_id)
+        return self
+
+    def __exit__(self, exc_type: object, exc_val: object, exc_tb: object) -> bool:
+        if self._token is not None:
+            _sync_id_var.reset(self._token)
+        return False
+
+    def _duration_ms(self) -> int:
+        return int((time.monotonic() - self._started_monotonic) * 1000)
+
+    def log_started(self, cursor_before: datetime, repos_total: int) -> None:
+        self.cursor_before = cursor_before.isoformat()
+        self._logger.info(
+            "GitHub sync started",
+            extra={
+                "event": "github_sync_started",
+                "sync_id": self.sync_id,
+                "cursor_before": self.cursor_before,
+                "repos_total": repos_total,
+            },
+        )
+
+    def log_completed(
+        self,
+        cursor_after: datetime,
+        *,
+        repos_processed: int,
+        events_fetched: int,
+        requests_total: int,
+    ) -> None:
+        self.cursor_after = cursor_after.isoformat()
+        self.log_request_summary(requests_total)
+        self._logger.info(
+            "GitHub sync completed",
+            extra={
+                "event": "github_sync_completed",
+                "sync_id": self.sync_id,
+                "cursor_before": self.cursor_before,
+                "cursor_after": self.cursor_after,
+                "repos_processed": repos_processed,
+                "events_fetched": events_fetched,
+                "duration_ms": self._duration_ms(),
+            },
+        )
+
+    def log_event_summary(self, contributions: list[Any]) -> None:
+        counts = Counter(event.event_type for event in contributions)
+        self._logger.info(
+            "GitHub event summary",
+            extra=self._event_summary_extra(dict(counts)),
+        )
+
+    def log_request_summary(self, requests_total: int) -> None:
+        self._logger.info(
+            "GitHub request summary",
+            extra={
+                "event": "github_request_summary",
+                "sync_id": self.sync_id,
+                "requests_total": requests_total,
+            },
+        )
+
+    def log_failed(self, error: str) -> None:
+        self._logger.error(
+            "GitHub sync failed",
+            extra={
+                "event": "github_sync_failed",
+                "sync_id": self.sync_id,
+                "error": error,
+                "duration_ms": self._duration_ms(),
+            },
+        )
+
+    def _event_summary_extra(self, counts: dict[str, int]) -> dict[str, Any]:
+        extra: dict[str, Any] = {
+            "event": "github_event_summary",
+            "sync_id": self.sync_id,
+        }
+        for event_type in self._EVENT_SUMMARY_TYPES:
+            extra[event_type] = counts.get(event_type, 0)
+        return extra

--- a/src/ghdcbot/logging/sync_context.py
+++ b/src/ghdcbot/logging/sync_context.py
@@ -109,6 +109,11 @@ class SyncSession(AbstractContextManager["SyncSession"]):
         counts = Counter(_contribution_event_type(event) for event in contributions)
         extra = self._event_summary_extra(dict(counts))
         unknown_count = counts.get("unknown", 0)
+        unknown_count += sum(
+            count
+            for event_type, count in counts.items()
+            if event_type not in self._EVENT_SUMMARY_TYPES and event_type != "unknown"
+        )
         if unknown_count:
             extra["unknown"] = unknown_count
         self._logger.info(

--- a/src/ghdcbot/logging/sync_context.py
+++ b/src/ghdcbot/logging/sync_context.py
@@ -22,6 +22,13 @@ def get_sync_id() -> str | None:
     return _sync_id_var.get()
 
 
+def _contribution_event_type(event: Any) -> str:
+    event_type = getattr(event, "event_type", None)
+    if isinstance(event_type, str) and event_type:
+        return event_type
+    return "unknown"
+
+
 class SyncContextFilter(logging.Filter):
     """Attach the active sync_id to every log record in the current context."""
 
@@ -99,10 +106,14 @@ class SyncSession(AbstractContextManager["SyncSession"]):
         )
 
     def log_event_summary(self, contributions: list[Any]) -> None:
-        counts = Counter(event.event_type for event in contributions)
+        counts = Counter(_contribution_event_type(event) for event in contributions)
+        extra = self._event_summary_extra(dict(counts))
+        unknown_count = counts.get("unknown", 0)
+        if unknown_count:
+            extra["unknown"] = unknown_count
         self._logger.info(
             "GitHub event summary",
-            extra=self._event_summary_extra(dict(counts)),
+            extra=extra,
         )
 
     def log_request_summary(self, requests_total: int) -> None:

--- a/tests/test_github_rate_limit.py
+++ b/tests/test_github_rate_limit.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 import httpx
 import pytest
 
-from ghdcbot.adapters.github.rest import GitHubRestAdapter
+from ghdcbot.adapters.github.rest import (
+    GitHubRestAdapter,
+    _GITHUB_MAX_RATE_LIMIT_RECOVERIES,
+)
 
 
 class _SequenceMockClient:
@@ -133,7 +136,37 @@ def test_rate_limit_malformed_reset_header_returns_none(caplog) -> None:
     assert len(_event_records(caplog, "github_rate_limit_missing_reset")) == 1
 
 
-def test_rate_limit_negative_sleep_clamped_to_zero(monkeypatch, caplog) -> None:
+def test_rate_limit_recovery_cap_returns_none(monkeypatch, caplog) -> None:
+    fixed_now = 1_000_000.0
+    reset_ts = int(fixed_now) + 1
+    client = _SequenceMockClient(
+        [
+            httpx.Response(
+                403,
+                headers={
+                    "X-RateLimit-Remaining": "0",
+                    "X-RateLimit-Reset": str(reset_ts),
+                },
+                text="rate limit",
+            )
+        ]
+        * (_GITHUB_MAX_RATE_LIMIT_RECOVERIES + 1)
+    )
+    adapter = _adapter_with_client(client)
+    sleep_calls: list[float] = []
+    monkeypatch.setattr("ghdcbot.adapters.github.rest.time.time", lambda: fixed_now)
+    monkeypatch.setattr("ghdcbot.adapters.github.rest.time.sleep", lambda s: sleep_calls.append(s))
+    caplog.set_level("WARNING")
+
+    response = adapter._request("GET", "/repos/AOSSIE/Gitcord/issues", {})
+
+    assert response is None
+    assert client.call_count == _GITHUB_MAX_RATE_LIMIT_RECOVERIES + 1
+    assert len(sleep_calls) == _GITHUB_MAX_RATE_LIMIT_RECOVERIES
+    assert len(_event_records(caplog, "github_rate_limit_recovery_exhausted")) == 1
+
+
+def test_rate_limit_negative_sleep_clamped_to_minimum(monkeypatch, caplog) -> None:
     fixed_now = 2_000_000.0
     reset_ts = int(fixed_now) - 10
     client = _SequenceMockClient(
@@ -159,4 +192,4 @@ def test_rate_limit_negative_sleep_clamped_to_zero(monkeypatch, caplog) -> None:
 
     assert response is not None
     assert response.status_code == 200
-    assert sleep_calls == [0.0]
+    assert sleep_calls == [1.0]

--- a/tests/test_github_rate_limit.py
+++ b/tests/test_github_rate_limit.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from ghdcbot.adapters.github.rest import GitHubRestAdapter
+
+
+class _SequenceMockClient:
+    def __init__(self, outcomes: list[httpx.Response | Exception]) -> None:
+        self._outcomes = list(outcomes)
+        self.call_count = 0
+
+    def request(self, method: str, path: str, params: dict | None = None) -> httpx.Response:
+        self.call_count += 1
+        outcome = self._outcomes.pop(0)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+
+def _adapter_with_client(client: _SequenceMockClient) -> GitHubRestAdapter:
+    adapter = GitHubRestAdapter(token="t", org="org", api_base="https://api.github.com")
+    adapter._client = client  # noqa: SLF001
+    return adapter
+
+
+def _ok_response() -> httpx.Response:
+    return httpx.Response(200, json=[], headers={"X-RateLimit-Remaining": "100"})
+
+
+def _event_records(caplog, event_name: str):
+    return [r for r in caplog.records if getattr(r, "event", None) == event_name]
+
+
+def test_rate_limit_sleep_then_success(monkeypatch, caplog) -> None:
+    fixed_now = 1_000_000.0
+    reset_ts = int(fixed_now) + 2
+    client = _SequenceMockClient(
+        [
+            httpx.Response(
+                403,
+                headers={
+                    "X-RateLimit-Remaining": "0",
+                    "X-RateLimit-Reset": str(reset_ts),
+                },
+                text="rate limit",
+            ),
+            _ok_response(),
+        ]
+    )
+    adapter = _adapter_with_client(client)
+    sleep_calls: list[float] = []
+    monkeypatch.setattr("ghdcbot.adapters.github.rest.time.time", lambda: fixed_now)
+    monkeypatch.setattr("ghdcbot.adapters.github.rest.time.sleep", lambda s: sleep_calls.append(s))
+    caplog.set_level("WARNING")
+
+    response = adapter._request("GET", "/repos/AOSSIE/Gitcord/issues", {})
+
+    assert response is not None
+    assert response.status_code == 200
+    assert client.call_count == 2
+    assert sleep_calls == [2.0]
+    assert len(_event_records(caplog, "github_rate_limit_exhausted")) == 1
+    assert _event_records(caplog, "github_rate_limit_exhausted")[0].sleep_seconds == 2.0
+    assert len(_event_records(caplog, "github_rate_limit_recovered")) == 1
+
+
+def test_rate_limit_missing_reset_header_returns_none(caplog) -> None:
+    client = _SequenceMockClient(
+        [
+            httpx.Response(
+                403,
+                headers={"X-RateLimit-Remaining": "0"},
+                text="rate limit",
+            )
+        ]
+    )
+    adapter = _adapter_with_client(client)
+    caplog.set_level("WARNING")
+
+    response = adapter._request("GET", "/repos/AOSSIE/Gitcord/issues", {})
+
+    assert response is None
+    assert client.call_count == 1
+    assert len(_event_records(caplog, "github_rate_limit_missing_reset")) == 1
+
+
+def test_permission_403_remaining_nonzero_no_sleep(monkeypatch, caplog) -> None:
+    client = _SequenceMockClient(
+        [
+            httpx.Response(
+                403,
+                headers={"X-RateLimit-Remaining": "5"},
+                text="Forbidden",
+            )
+        ]
+    )
+    adapter = _adapter_with_client(client)
+    sleep_calls: list[float] = []
+    monkeypatch.setattr("ghdcbot.adapters.github.rest.time.sleep", lambda s: sleep_calls.append(s))
+    caplog.set_level("WARNING")
+
+    response = adapter._request("GET", "/repos/AOSSIE/private-repo/issues", {})
+
+    assert response is None
+    assert client.call_count == 1
+    assert sleep_calls == []
+    assert _event_records(caplog, "github_rate_limit_exhausted") == []
+    assert any("permission or visibility issue" in r.message.lower() for r in caplog.records)
+
+
+def test_rate_limit_malformed_reset_header_returns_none(caplog) -> None:
+    client = _SequenceMockClient(
+        [
+            httpx.Response(
+                403,
+                headers={
+                    "X-RateLimit-Remaining": "0",
+                    "X-RateLimit-Reset": "not-a-timestamp",
+                },
+                text="rate limit",
+            )
+        ]
+    )
+    adapter = _adapter_with_client(client)
+    caplog.set_level("WARNING")
+
+    response = adapter._request("GET", "/repos/AOSSIE/Gitcord/issues", {})
+
+    assert response is None
+    assert client.call_count == 1
+    assert len(_event_records(caplog, "github_rate_limit_missing_reset")) == 1
+
+
+def test_rate_limit_negative_sleep_clamped_to_zero(monkeypatch, caplog) -> None:
+    fixed_now = 2_000_000.0
+    reset_ts = int(fixed_now) - 10
+    client = _SequenceMockClient(
+        [
+            httpx.Response(
+                403,
+                headers={
+                    "X-RateLimit-Remaining": "0",
+                    "X-RateLimit-Reset": str(reset_ts),
+                },
+                text="rate limit",
+            ),
+            _ok_response(),
+        ]
+    )
+    adapter = _adapter_with_client(client)
+    sleep_calls: list[float] = []
+    monkeypatch.setattr("ghdcbot.adapters.github.rest.time.time", lambda: fixed_now)
+    monkeypatch.setattr("ghdcbot.adapters.github.rest.time.sleep", lambda s: sleep_calls.append(s))
+    caplog.set_level("WARNING")
+
+    response = adapter._request("GET", "/repos/AOSSIE/Gitcord/issues", {})
+
+    assert response is not None
+    assert response.status_code == 200
+    assert sleep_calls == [0.0]

--- a/tests/test_github_retry.py
+++ b/tests/test_github_retry.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from ghdcbot.adapters.github.rest import GitHubRestAdapter
+
+
+class _SequenceMockClient:
+    def __init__(self, outcomes: list[httpx.Response | Exception]) -> None:
+        self._outcomes = list(outcomes)
+        self.call_count = 0
+
+    def request(self, method: str, path: str, params: dict | None = None) -> httpx.Response:
+        self.call_count += 1
+        outcome = self._outcomes.pop(0)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+
+def _adapter_with_client(client: _SequenceMockClient) -> GitHubRestAdapter:
+    adapter = GitHubRestAdapter(token="t", org="org", api_base="https://api.github.com")
+    adapter._client = client  # noqa: SLF001
+    return adapter
+
+
+def _ok_response() -> httpx.Response:
+    return httpx.Response(200, json=[], headers={"X-RateLimit-Remaining": "100"})
+
+
+def _status_response(status_code: int) -> httpx.Response:
+    return httpx.Response(status_code, headers={"X-RateLimit-Remaining": "100"})
+
+
+def _retry_records(caplog):
+    return [r for r in caplog.records if getattr(r, "event", None) == "github_request_retry"]
+
+
+def _failed_records(caplog):
+    return [r for r in caplog.records if getattr(r, "event", None) == "github_request_failed"]
+
+
+def test_retry_503_twice_then_200(monkeypatch, caplog) -> None:
+    client = _SequenceMockClient(
+        [
+            _status_response(503),
+            _status_response(503),
+            _ok_response(),
+        ]
+    )
+    adapter = _adapter_with_client(client)
+    monkeypatch.setattr("ghdcbot.adapters.github.rest.time.sleep", lambda _s: None)
+    caplog.set_level("WARNING")
+
+    response = adapter._request("GET", "/repos/AOSSIE/Gitcord/issues", {})
+
+    assert response is not None
+    assert response.status_code == 200
+    assert client.call_count == 3
+    assert len(_retry_records(caplog)) == 2
+    assert _retry_records(caplog)[0].attempt == 2
+    assert _retry_records(caplog)[1].attempt == 3
+
+
+def test_retry_timeout_twice_then_200(monkeypatch, caplog) -> None:
+    client = _SequenceMockClient(
+        [
+            httpx.TimeoutException("timeout"),
+            httpx.TimeoutException("timeout"),
+            _ok_response(),
+        ]
+    )
+    adapter = _adapter_with_client(client)
+    monkeypatch.setattr("ghdcbot.adapters.github.rest.time.sleep", lambda _s: None)
+    caplog.set_level("WARNING")
+
+    response = adapter._request("GET", "/repos/AOSSIE/Gitcord/issues", {})
+
+    assert response is not None
+    assert response.status_code == 200
+    assert client.call_count == 3
+    assert len(_retry_records(caplog)) == 2
+    assert _retry_records(caplog)[0].reason == "Timeout"
+
+
+def test_404_no_retry(caplog) -> None:
+    client = _SequenceMockClient([_status_response(404)])
+    adapter = _adapter_with_client(client)
+    caplog.set_level("WARNING")
+
+    response = adapter._request("GET", "/repos/AOSSIE/Gitcord/issues/999", {})
+
+    assert response is None
+    assert client.call_count == 1
+    assert _retry_records(caplog) == []
+    assert _failed_records(caplog) == []
+
+
+def test_401_no_retry(caplog) -> None:
+    client = _SequenceMockClient([_status_response(401)])
+    adapter = _adapter_with_client(client)
+    caplog.set_level("WARNING")
+
+    response = adapter._request("GET", "/repos/AOSSIE/Gitcord/issues", {})
+
+    assert response is None
+    assert client.call_count == 1
+    assert _retry_records(caplog) == []
+    assert _failed_records(caplog) == []
+
+
+def test_503_exhausts_max_attempts(monkeypatch, caplog) -> None:
+    client = _SequenceMockClient(
+        [
+            _status_response(503),
+            _status_response(503),
+            _status_response(503),
+            _status_response(503),
+        ]
+    )
+    adapter = _adapter_with_client(client)
+    monkeypatch.setattr("ghdcbot.adapters.github.rest.time.sleep", lambda _s: None)
+    caplog.set_level("WARNING")
+
+    response = adapter._request("GET", "/repos/AOSSIE/Gitcord/issues", {})
+
+    assert response is None
+    assert client.call_count == 4
+    assert len(_retry_records(caplog)) == 3
+    assert len(_failed_records(caplog)) == 1
+    assert _failed_records(caplog)[0].attempts == 4
+    assert "503" in _failed_records(caplog)[0].reason
+
+
+def test_permission_403_no_retry(caplog) -> None:
+    client = _SequenceMockClient(
+        [
+            httpx.Response(
+                403,
+                headers={"X-RateLimit-Remaining": "4521"},
+                text="Forbidden",
+            )
+        ]
+    )
+    adapter = _adapter_with_client(client)
+    caplog.set_level("WARNING")
+
+    response = adapter._request("GET", "/repos/AOSSIE/private-repo/issues", {})
+
+    assert response is None
+    assert client.call_count == 1
+    assert _retry_records(caplog) == []
+
+
+def test_rate_limit_403_missing_reset_no_transient_retry(caplog) -> None:
+    client = _SequenceMockClient(
+        [
+            httpx.Response(
+                403,
+                headers={"X-RateLimit-Remaining": "0"},
+                text="rate limit",
+            )
+        ]
+    )
+    adapter = _adapter_with_client(client)
+    caplog.set_level("WARNING")
+
+    response = adapter._request("GET", "/repos/AOSSIE/Gitcord/issues", {})
+
+    assert response is None
+    assert client.call_count == 1
+    assert _retry_records(caplog) == []
+    assert any(
+        getattr(r, "event", None) == "github_rate_limit_missing_reset" for r in caplog.records
+    )

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -20,7 +20,7 @@ from ghdcbot.config.models import (
 from ghdcbot.core.models import ContributionEvent
 from ghdcbot.engine.orchestrator import Orchestrator
 from ghdcbot.logging.setup import JsonFormatter, configure_logging
-from ghdcbot.logging.sync_context import SyncSession, generate_sync_id
+from ghdcbot.logging.sync_context import SyncContextFilter, SyncSession, generate_sync_id
 
 
 def test_json_formatter_preserves_extra_fields() -> None:
@@ -59,7 +59,7 @@ def test_json_formatter_includes_sync_id_from_filter() -> None:
 
     capture = _CaptureHandler()
     capture.setFormatter(JsonFormatter())
-    capture.addFilter(__import__("ghdcbot.logging.sync_context", fromlist=["SyncContextFilter"]).SyncContextFilter())
+    capture.addFilter(SyncContextFilter())
 
     with SyncSession() as sync:
         capture.handle(
@@ -125,6 +125,24 @@ def test_sync_session_logs_started_and_completed(caplog) -> None:
     assert len(event_summary) == 1
     assert event_summary[0].issue_opened == 0
     assert event_summary[0].pr_merged == 0
+
+
+def test_log_event_summary_handles_missing_event_type(caplog) -> None:
+    caplog.set_level(logging.INFO, logger="Orchestrator")
+
+    with SyncSession() as sync:
+        sync.log_event_summary([SimpleNamespace(), ContributionEvent(
+            github_user="alice",
+            event_type="issue_opened",
+            repo="repo",
+            created_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+            payload={},
+        )])
+
+    summary = [r for r in caplog.records if getattr(r, "event", None) == "github_event_summary"]
+    assert len(summary) == 1
+    assert summary[0].issue_opened == 1
+    assert summary[0].unknown == 1
 
 
 def test_sync_session_logs_failed(caplog) -> None:

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from ghdcbot.adapters.storage.sqlite import SqliteStorage
+from ghdcbot.config.models import (
+    AssignmentConfig,
+    BotConfig,
+    DiscordConfig,
+    GitHubConfig,
+    RoleMappingConfig,
+    RuntimeConfig,
+    ScoringConfig,
+)
+from ghdcbot.core.models import ContributionEvent
+from ghdcbot.engine.orchestrator import Orchestrator
+from ghdcbot.logging.setup import JsonFormatter, configure_logging
+from ghdcbot.logging.sync_context import SyncSession, generate_sync_id
+
+
+def test_json_formatter_preserves_extra_fields() -> None:
+    formatter = JsonFormatter()
+    record = logging.LogRecord(
+        name="GitHubRestAdapter",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="Ingesting repository",
+        args=(),
+        exc_info=None,
+    )
+    record.repo = "AOSSIE/Gitcord"
+
+    payload = json.loads(formatter.format(record))
+
+    assert payload["message"] == "Ingesting repository"
+    assert payload["repo"] == "AOSSIE/Gitcord"
+    assert payload["level"] == "INFO"
+
+
+def test_json_formatter_includes_sync_id_from_filter() -> None:
+    configure_logging("INFO")
+    logger = logging.getLogger("test.sync_id")
+
+    with SyncSession() as sync:
+        logger.info("inside sync", extra={"repo": "AOSSIE/Gitcord"})
+
+    # Capture via custom handler for assertion
+    records: list[logging.LogRecord] = []
+
+    class _CaptureHandler(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            records.append(record)
+
+    capture = _CaptureHandler()
+    capture.setFormatter(JsonFormatter())
+    capture.addFilter(__import__("ghdcbot.logging.sync_context", fromlist=["SyncContextFilter"]).SyncContextFilter())
+
+    with SyncSession() as sync:
+        capture.handle(
+            logging.LogRecord(
+                name="test",
+                level=logging.INFO,
+                pathname=__file__,
+                lineno=1,
+                msg="inside sync",
+                args=(),
+                exc_info=None,
+            )
+        )
+        payload = json.loads(capture.formatter.format(records[-1]))
+        assert payload["sync_id"] == sync.sync_id
+        assert sync.sync_id.startswith("sync_")
+
+
+def test_generate_sync_id_format() -> None:
+    sync_id = generate_sync_id()
+    parts = sync_id.split("_")
+    assert parts[0] == "sync"
+    assert len(parts[1]) == 8
+    assert len(parts[2]) == 6
+    assert len(parts[3]) == 4
+
+
+def test_sync_session_logs_started_and_completed(caplog) -> None:
+    caplog.set_level(logging.INFO, logger="Orchestrator")
+    started_at = datetime(2026, 6, 18, 14, 23, tzinfo=timezone.utc)
+    completed_at = datetime(2026, 6, 18, 14, 24, tzinfo=timezone.utc)
+
+    with SyncSession() as sync:
+        sync.log_started(started_at, repos_total=12)
+        sync.log_event_summary([])
+        sync.log_completed(
+            completed_at,
+            repos_processed=12,
+            events_fetched=240,
+            requests_total=418,
+        )
+
+    started = [r for r in caplog.records if getattr(r, "event", None) == "github_sync_started"]
+    completed = [r for r in caplog.records if getattr(r, "event", None) == "github_sync_completed"]
+    request_summary = [r for r in caplog.records if getattr(r, "event", None) == "github_request_summary"]
+    event_summary = [r for r in caplog.records if getattr(r, "event", None) == "github_event_summary"]
+
+    assert len(started) == 1
+    assert started[0].cursor_before == started_at.isoformat()
+    assert started[0].repos_total == 12
+    assert started[0].sync_id == sync.sync_id
+
+    assert len(completed) == 1
+    assert completed[0].cursor_before == started_at.isoformat()
+    assert completed[0].cursor_after == completed_at.isoformat()
+    assert completed[0].repos_processed == 12
+    assert completed[0].events_fetched == 240
+    assert isinstance(completed[0].duration_ms, int)
+
+    assert len(request_summary) == 1
+    assert request_summary[0].requests_total == 418
+
+    assert len(event_summary) == 1
+    assert event_summary[0].issue_opened == 0
+    assert event_summary[0].pr_merged == 0
+
+
+def test_sync_session_logs_failed(caplog) -> None:
+    caplog.set_level(logging.ERROR, logger="Orchestrator")
+
+    with SyncSession() as sync:
+        sync.log_failed("boom")
+
+    failed = [r for r in caplog.records if getattr(r, "event", None) == "github_sync_failed"]
+    assert len(failed) == 1
+    assert failed[0].error == "boom"
+    assert isinstance(failed[0].duration_ms, int)
+
+
+class _FakeGitHubReader:
+    def __init__(self, events: list[ContributionEvent]) -> None:
+        self._events = events
+        self._repos_processed = 0
+
+    def peek_repos_for_sync(self) -> int:
+        return 1
+
+    @property
+    def sync_repos_processed(self) -> int:
+        return self._repos_processed
+
+    @property
+    def sync_request_count(self) -> int:
+        return 3
+
+    def list_contributions(self, since: datetime) -> list[ContributionEvent]:
+        self._repos_processed = 1
+        return list(self._events)
+
+    def list_open_issues(self) -> list[dict]:
+        return []
+
+    def list_open_pull_requests(self) -> list[dict]:
+        return []
+
+    def close(self) -> None:
+        return None
+
+
+def _minimal_config(tmp_path) -> BotConfig:
+    return BotConfig(
+        runtime=RuntimeConfig(
+            mode="dry-run",
+            data_dir=str(tmp_path),
+            storage_adapter="ghdcbot.adapters.storage.sqlite:SqliteStorage",
+            github_adapter="ghdcbot.adapters.github.rest:GitHubRestAdapter",
+            discord_adapter="ghdcbot.adapters.discord.api:DiscordApiAdapter",
+            enable_scoring=False,
+            enable_discord_role_updates=False,
+        ),
+        github=GitHubConfig(org="x", token="t", api_base="https://api.github.com"),
+        discord=DiscordConfig(token="t", guild_id="1"),
+        scoring=ScoringConfig(period_days=30, weights={}),
+        assignments=AssignmentConfig(issue_assignees=[], review_roles=[]),
+        identity_mappings=[],
+        role_mappings=[RoleMappingConfig(discord_role="Contributor", min_score=1)],
+    )
+
+
+def test_orchestrator_run_once_emits_sync_lifecycle_logs(tmp_path, caplog) -> None:
+    caplog.set_level(logging.INFO, logger="Orchestrator")
+
+    storage = SqliteStorage(data_dir=str(tmp_path))
+    storage.init_schema()
+    since = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    events = [
+        ContributionEvent(
+            github_user="alice",
+            event_type="issue_opened",
+            repo="repo",
+            created_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+            payload={"issue_number": 1},
+        ),
+        ContributionEvent(
+            github_user="bob",
+            event_type="pr_merged",
+            repo="repo",
+            created_at=datetime(2026, 6, 2, tzinfo=timezone.utc),
+            payload={"pr_number": 2},
+        ),
+    ]
+    github = _FakeGitHubReader(events)
+    discord = SimpleNamespace(
+        list_member_roles=lambda: {},
+        close=lambda: None,
+    )
+    orch = Orchestrator(
+        github_reader=github,
+        github_writer=github,
+        discord_reader=discord,
+        discord_writer=discord,
+        storage=storage,
+        config=_minimal_config(tmp_path),
+    )
+
+    orch.run_once()
+
+    started = [r for r in caplog.records if getattr(r, "event", None) == "github_sync_started"]
+    completed = [r for r in caplog.records if getattr(r, "event", None) == "github_sync_completed"]
+    event_summary = [r for r in caplog.records if getattr(r, "event", None) == "github_event_summary"]
+
+    assert len(started) == 1
+    assert started[0].repos_total == 1
+    assert len(completed) == 1
+    assert completed[0].events_fetched == 2
+    assert completed[0].repos_processed == 1
+    assert completed[0].cursor_before is not None
+    assert completed[0].cursor_after is not None
+    assert len(event_summary) == 1
+    assert event_summary[0].issue_opened == 1
+    assert event_summary[0].pr_merged == 1

--- a/week3_notes.md
+++ b/week3_notes.md
@@ -149,101 +149,86 @@ flowchart TD
 
 ---
 
-## Goal 2: Week 3 Implementation Points
+## Goal 2: Week 3 Implementation Status
 
-Implementation TODO notes per target area (for code changes in a follow-up PR).
+Implemented symbols: `_execute_request_with_retries()`, `_request()`, `_parse_rate_limit()`, `logging/setup.py` → `configure_logging()`, `SyncSession`, `sync_context.py`.
 
-### Retry handling
+### Retry handling — before vs after
 
-| Target | File / Function | Current behavior | Week 3 TODO |
-|--------|-----------------|------------------|-------------|
-| HTTP retry | `rest.py` → `GitHubRestAdapter._request()` | Single attempt; `httpx.HTTPError` → log + return `None` | Add retry wrapper for transient failures (see `retry_design.md`) |
-| Status retry | `rest.py` → `_request()` | 403/404 → return `None` immediately | Retry 502/503/504 only; distinguish rate-limit 403 from permission 403 |
-| Bypass paths | `rest.py` → `assign_issue`, CI checks, etc. | Some calls use `_client` directly | Route through centralized `_request()` or shared retry helper |
+| Area | Before this PR | After this PR |
+|------|----------------|---------------|
+| HTTP retry | Single attempt in `_request()` | `_execute_request_with_retries()` — max 4 attempts with backoff + jitter |
+| Transient status | 502/503/504 stopped pagination | Retried via `_execute_request_with_retries()` |
+| Permission 403 | Returned `None` immediately | Still `None` via `_request()` + `_log_permission_issue()` |
+| Direct `_client` calls | No retry | **Still bypass** `_request()` in some mutation helpers (future refactor) |
 
-### Pagination
+### Rate-limit handling — before vs after
 
-| Target | File / Function | Current behavior | Week 3 TODO |
-|--------|-----------------|------------------|-------------|
-| Page loop | `rest.py` → `_paginate()` | Stops on first `_request()` failure | After retry exhaustion, log repo+path+page; consider partial-ingestion summary |
-| Repo listing | `rest.py` → `_list_repos_from_path()` | Uses `_request_with_status` for first page | Same retry semantics as `_paginate` |
-| PR early exit | `rest.py` → `_collect_pull_request_events()` | Stops when `updated_at < since` | No change expected; document assumption (desc sort) |
+| Area | Before this PR | After this PR |
+|------|----------------|---------------|
+| Header parse | `_parse_rate_limit()` warn-only | Same parser; used for sleep-until-reset |
+| `403` + `Remaining == 0` | Log + return `None` | Sleep until `X-RateLimit-Reset` in inner loop (`_is_rate_limit_exhausted`, `_rate_limit_sleep_seconds`); capped by `_GITHUB_MAX_RATE_LIMIT_RECOVERIES` |
+| Permission `403` | Log + `None` | Unchanged — no sleep/retry |
+| Structured logs | None | `github_rate_limit_exhausted`, `github_rate_limit_recovered`, `github_request_retry` |
 
-### Rate-limit handling
+### Observability — before vs after
 
-| Target | File / Function | Current behavior | Week 3 TODO |
-|--------|-----------------|------------------|-------------|
-| Header parse | `rest.py` → `_parse_rate_limit()` | Reads `X-RateLimit-Remaining`, `X-RateLimit-Reset` | Keep; use `reset_at` for sleep-until-reset |
-| Warn only | `rest.py` → `_request()` L1072–1083 | Warns when `remaining <= 1` | On 403 + `remaining == 0`, sleep until `reset_at` then retry |
-| Permission 403 | `rest.py` → `_log_permission_issue()` | Returns `None` (no retry) | Do not sleep/retry on permission errors |
+| Area | Before this PR | After this PR |
+|------|----------------|---------------|
+| `JsonFormatter` | Dropped `extra` fields | Preserves all custom fields |
+| Sync correlation | None | `sync_id` via `SyncSession` + `SyncContextFilter` |
+| Lifecycle logs | None | `github_sync_started` / `completed` / `failed` |
+| Per-repo | Generic info logs | `repo_ingestion_started` / `completed` with timing |
 
-### Cursor management
+### Still open (not in this PR)
 
-| Target | File / Function | Current behavior | Week 3 TODO |
-|--------|-----------------|------------------|-------------|
-| Read | `orchestrator.py` L45 | `get_cursor("github") or period_start` | Document: first run only backfills scoring window, not full history |
-| Write | `orchestrator.py` L48–51 | `max(created_at)` of **this run only** | On partial ingestion failure, cursor may advance past un-fetched repos — discuss with mentors |
-| Storage | `sqlite.py` → `get_cursor` / `set_cursor` | Single global `"github"` key | Per-repo cursors out of scope unless mentors approve |
+| Area | Notes |
+|------|-------|
+| Pagination partial-ingestion summary | `_paginate()` stops on failure; no repo-level failure rollup yet |
+| Per-repo cursors | Single global `"github"` cursor remains |
+| Mutation bypass paths | `assign_issue`, CI checks still call `_client` directly |
+| `Retry-After` header | Secondary rate limits not handled |
 
-### Logging
-
-| Target | File / Function | Current behavior | Week 3 TODO |
-|--------|-----------------|------------------|-------------|
-| Setup | `logging/setup.py` → `configure_logging()` | JSON lines to stdout | Add structured fields for retry attempts, rate-limit waits |
-| Ingestion | `rest.py` loggers | Per-repo info/warning | Log retry count, sleep duration, partial completion |
-| Orchestrator | `orchestrator.py` | `"Stored GitHub contributions"` count | Log cursor before/after, duration, repos processed |
-
-### PR / Issue fetching
-
-| Target | File / Function | Current behavior | Week 3 TODO |
-|--------|-----------------|------------------|-------------|
-| Issues | `rest.py` → `_collect_issue_events()` | `GET .../issues?since=...` | Retry via `_request` |
-| PRs | `rest.py` → `_collect_pull_request_events()` | `GET .../pulls?sort=updated&direction=desc` | Same |
-| Timeline | `rest.py` → `_issue_assignment_events()` | Timeline API for `issue_assigned` | Same |
-| Reviews | `rest.py` → `_pull_request_reviews()` | Review API for `pr_reviewed` | Same |
-| Open items (assignment) | `list_open_issues()`, `list_open_pull_requests()` | Separate from ingestion cursor | Same retry policy |
+See also: `retry_design.md`, `request_flow.md`, `observability_design.md`.
 
 ---
 
-## Goal 4: Rate Limiting — Today vs Proposed
+## Goal 4: Rate Limiting — Implemented Behavior
 
-### What happens today
+### Before this PR
 
-1. Every `_request()` / `_request_with_status()` call parses `X-RateLimit-Remaining` and `X-RateLimit-Reset` via `_parse_rate_limit()`.
-2. When `remaining <= 1`, a **warning** is logged with `reset_at` — no sleep, no throttle.
-3. On **403**, `_log_permission_issue()` runs and the function returns `None` — pagination stops for that path.
-4. There is **no distinction** between:
-   - Rate limit exhausted (`403` + `X-RateLimit-Remaining: 0`)
-   - Permission denied (`403` + non-zero remaining or missing headers)
-5. `tenacity` is in `pyproject.toml` but **not used** anywhere in the codebase.
-6. **502/503/504** are returned as-is; `_paginate` treats non-200 as failure and stops (partial data).
+1. `_request()` logged rate-limit warnings but did **not** sleep on exhaustion.
+2. All `403` responses were treated as permission failures.
+3. `502/503/504` aborted pagination without retry.
 
-### What should happen instead
+### What changed in this PR
+
+Implemented in `rest.py` via `_execute_request_with_retries()`:
 
 ```text
 HTTP response
     │
-    ├─ Timeout / ConnectionError → retry with backoff (see retry_design.md)
+    ├─ Timeout / ConnectionError → retry with backoff (max 4 transient attempts)
     │
     ├─ 502 / 503 / 504 → retry with backoff
     │
-    ├─ 403
-    │     ├─ X-RateLimit-Remaining == 0
-    │     │     → log warning
-    │     │     → sleep until X-RateLimit-Reset (+ small buffer)
-    │     │     → retry same request (counts toward retry budget)
-    │     │
-    │     └─ else (permission / abuse / secondary limit)
-    │           → log error, return None, do NOT retry
+    ├─ 403 + X-RateLimit-Remaining == 0
+    │     → _is_rate_limit_exhausted()
+    │     → _rate_limit_sleep_seconds() / _rate_limit_reset_timestamp()
+    │     → _log_github_rate_limit_exhausted → sleep → _log_github_rate_limit_recovered
+    │     → retry same request (separate from transient budget; capped at _GITHUB_MAX_RATE_LIMIT_RECOVERIES)
+    │     → missing reset → _log_github_rate_limit_missing_reset → return None
     │
-    ├─ 401 / 404 → return None, do NOT retry
+    ├─ 403 (permission, Remaining > 0) → _log_permission_issue() → return None via _request()
+    │
+    ├─ 401 / 404 → return None, no retry
     │
     └─ 200 → continue pagination
 ```
 
-### Secondary rate limits
+### Future stretch
 
-GitHub may return `403` with `Retry-After` header for abuse/secondary limits (not always accompanied by `X-RateLimit-Remaining: 0`). Week 3 stretch: parse `Retry-After` if present.
+GitHub may return `403` with `Retry-After` for abuse/secondary limits (not always `Remaining == 0`). Not implemented yet.
 
 ---
 

--- a/week3_notes.md
+++ b/week3_notes.md
@@ -1,0 +1,283 @@
+# Week 3 Notes — Ingestion Flow & Implementation Map
+
+> Investigation only. No production code changes in this document.
+
+---
+
+## Goal 1: Complete Ingestion Flow
+
+### Flow diagram
+
+```text
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ ENTRY POINTS                                                                │
+├─────────────────────────────────────────────────────────────────────────────┤
+│  CLI: ghdcbot --config <yaml> run-once                                      │
+│    → cli.py:main() → build_orchestrator() → orchestrator.run_once()         │
+│                                                                             │
+│  Discord: /sync (mentor-only)                                               │
+│    → bot.py:sync_cmd() → Orchestrator(...) → asyncio.to_thread(run_once)  │
+└─────────────────────────────────────────────────────────────────────────────┘
+                                    │
+                                    ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ Orchestrator.run_once()          [engine/orchestrator.py]                   │
+├─────────────────────────────────────────────────────────────────────────────┤
+│  1. storage.init_schema()                                                   │
+│  2. prior_cursor = storage.get_cursor("github") or period_start             │
+│  3. contributions = list(github_reader.list_contributions(prior_cursor))    │
+│  4. storage.record_contributions(contributions)                             │
+│  5. storage.set_cursor("github", max(created_at)) if advanced               │
+│  6. scoring, assignment planning, role plans, reports, mutations, snapshots │
+│  7. _send_notifications_for_new_events(contributions, ...)                │
+└─────────────────────────────────────────────────────────────────────────────┘
+                                    │
+                                    ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ GitHubRestAdapter.list_contributions(since)  [adapters/github/rest.py]     │
+├─────────────────────────────────────────────────────────────────────────────┤
+│  _list_repos()                                                              │
+│    → GET /orgs/{org}/repos (paginated)                                      │
+│    → optional fallback: GET /user/repos on 401/403                          │
+│    → _apply_repo_filter()                                                   │
+│  for each repo: _ingest_repo(repo, since)                                   │
+│    → _collect_issue_events()      → issue_opened, issue_closed, assigned    │
+│    → _collect_pull_request_events() → pr_opened, pr_merged, pr_reverted, …  │
+│    → _ingest_issue_comments()     → comment                                 │
+│    → _ingest_pr_comments()        → comment                                 │
+│    → _ingest_helpful_comments()   → helpful_comment                         │
+│    → each collector uses _paginate() → _request() per page                    │
+└─────────────────────────────────────────────────────────────────────────────┘
+                                    │
+                                    ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ PAGINATION                     [rest.py: _paginate, _paginate_from_page]     │
+├─────────────────────────────────────────────────────────────────────────────┤
+│  page = 1, loop:                                                            │
+│    response = _request("GET", path, params={..., "page": page})             │
+│    stop on None / non-200 / empty list / no Link rel="next"                 │
+│    yield page data; page += 1                                               │
+└─────────────────────────────────────────────────────────────────────────────┘
+                                    │
+                                    ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ NORMALIZATION                  [rest.py collectors → core/models.py]        │
+├─────────────────────────────────────────────────────────────────────────────┤
+│  Raw GitHub JSON → ContributionEvent(                                       │
+│    github_user, event_type, repo, created_at, payload                       │
+│  )                                                                          │
+│  Filters: bot users (_is_bot_user), PR-vs-issue separation, since cutoff    │
+└─────────────────────────────────────────────────────────────────────────────┘
+                                    │
+                                    ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ SQLITE STORAGE                 [adapters/storage/sqlite.py]                 │
+├─────────────────────────────────────────────────────────────────────────────┤
+│  record_contributions() → INSERT INTO contributions (no dedupe)             │
+│  DB: {data_dir}/state.db                                                    │
+└─────────────────────────────────────────────────────────────────────────────┘
+                                    │
+                                    ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ CURSOR UPDATE                  [sqlite.py + orchestrator.py]                │
+├─────────────────────────────────────────────────────────────────────────────┤
+│  Table: cursors (source, cursor)                                            │
+│  Key: "github"                                                              │
+│  Read: get_cursor("github") — None → defaults to period_start (not epoch)   │
+│  Write: set_cursor("github", max(event.created_at)) only if > prior_cursor  │
+│  Empty fetch: cursor unchanged                                              │
+└─────────────────────────────────────────────────────────────────────────────┘
+                                    │
+                                    ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ NOTIFICATIONS                  [engine/notifications.py]                    │
+├─────────────────────────────────────────────────────────────────────────────┤
+│  _send_notifications_for_new_events() filters this run's contributions:     │
+│    issue_assigned | pr_reviewed | pr_merged                                 │
+│  send_notification_for_event() per event:                                   │
+│    config flag check → resolve verified GitHub→Discord → dedupe key         │
+│    → build message → DiscordApiAdapter.send_dm / send_message               │
+│    → mark notifications_sent + audit event                                  │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+### Mermaid (optional view)
+
+```mermaid
+flowchart TD
+    A["/sync or run-once"] --> B["build_orchestrator / sync_cmd"]
+    B --> C["Orchestrator.run_once()"]
+    C --> D["get_cursor('github')"]
+    D --> E["GitHubRestAdapter.list_contributions()"]
+    E --> F["_list_repos → _ingest_repo per repo"]
+    F --> G["_paginate → _request"]
+    G --> H["ContributionEvent normalization"]
+    H --> I["record_contributions()"]
+    I --> J["set_cursor('github')"]
+    J --> K["_send_notifications_for_new_events()"]
+    K --> L["send_notification_for_event()"]
+    L --> M["Discord DM or channel"]
+```
+
+---
+
+## All Files Involved (by layer)
+
+| Layer | File | Role |
+|-------|------|------|
+| **Entry — CLI** | `src/ghdcbot/__main__.py` | Delegates to `cli.main()` |
+| | `src/ghdcbot/cli.py` | `run-once` subcommand; `build_orchestrator()` |
+| **Entry — Discord** | `src/ghdcbot/bot.py` | `/sync` slash command (`sync_cmd`); runs `run_once` in worker thread |
+| **Config** | `src/ghdcbot/config/loader.py` | `load_config()`, `get_active_config()` |
+| | `src/ghdcbot/config/models.py` | `BotConfig`, `GitHubConfig`, `NotificationConfig`, scoring/assignment |
+| **Wiring** | `src/ghdcbot/plugins/registry.py` | `build_adapter()` — dynamic adapter import |
+| **Orchestration** | `src/ghdcbot/engine/orchestrator.py` | `Orchestrator.run_once()`, cursor read/write, notification dispatch |
+| **GitHub ingestion** | `src/ghdcbot/adapters/github/rest.py` | `list_contributions`, `_paginate`, `_request`, PR/issue collectors |
+| **Identity (separate path)** | `src/ghdcbot/adapters/github/identity.py` | Bio/gist verification only — not part of sync ingestion |
+| **Storage** | `src/ghdcbot/adapters/storage/sqlite.py` | `record_contributions`, `get_cursor`, `set_cursor`, `notifications_sent` |
+| **Interfaces** | `src/ghdcbot/core/interfaces.py` | `GitHubReader`, `Storage` contracts |
+| **Models** | `src/ghdcbot/core/models.py` | `ContributionEvent`, `GitHubAssignmentPlan` |
+| **Notifications** | `src/ghdcbot/engine/notifications.py` | `send_notification_for_event`, dedupe, CodeRabbit reminders |
+| **Discord delivery** | `src/ghdcbot/adapters/discord/api.py` | `send_dm`, `send_message`, Discord `_request` |
+| **Scoring (post-ingest)** | `src/ghdcbot/engine/scoring.py` | `WeightedScoreStrategy.compute_scores()` |
+| **Assignment (post-ingest)** | `src/ghdcbot/engine/assignment.py` | `RoleBasedAssignmentStrategy` |
+| | `src/ghdcbot/engine/planning.py` | Discord role plans from scores |
+| **Logging** | `src/ghdcbot/logging/setup.py` | `configure_logging()`, `JsonFormatter` |
+| **Tests** | `tests/test_github_ingestion_comments.py` | Ingestion + rate-limit header parsing |
+| | `tests/test_notifications.py` | Notification message building |
+| | `tests/test_readme_setup.py` | End-to-end `run_once` smoke test |
+
+---
+
+## Goal 2: Week 3 Implementation Points
+
+Implementation TODO notes per target area (for code changes in a follow-up PR).
+
+### Retry handling
+
+| Target | File / Function | Current behavior | Week 3 TODO |
+|--------|-----------------|------------------|-------------|
+| HTTP retry | `rest.py` → `GitHubRestAdapter._request()` | Single attempt; `httpx.HTTPError` → log + return `None` | Add retry wrapper for transient failures (see `retry_design.md`) |
+| Status retry | `rest.py` → `_request()` | 403/404 → return `None` immediately | Retry 502/503/504 only; distinguish rate-limit 403 from permission 403 |
+| Bypass paths | `rest.py` → `assign_issue`, CI checks, etc. | Some calls use `_client` directly | Route through centralized `_request()` or shared retry helper |
+
+### Pagination
+
+| Target | File / Function | Current behavior | Week 3 TODO |
+|--------|-----------------|------------------|-------------|
+| Page loop | `rest.py` → `_paginate()` | Stops on first `_request()` failure | After retry exhaustion, log repo+path+page; consider partial-ingestion summary |
+| Repo listing | `rest.py` → `_list_repos_from_path()` | Uses `_request_with_status` for first page | Same retry semantics as `_paginate` |
+| PR early exit | `rest.py` → `_collect_pull_request_events()` | Stops when `updated_at < since` | No change expected; document assumption (desc sort) |
+
+### Rate-limit handling
+
+| Target | File / Function | Current behavior | Week 3 TODO |
+|--------|-----------------|------------------|-------------|
+| Header parse | `rest.py` → `_parse_rate_limit()` | Reads `X-RateLimit-Remaining`, `X-RateLimit-Reset` | Keep; use `reset_at` for sleep-until-reset |
+| Warn only | `rest.py` → `_request()` L1072–1083 | Warns when `remaining <= 1` | On 403 + `remaining == 0`, sleep until `reset_at` then retry |
+| Permission 403 | `rest.py` → `_log_permission_issue()` | Returns `None` (no retry) | Do not sleep/retry on permission errors |
+
+### Cursor management
+
+| Target | File / Function | Current behavior | Week 3 TODO |
+|--------|-----------------|------------------|-------------|
+| Read | `orchestrator.py` L45 | `get_cursor("github") or period_start` | Document: first run only backfills scoring window, not full history |
+| Write | `orchestrator.py` L48–51 | `max(created_at)` of **this run only** | On partial ingestion failure, cursor may advance past un-fetched repos — discuss with mentors |
+| Storage | `sqlite.py` → `get_cursor` / `set_cursor` | Single global `"github"` key | Per-repo cursors out of scope unless mentors approve |
+
+### Logging
+
+| Target | File / Function | Current behavior | Week 3 TODO |
+|--------|-----------------|------------------|-------------|
+| Setup | `logging/setup.py` → `configure_logging()` | JSON lines to stdout | Add structured fields for retry attempts, rate-limit waits |
+| Ingestion | `rest.py` loggers | Per-repo info/warning | Log retry count, sleep duration, partial completion |
+| Orchestrator | `orchestrator.py` | `"Stored GitHub contributions"` count | Log cursor before/after, duration, repos processed |
+
+### PR / Issue fetching
+
+| Target | File / Function | Current behavior | Week 3 TODO |
+|--------|-----------------|------------------|-------------|
+| Issues | `rest.py` → `_collect_issue_events()` | `GET .../issues?since=...` | Retry via `_request` |
+| PRs | `rest.py` → `_collect_pull_request_events()` | `GET .../pulls?sort=updated&direction=desc` | Same |
+| Timeline | `rest.py` → `_issue_assignment_events()` | Timeline API for `issue_assigned` | Same |
+| Reviews | `rest.py` → `_pull_request_reviews()` | Review API for `pr_reviewed` | Same |
+| Open items (assignment) | `list_open_issues()`, `list_open_pull_requests()` | Separate from ingestion cursor | Same retry policy |
+
+---
+
+## Goal 4: Rate Limiting — Today vs Proposed
+
+### What happens today
+
+1. Every `_request()` / `_request_with_status()` call parses `X-RateLimit-Remaining` and `X-RateLimit-Reset` via `_parse_rate_limit()`.
+2. When `remaining <= 1`, a **warning** is logged with `reset_at` — no sleep, no throttle.
+3. On **403**, `_log_permission_issue()` runs and the function returns `None` — pagination stops for that path.
+4. There is **no distinction** between:
+   - Rate limit exhausted (`403` + `X-RateLimit-Remaining: 0`)
+   - Permission denied (`403` + non-zero remaining or missing headers)
+5. `tenacity` is in `pyproject.toml` but **not used** anywhere in the codebase.
+6. **502/503/504** are returned as-is; `_paginate` treats non-200 as failure and stops (partial data).
+
+### What should happen instead
+
+```text
+HTTP response
+    │
+    ├─ Timeout / ConnectionError → retry with backoff (see retry_design.md)
+    │
+    ├─ 502 / 503 / 504 → retry with backoff
+    │
+    ├─ 403
+    │     ├─ X-RateLimit-Remaining == 0
+    │     │     → log warning
+    │     │     → sleep until X-RateLimit-Reset (+ small buffer)
+    │     │     → retry same request (counts toward retry budget)
+    │     │
+    │     └─ else (permission / abuse / secondary limit)
+    │           → log error, return None, do NOT retry
+    │
+    ├─ 401 / 404 → return None, do NOT retry
+    │
+    └─ 200 → continue pagination
+```
+
+### Secondary rate limits
+
+GitHub may return `403` with `Retry-After` header for abuse/secondary limits (not always accompanied by `X-RateLimit-Remaining: 0`). Week 3 stretch: parse `Retry-After` if present.
+
+---
+
+## Goal 5: Mentor Discussion Points
+
+Questions for Bhavik / Bruno:
+
+1. **Blocking on rate limit** — Should `/sync` and `run-once` block (sleep) until `X-RateLimit-Reset`, or fail fast and let the operator re-run later?
+2. **Acceptable `/sync` duration** — Large orgs can take many minutes today (`bot.py` runs `run_once` in a worker thread for this reason). Is a 5–15 minute sync acceptable if rate-limited?
+3. **Partial ingestion** — If repo 3 of 10 fails after retries, should we:
+   - advance the global cursor anyway (current risk: skip events),
+   - leave cursor unchanged (risk: re-fetch duplicates),
+   - or log a warning and surface it in `/sync` response?
+4. **Failure visibility** — Warning logs only, or should `/sync` report "synced N/M repos" or fail the command on partial ingestion?
+5. **Per-repo cursors** — Is a single global `"github"` cursor sufficient for GSoC scope, or is per-repo cursor management a future requirement?
+6. **Duplicate contributions** — `record_contributions()` has no dedupe. Is cursor-only deduplication acceptable, or should we add a unique constraint?
+7. **`tenacity` vs custom** — Prefer `tenacity` (already a dependency) or a small inline retry loop in `_request()`?
+
+---
+
+## Known Gaps (observed during trace)
+
+- Duplicate `_send_notifications_for_new_events` definition in `orchestrator.py` (L287–304 stub + L296–333 real impl) — cleanup candidate, not Week 3 scope unless mentors want it.
+- Notifications only fire for events ingested **in the current run** — not re-scanned from DB.
+- `pr_review_requested` is in config but not in orchestrator's notification filter.
+- Some `rest.py` mutation helpers bypass `_request()` entirely.
+
+---
+
+## End-of-Day Checklist
+
+- [x] Complete ingestion flow diagram
+- [x] List of files/functions to modify
+- [x] Retry strategy document (`retry_design.md`)
+- [x] Rate-limit handling design (this file)
+- [x] Questions for mentors
+- [x] No production code changes


### PR DESCRIPTION
## Summary

- Improve `/link` onboarding with GitHub profile settings link, **Open GitHub Profile** button, and post-verification guidance to remove the code from bio
- Derive profile settings URL from `config.github.api_base` (supports GHES, not hardcoded `github.com`)
- Add transient retry handling (timeout, connection errors, 502/503/504) with exponential backoff and jitter
- Add rate-limit recovery: sleep until `X-RateLimit-Reset` on `403` + `Remaining == 0`
- Add sync observability: `sync_id`, lifecycle logs, API request counts, per-repo ingestion timing, event summaries
- Fix `JsonFormatter` to preserve custom `extra` fields in JSON logs

## Changes

### Identity linking (`/link`)
- Updated embed instructions (4-step flow with profile settings URL)
- Added **Open GitHub Profile** link button
- Success messages (Verify button + `/verify-link`) note that users can remove the verification code after verification

### GitHub adapter (`rest.py`)
- `_execute_request_with_retries()` — max 4 attempts, backoff 1s → 2s → 4s + jitter
- Rate-limit inner loop — sleep until reset, does not consume transient retry budget
- Structured logs: `github_request_retry`, `github_request_failed`, `github_rate_limit_exhausted`, `github_rate_limit_recovered`
- Per-repo logs: `repo_ingestion_started`, `repo_ingestion_completed`
- API request counting per sync (`sync_request_count`)

### Observability
- `sync_id` format: `sync_YYYYMMDD_HHMMSS_ab12` — attached to all logs during `run-once` / `/sync`
- Sync lifecycle: `github_sync_started`, `github_sync_completed`, `github_sync_failed`
- End-of-sync: `github_request_summary`, `github_event_summary`
- `JsonFormatter` now includes all custom `extra` fields (e.g. `repo`)

### Documentation
- `week3_notes.md` — ingestion flow and implementation map
- `request_flow.md` — `_request()` behavior and 403 flow
- `retry_design.md` — retry and rate-limit strategy
- `observability_design.md` — sync logging design

## Test plan

- [x] `pytest tests/test_identity_linking.py` — identity linking + /link UX
- [x] `pytest tests/test_github_retry.py` — transient retry scenarios
- [x] `pytest tests/test_github_rate_limit.py` — rate-limit sleep and recovery
- [x] `pytest tests/test_observability.py` — JsonFormatter, sync_id, lifecycle logs
- [x] Full suite: **228 passed**
- [ ] Manual: run `/link` in Discord — confirm profile link + button + success message
- [ ] Manual: `docker compose up -d --build` then `/sync` — confirm structured logs with `sync_id`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic retry with randomized exponential backoff for transient GitHub API failures; explicit rate-limit recovery that waits until reset when exhausted.
  * Per-sync correlation (sync_id), structured lifecycle events, improved JSON logging preserving extra fields, and sync progress/request counters with repo peeking.

* **Documentation**
  * Added design docs for observability, request flow, retry/rate-limit design, and week3 notes.

* **Tests**
  * New test suites for retry logic, rate-limit recovery, and observability/logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->