### PR TITLE
fix: clean example config and env template for onboarding (Week 4)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,5 @@
+# GitHub fine-grained personal access token (read org repos; write if using assignments/snapshots)
 GITHUB_TOKEN=your_github_token
-DISCORD_TOKEN=your_discord_token
+
+# Discord bot token from Developer Portal → Bot → Reset Token
+DISCORD_TOKEN=your_discord_bot_token

--- a/config/example.yaml
+++ b/config/example.yaml
@@ -53,9 +53,6 @@ discord:
   #   pr_review_result: true
   #   pr_review_comment: true
   #   pr_merged: true
-  #   pr_closed: true
-  #   pr_reopened: true
-  #   issue_reopened: true
   #   coderabbit_reminders: false
   #   coderabbit_reminder_after_hours: 48
   #   coderabbit_bot_logins: ["coderabbitai", "coderabbitai[bot]"]

--- a/config/example.yaml
+++ b/config/example.yaml
@@ -1,7 +1,7 @@
 runtime:
   mode: "dry-run"
   log_level: "INFO"
-  data_dir: "/tmp/ghdcbot-state"
+  data_dir: "./data"
   github_adapter: "ghdcbot.adapters.github.rest:GitHubRestAdapter"
   discord_adapter: "ghdcbot.adapters.discord.api:DiscordApiAdapter"
   storage_adapter: "ghdcbot.adapters.storage.sqlite:SqliteStorage"
@@ -51,7 +51,11 @@ discord:
   #   issue_assignment: true
   #   pr_review_requested: true
   #   pr_review_result: true
+  #   pr_review_comment: true
   #   pr_merged: true
+  #   pr_closed: true
+  #   pr_reopened: true
+  #   issue_reopened: true
   #   coderabbit_reminders: false
   #   coderabbit_reminder_after_hours: 48
   #   coderabbit_bot_logins: ["coderabbitai", "coderabbitai[bot]"]
@@ -84,8 +88,9 @@ assignments:
 
 # Optional: when a contributor has a PR merged in a repo, grant them the corresponding Discord role
 # (repo name -> Discord role name). Roles are add-only and never auto-removed.
-repo_contributor_roles:
-  castro: "castro"
+# Example:
+# repo_contributor_roles:
+#   my-repo: "Contributor"
 
 identity_mappings:
   - github_user: "YOUR_GITHUB_USERNAME"

--- a/tests/test_readme_setup.py
+++ b/tests/test_readme_setup.py
@@ -34,13 +34,11 @@ def test_load_config_with_env_vars_set(monkeypatch: pytest.MonkeyPatch) -> None:
     assert config.runtime.mode.value == "dry-run"
     assert config.github.org == "example-org"
     assert config.discord.guild_id == "000000000000000000"
-    assert config.runtime.data_dir == "/tmp/ghdcbot-state"
+    assert config.runtime.data_dir == "./data"
 
 
 def test_load_config_fails_without_env_vars(monkeypatch: pytest.MonkeyPatch) -> None:
     """If env vars are missing, config load should fail with a clear error."""
-    monkeypatch.setenv("GITHUB_TOKEN", "")
-    monkeypatch.setenv("DISCORD_TOKEN", "")
     # Prevent .env from repopulating env so we truly test missing vars
     import ghdcbot.config.loader as loader_module
     monkeypatch.setattr(loader_module, "load_dotenv", lambda: None)
@@ -48,7 +46,8 @@ def test_load_config_fails_without_env_vars(monkeypatch: pytest.MonkeyPatch) -> 
     monkeypatch.delenv("DISCORD_TOKEN", raising=False)
     with pytest.raises(ConfigError) as excinfo:
         load_config(str(EXAMPLE_CONFIG_PATH))
-    assert "GITHUB_TOKEN" in str(excinfo.value) or "DISCORD_TOKEN" in str(excinfo.value)
+    message = str(excinfo.value)
+    assert "GITHUB_TOKEN is missing" in message or "DISCORD_TOKEN is missing" in message
 
 
 def test_readme_setup_run_once_completes_and_writes_reports(
@@ -61,10 +60,10 @@ def test_readme_setup_run_once_completes_and_writes_reports(
     monkeypatch.setenv("GITHUB_TOKEN", "test-token-github")
     monkeypatch.setenv("DISCORD_TOKEN", "test-token-discord")
 
-    # Use isolated data_dir (README uses /tmp/ghdcbot-state; we use tmp_path)
+    # Use isolated data_dir (example template uses ./data; override for test isolation)
     config_content = EXAMPLE_CONFIG_PATH.read_text()
     config_content = config_content.replace(
-        'data_dir: "/tmp/ghdcbot-state"',
+        'data_dir: "./data"',
         f'data_dir: "{tmp_path}"',
     )
     config_path = tmp_path / "ghdcbot-config.yaml"


### PR DESCRIPTION
## Summary

- **`config/example.yaml`**: `data_dir: "./data"` (matches INSTALLATION.md); remove `castro` `repo_contributor_roles` leftover; document as commented example
- **`.env.example`**: add comments for both tokens
- **`tests/test_readme_setup.py`**: align with `./data` template default

Small, focused PR for template cleanup after validation lands.

## Test plan

- [ ] `pytest tests/test_readme_setup.py -v`
- [ ] Copy `config/example.yaml` → `config/config.yaml`; confirm reports land under `./data/reports/`
- [ ] `ghdcbot validate` no longer fails on spurious `castro` role from template

## Depends on

- Validation PR (stacked on #23)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enhanced setup guidance with improved environment variable comments
  * Updated configuration examples with relative path usage and additional notification options

* **Tests**
  * Tests updated to align with new configuration examples
<!-- end of auto-generated comment: release notes by coderabbit.ai -->