### PR TITLE
test: validate pr_opened Discord notification

### DIFF
--- a/PR_OPEN_TEST.md
+++ b/PR_OPEN_TEST.md
@@ -1,0 +1,3 @@
+# PR-open notification test
+
+Temporary file to validate pr_opened to Discord thread routing.


### PR DESCRIPTION
Temporary PR to validate the pr_opened Discord thread routing pilot for the Gitcord repo. Will be closed after verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a temporary markdown note to help validate PR-open routing into a Discord thread.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->