### PR TITLE
Week 7: /open-prs and PR-opened Discord channel notifications

### DIFF
--- a/config/aussie-repos.yaml
+++ b/config/aussie-repos.yaml
@@ -1,4 +1,4 @@
-# Shared AOSSIE repo allowlist for Gitcord sync (15 repos).
+# Shared AOSSIE repo allowlist for Gitcord sync (19 repos).
 # Referenced via !include from aussie.yaml and config/examples/aussie*.yaml
 mode: allow
 names:
@@ -14,6 +14,10 @@ names:
   - "NeuroTrack"
   - "Perspective"
   - "PictoPy"
+  - "PullRequestDashboard"
   - "Rein"
   - "Resonate"
   - "Resonate-Website"
+  - "SkillBot"
+  - "Skills"
+  - "Template-Repo"

--- a/config/aussie.yaml
+++ b/config/aussie.yaml
@@ -49,7 +49,9 @@ discord:
   activity_channel_id: null
   pr_preview_channels: []
   pr_open_channels:
-    # #projects forum threads — repo short name → thread ID (verified authors only).
+    # #projects forum threads — repo short name → thread ID.
+    # Posts for all PR opens in mapped repos; verified authors are @mentioned,
+    # unverified authors show "Contributor is not verified on gitcord".
     Agora-Blockchain: "1331983948175380581"       # Agora Blockchain
     BabyNest: "1339225155481763882"              # BabyNest
     DebateAI: "1312986807914463252"              # AI for Debates

--- a/config/aussie.yaml
+++ b/config/aussie.yaml
@@ -24,7 +24,7 @@ github:
     write: true
   user_fallback: false
   # Repo allowlist: only these repositories are scanned (sync/run-once). Uses short repo names under the org (not "org/name").
-  # Shared list: config/aussie-repos.yaml (15 AOSSIE repos).
+  # Shared list: config/aussie-repos.yaml (19 AOSSIE repos).
   repos: !include aussie-repos.yaml
 
 discord:
@@ -48,7 +48,24 @@ discord:
       allow_discord_administrators: true
   activity_channel_id: null
   pr_preview_channels: []
-  # Verified GitHub → Discord DMs (or channel if channel_id is set). Requires linked users (/link + /verify-link).
+  pr_open_channels:
+    # #projects forum threads — repo short name → thread ID (verified authors only).
+    Agora-Blockchain: "1331983948175380581"       # Agora Blockchain
+    BabyNest: "1339225155481763882"              # BabyNest
+    DebateAI: "1312986807914463252"              # AI for Debates
+    Devr.AI: "1345044976794472498"               # Devr.AI
+    EduAid: "1317912993786499072"                # EduAid
+    Ell-ena: "1349032611267477586"               # Ell-ena
+    Gitcord-GithubDiscordBot: "1465995983791063140"  # Gitcord - Github Discord Bot
+    Gitcord-Test: "1524006041677729823"          # gitcord testing
+    InPactAI: "1345044736515379210"              # InPact AI
+    NeuroTrack: "1347053043711082507"           # NeuroTrack
+    Perspective: "1339226574276268144"           # Perspective AI
+    PictoPy: "1311271974630330388"               # Pictopy
+    Rein: "1467370739152846899"                  # Rein
+    Resonate: "1317913663360864346"              # Resonate
+    Resonate-Website: "1317913663360864346"       # Resonate (shared project thread)
+    # No #projects thread yet: PullRequestDashboard, SkillBot, Skills, Template-Repo
   notifications:
     enabled: true
     issue_assignment: false          # Off: avoids DM flood from assignment events (use /assign-issue manually)
@@ -59,6 +76,7 @@ discord:
     pr_closed: true
     issue_reopened: true
     pr_reopened: true
+    pr_opened: true
     coderabbit_reminders: false
     coderabbit_reminder_after_hours: 48
     channel_id: null

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,11 @@ services:
     depends_on:
       init_data:
         condition: service_completed_successfully
+    # Stable public resolvers — host/Docker DNS flakes were dropping the Discord gateway
+    # and causing slash commands to show "The application did not respond".
+    dns:
+      - 1.1.1.1
+      - 8.8.8.8
     volumes:
       # Mount config so you can edit YAML without rebuilding (use data_dir: /data in config).
       - ./config:/app/config:ro
@@ -43,6 +48,9 @@ services:
     depends_on:
       init_data:
         condition: service_completed_successfully
+    # Host networking: Docker bridge DNS on this campus network is flaky
+    # (Temporary failure in name resolution → empty syncs). Host DNS works.
+    network_mode: host
     volumes:
       - ./config:/app/config:ro
       - ./scripts:/app/scripts:ro

--- a/src/ghdcbot/adapters/discord/api.py
+++ b/src/ghdcbot/adapters/discord/api.py
@@ -177,7 +177,7 @@ class DiscordApiAdapter:
             response = self._client.request(
                 "POST",
                 f"/channels/{channel_id}/messages",
-                json={"content": text},
+                json={"content": text, "flags": 4},  # 4 = SUPPRESS_EMBEDS (no link previews)
             )
         except httpx.HTTPError as exc:
             self._logger.warning(
@@ -227,7 +227,7 @@ class DiscordApiAdapter:
             msg_response = self._client.request(
                 "POST",
                 f"/channels/{channel_id}/messages",
-                json={"content": text},
+                json={"content": text, "flags": 4},  # 4 = SUPPRESS_EMBEDS (no link previews)
             )
             if msg_response.status_code not in (200, 201):
                 self._logger.warning(

--- a/src/ghdcbot/adapters/github/rest.py
+++ b/src/ghdcbot/adapters/github/rest.py
@@ -793,6 +793,7 @@ class GitHubRestAdapter:
             author = pr_author or (pr.get("user") or {}).get("login")
             if not author:
                 author = "<deleted>"
+            merged_at = _parse_iso8601(pr.get("merged_at"))
 
             for index, event in enumerate(timeline_events):
                 event_type = event.get("event")
@@ -801,7 +802,9 @@ class GitHubRestAdapter:
                     continue
 
                 if event_type == "closed":
-                    if not _should_emit_pr_closed_for_timeline_close(timeline_events, index):
+                    if not _should_emit_pr_closed_for_timeline_close(
+                        timeline_events, index, merged_at
+                    ):
                         continue
                     yield ContributionEvent(
                         github_user=author,
@@ -1228,7 +1231,14 @@ class GitHubRestAdapter:
         for page in self._paginate(f"/repos/{owner}/{repo_name}/pulls", params=params):
             for pr in page:
                 author = (pr.get("user") or {}).get("login") if pr.get("user") else None
-                yield {"repo": repo["name"], "number": pr["number"], "author": author}
+                yield {
+                    "repo": repo["name"],
+                    "number": pr["number"],
+                    "author": author,
+                    "title": pr.get("title"),
+                    "html_url": pr.get("html_url"),
+                    "created_at": pr.get("created_at"),
+                }
 
     def _paginate(self, path: str, params: dict) -> Iterator[list]:
         page = 1
@@ -1521,8 +1531,19 @@ class GitHubRestAdapter:
         )
 
 
-def _should_emit_pr_closed_for_timeline_close(timeline_events: list[dict], close_index: int) -> bool:
-    """Skip pr_closed when a close event was followed by merge rather than reopen."""
+def _should_emit_pr_closed_for_timeline_close(
+    timeline_events: list[dict], close_index: int, merged_at: datetime | None = None
+) -> bool:
+    """Skip pr_closed when the close corresponds to a merge rather than a real close.
+
+    A merged PR emits both ``merged`` and ``closed`` timeline events at the same
+    timestamp; their relative sort order is not guaranteed. Treat any close at or
+    after the merge time as the merge-close (no pr_closed). Earlier closes (before
+    the merge) are genuine close-without-merge events and still emit.
+    """
+    close_at = _parse_iso8601(timeline_events[close_index].get("created_at"))
+    if merged_at and close_at and close_at >= merged_at:
+        return False
     for event in timeline_events[close_index + 1 :]:
         event_type = event.get("event")
         if event_type == "reopened":

--- a/src/ghdcbot/adapters/github/rest.py
+++ b/src/ghdcbot/adapters/github/rest.py
@@ -136,6 +136,77 @@ class GitHubRestAdapter:
         for repo in self._list_repos():
             yield from self._list_repo_open_prs(repo)
 
+    def list_open_pull_requests_for_author(self, github_user: str) -> list[dict]:
+        """List open PRs by one author via Search API (avoids scanning every repo).
+
+        Results are limited to the configured org and filtered by the active repo
+        allowlist/denylist when present. Shape matches ``list_open_pull_requests``.
+        """
+        author = (github_user or "").strip()
+        if not author:
+            return []
+
+        repo_filter = _load_repo_filter()
+        allowed_names: set[str] | None = None
+        denied_names: set[str] = set()
+        if repo_filter is not None:
+            names = {name.strip() for name in repo_filter.names if name and name.strip()}
+            if repo_filter.mode == "allow":
+                allowed_names = names
+            else:
+                denied_names = names
+
+        # Search is author-scoped; one or two pages is enough for contributor lookups.
+        query = f"is:pr is:open author:{author} org:{self._org}"
+        results: list[dict] = []
+        page = 1
+        while page <= 5:
+            response = self._request(
+                "GET",
+                "/search/issues",
+                params={"q": query, "per_page": 100, "page": page},
+            )
+            if response is None or response.status_code != 200:
+                if response is not None:
+                    self._logger.warning(
+                        "GitHub search for open PRs failed",
+                        extra={
+                            "status_code": response.status_code,
+                            "github_user": author,
+                            "org": self._org,
+                        },
+                    )
+                break
+            payload = response.json()
+            items = payload.get("items") if isinstance(payload, dict) else None
+            if not isinstance(items, list) or not items:
+                break
+            for item in items:
+                if not isinstance(item, dict):
+                    continue
+                repo_name = _repo_name_from_search_issue(item, self._org)
+                if not repo_name:
+                    continue
+                if allowed_names is not None and repo_name not in allowed_names:
+                    continue
+                if repo_name in denied_names:
+                    continue
+                user = item.get("user") if isinstance(item.get("user"), dict) else {}
+                results.append(
+                    {
+                        "repo": repo_name,
+                        "number": item.get("number"),
+                        "author": user.get("login") or author,
+                        "title": item.get("title"),
+                        "html_url": item.get("html_url"),
+                        "created_at": item.get("created_at"),
+                    }
+                )
+            if len(items) < 100:
+                break
+            page += 1
+        return results
+
     def assign_issue(self, owner: str, repo: str, issue_number: int, assignee: str) -> bool:
         """Assign a GitHub issue to a user.
 
@@ -1723,6 +1794,25 @@ def _issue_payload(issue: dict) -> dict:
         "state": issue.get("state"),
         "labels": [label.get("name") for label in issue.get("labels") or []],
     }
+
+
+def _repo_name_from_search_issue(item: dict, org: str) -> str | None:
+    """Extract short repo name from a Search API issue/PR item."""
+    repository_url = item.get("repository_url")
+    if isinstance(repository_url, str) and repository_url:
+        # https://api.github.com/repos/{org}/{repo}
+        parts = repository_url.rstrip("/").split("/")
+        if len(parts) >= 2:
+            return parts[-1]
+    html_url = item.get("html_url")
+    if isinstance(html_url, str) and html_url:
+        # https://github.com/{org}/{repo}/pull/{n}
+        marker = f"github.com/{org}/"
+        idx = html_url.find(marker)
+        if idx >= 0:
+            rest = html_url[idx + len(marker) :]
+            return rest.split("/", 1)[0] or None
+    return None
 
 
 def _load_repo_filter() -> RepoFilterConfig | None:

--- a/src/ghdcbot/bot.py
+++ b/src/ghdcbot/bot.py
@@ -692,9 +692,14 @@ def run_bot(config_path: str) -> None:
             return
 
         try:
-            open_prs = await asyncio.to_thread(
-                lambda: list(github_adapter.list_open_pull_requests())
-            )
+            # Prefer author-scoped Search API (one query) over scanning every configured repo.
+            list_for_author = getattr(github_adapter, "list_open_pull_requests_for_author", None)
+            if callable(list_for_author):
+                open_prs = await asyncio.to_thread(list_for_author, github_user)
+            else:
+                open_prs = await asyncio.to_thread(
+                    lambda: list(github_adapter.list_open_pull_requests())
+                )
         except Exception as exc:
             logger.exception(
                 "Failed to list open pull requests",

--- a/src/ghdcbot/bot.py
+++ b/src/ghdcbot/bot.py
@@ -43,6 +43,7 @@ from ghdcbot.engine.notifications import (
     send_notification_for_event,
 )
 from ghdcbot.core.models import ContributionEvent
+from ghdcbot.engine.open_prs import format_open_prs_report, list_open_prs_for_author
 from ghdcbot.engine.pr_context import (
     build_pr_embed,
     fetch_pr_context,
@@ -624,8 +625,8 @@ def run_bot(config_path: str) -> None:
         
         # Fetch PR context
         try:
-            pr, reviews, ci_status, last_commit_time = fetch_pr_context(
-                github_adapter, owner, repo, pr_number
+            pr, reviews, ci_status, last_commit_time = await asyncio.to_thread(
+                fetch_pr_context, github_adapter, owner, repo, pr_number
             )
         except Exception as exc:
             logger.exception("Failed to fetch PR context", extra={"owner": owner, "repo": repo, "pr_number": pr_number})
@@ -669,6 +670,50 @@ def run_bot(config_path: str) -> None:
         
         embed = discord.Embed.from_dict(embed_dict)
         await interaction.followup.send(embed=embed, ephemeral=False)
+
+    @tree.command(
+        name="open-prs",
+        description="List a contributor's currently open PRs in configured repos (read-only)",
+        guild=discord.Object(id=guild_id),
+    )
+    @app_commands.describe(contributor="Discord member whose open PRs to list")
+    async def open_prs_cmd(interaction: discord.Interaction, contributor: discord.Member) -> None:
+        await interaction.response.defer(ephemeral=True)
+
+        github_user = resolve_discord_to_github(storage, str(contributor.id))
+        if not github_user:
+            await interaction.followup.send(
+                (
+                    f"❌ {contributor.mention} has not verified their GitHub identity. "
+                    "Use `/link` and `/verify-link` first."
+                ),
+                ephemeral=True,
+            )
+            return
+
+        try:
+            open_prs = await asyncio.to_thread(
+                lambda: list(github_adapter.list_open_pull_requests())
+            )
+        except Exception as exc:
+            logger.exception(
+                "Failed to list open pull requests",
+                extra={"github_user": github_user, "discord_user_id": str(contributor.id)},
+            )
+            await interaction.followup.send(
+                f"❌ Error fetching open PRs: {exc}",
+                ephemeral=True,
+            )
+            return
+
+        prs = list_open_prs_for_author(open_prs, github_user)
+        message = format_open_prs_report(
+            contributor_mention=contributor.mention,
+            github_user=github_user,
+            prs=prs,
+            org=config.github.org,
+        )
+        await interaction.followup.send(message, ephemeral=True, suppress_embeds=True)
 
     # Issue assignment confirmation view
     class IssueAssignmentView(discord.ui.View):
@@ -1875,8 +1920,8 @@ def run_bot(config_path: str) -> None:
         
         # Fetch and send PR preview
         try:
-            pr, reviews, ci_status, last_commit_time = fetch_pr_context(
-                github_adapter, owner, repo, pr_number
+            pr, reviews, ci_status, last_commit_time = await asyncio.to_thread(
+                fetch_pr_context, github_adapter, owner, repo, pr_number
             )
         except Exception:
             logger.exception(

--- a/src/ghdcbot/config/models.py
+++ b/src/ghdcbot/config/models.py
@@ -88,7 +88,7 @@ class NotificationConfig(BaseModel):
     pr_closed: bool = True  # PR closed without merge
     issue_reopened: bool = True  # Issue reopened (notifies assignee)
     pr_reopened: bool = True  # PR reopened (notifies author)
-    pr_opened: bool = False  # PR opened → repo-mapped Discord channel (see discord.pr_open_channels)
+    pr_opened: bool = False  # PR opened → repo-mapped Discord channel (see discord.pr_open_channels); unverified authors still posted
     coderabbit_reminders: bool = False  # Remind PR authors about old CodeRabbit review comments
     coderabbit_reminder_after_hours: int = 48  # Only remind if comment is at least this old
     coderabbit_bot_logins: list[str] | None = None  # Bot logins to treat as CodeRabbit; default ["coderabbitai", "coderabbitai[bot]"]

--- a/src/ghdcbot/config/models.py
+++ b/src/ghdcbot/config/models.py
@@ -88,6 +88,7 @@ class NotificationConfig(BaseModel):
     pr_closed: bool = True  # PR closed without merge
     issue_reopened: bool = True  # Issue reopened (notifies assignee)
     pr_reopened: bool = True  # PR reopened (notifies author)
+    pr_opened: bool = False  # PR opened → repo-mapped Discord channel (see discord.pr_open_channels)
     coderabbit_reminders: bool = False  # Remind PR authors about old CodeRabbit review comments
     coderabbit_reminder_after_hours: int = 48  # Only remind if comment is at least this old
     coderabbit_bot_logins: list[str] | None = None  # Bot logins to treat as CodeRabbit; default ["coderabbitai", "coderabbitai[bot]"]
@@ -110,6 +111,8 @@ class DiscordConfig(BaseModel):
     activity_channel_id: str | None = None
     # Optional: channel names where PR URLs trigger passive preview (requires message content intent)
     pr_preview_channels: list[str] = Field(default_factory=list)
+    # Repo short name → Discord channel/thread ID for pr_opened notifications (verified authors only).
+    pr_open_channels: dict[str, str] = Field(default_factory=dict)
     # Optional: verified-only GitHub → Discord notifications
     notifications: NotificationConfig | None = None
     # Optional: per-command slash permission (keys: assign-issue, issue-requests, sync). See SlashCommandPermissionRule.

--- a/src/ghdcbot/engine/notifications.py
+++ b/src/ghdcbot/engine/notifications.py
@@ -230,6 +230,16 @@ def send_pr_opened_channel_notification(
     return sent
 
 
+def _suppress_discord_embed(url: str) -> str:
+    """Wrap a URL so Discord clients do not generate a link preview card."""
+    text = (url or "").strip()
+    if not text:
+        return text
+    if text.startswith("<") and text.endswith(">"):
+        return text
+    return f"<{text}>"
+
+
 def _build_pr_opened_channel_message(
     event: ContributionEvent,
     github_org: str,
@@ -240,7 +250,9 @@ def _build_pr_opened_channel_message(
     if pr_number is None:
         return None
     pr_title = (event.payload.get("title") or "Untitled")[:100]
-    url = f"https://github.com/{github_org}/{event.repo}/pull/{pr_number}"
+    url = _suppress_discord_embed(
+        f"https://github.com/{github_org}/{event.repo}/pull/{pr_number}"
+    )
     author_display = f"<@{discord_user_id}> (`{author_github}`)"
     return (
         f"🆕 **New PR opened**\n\n"
@@ -365,7 +377,7 @@ def _build_notification_message(
             f"**#{issue_number} – {issue_title}**\n\n"
             f"**Repository:** `{github_org}/{repo}`\n"
             f"{f'**Assigned{assigned_by_str}**' if assigned_by else ''}\n"
-            f"**Link:** https://github.com/{github_org}/{repo}/issues/{issue_number}\n\n"
+            f"**Link:** {_suppress_discord_embed(f'https://github.com/{github_org}/{repo}/issues/{issue_number}')}\n\n"
             f"💡 You're now responsible for this issue. Good luck!"
         )
     
@@ -376,7 +388,7 @@ def _build_notification_message(
             f"👀 **PR Review Requested**\n\n"
             f"**PR:** #{pr_number} – {pr_title}\n"
             f"**Repository:** {github_org}/{repo}\n"
-            f"**Link:** https://github.com/{github_org}/{repo}/pull/{pr_number}\n\n"
+            f"**Link:** {_suppress_discord_embed(f'https://github.com/{github_org}/{repo}/pull/{pr_number}')}\n\n"
             f"Please review when you have time."
         )
     
@@ -389,7 +401,7 @@ def _build_notification_message(
             f"Great news! Your **PR #{pr_number}** has been approved by `{reviewer}`.\n\n"
             f"**Repository:** `{github_org}/{repo}`\n"
             f"**Status:** 🟢 Ready to merge\n"
-            f"**Link:** https://github.com/{github_org}/{repo}/pull/{pr_number}\n\n"
+            f"**Link:** {_suppress_discord_embed(f'https://github.com/{github_org}/{repo}/pull/{pr_number}')}\n\n"
             f"🎉 Excellent work!"
         )
     
@@ -402,7 +414,7 @@ def _build_notification_message(
             f"**PR #{pr_number}** needs some updates before it can be merged.\n\n"
             f"**Reviewer:** `{reviewer}`\n"
             f"**Repository:** `{github_org}/{repo}`\n"
-            f"**Link:** https://github.com/{github_org}/{repo}/pull/{pr_number}\n\n"
+            f"**Link:** {_suppress_discord_embed(f'https://github.com/{github_org}/{repo}/pull/{pr_number}')}\n\n"
             f"💬 Please check the review comments on GitHub and address the feedback."
         )
 
@@ -416,7 +428,7 @@ def _build_notification_message(
             f"**Reviewer:** `{reviewer}`\n"
             f"**Repository:** `{github_org}/{repo}`\n"
             f"**PR:** {pr_title}\n"
-            f"**Link:** https://github.com/{github_org}/{repo}/pull/{pr_number}\n\n"
+            f"**Link:** {_suppress_discord_embed(f'https://github.com/{github_org}/{repo}/pull/{pr_number}')}\n\n"
             f"Review the feedback and update your PR if needed."
         )
     
@@ -426,42 +438,45 @@ def _build_notification_message(
             f"🚀 **PR Merged Successfully!**\n\n"
             f"Congratulations! Your **PR #{pr_number}** has been merged into the main branch. 🎉\n\n"
             f"**Repository:** `{github_org}/{repo}`\n"
-            f"**Link:** https://github.com/{github_org}/{repo}/pull/{pr_number}\n\n"
+            f"**Link:** {_suppress_discord_embed(f'https://github.com/{github_org}/{repo}/pull/{pr_number}')}\n\n"
             f"✨ Thank you for your contribution!"
         )
 
     elif event_type_key == "pr_closed":
         pr_number = payload.get("pr_number")
         pr_title = payload.get("pr_title") or payload.get("title", "Untitled")[:100]
+        closed_url = payload.get("html_url") or f"https://github.com/{github_org}/{repo}/pull/{pr_number}"
         return (
             f"🔒 **PR Closed**\n\n"
             f'Your PR **#{pr_number}** — *{pr_title}* was closed without being merged.\n\n'
             f"**Repository:** `{github_org}/{repo}`\n"
-            f"**Link:** {payload.get('html_url') or f'https://github.com/{github_org}/{repo}/pull/{pr_number}'}\n\n"
+            f"**Link:** {_suppress_discord_embed(str(closed_url))}\n\n"
             f"Review the discussion for more details."
         )
 
     elif event_type_key == "issue_reopened":
         issue_number = payload.get("issue_number")
         issue_title = payload.get("title", "Untitled")[:100]
+        issue_url = payload.get("html_url") or f"https://github.com/{github_org}/{repo}/issues/{issue_number}"
         return (
             f"📌 **Issue Reopened**\n\n"
             f"Issue #{issue_number} **{issue_title}**\n\n"
             f"assigned to you has been reopened.\n\n"
             f"**Repository:** `{github_org}/{repo}`\n"
-            f"**Link:** {payload.get('html_url') or f'https://github.com/{github_org}/{repo}/issues/{issue_number}'}\n\n"
+            f"**Link:** {_suppress_discord_embed(str(issue_url))}\n\n"
             f"Please review the latest discussion and continue working if needed."
         )
 
     elif event_type_key == "pr_reopened":
         pr_number = payload.get("pr_number")
         pr_title = payload.get("title", "Untitled")[:100]
+        reopen_url = payload.get("html_url") or f"https://github.com/{github_org}/{repo}/pull/{pr_number}"
         return (
             f"🔄 **PR Reopened**\n\n"
             f"Your PR #{pr_number} **{pr_title}**\n\n"
             f"has been reopened.\n\n"
             f"**Repository:** `{github_org}/{repo}`\n"
-            f"**Link:** {payload.get('html_url') or f'https://github.com/{github_org}/{repo}/pull/{pr_number}'}\n\n"
+            f"**Link:** {_suppress_discord_embed(str(reopen_url))}\n\n"
             f"Please review the discussion and continue updating your PR."
         )
     
@@ -600,7 +615,7 @@ def _is_coderabbit_comment(comment: dict, bot_logins_lower: list[str], cutoff: d
 def _build_coderabbit_reminder_message(
     github_org: str, repo: str, pr_number: int, after_hours: int
 ) -> str:
-    url = f"https://github.com/{github_org}/{repo}/pull/{pr_number}"
+    url = _suppress_discord_embed(f"https://github.com/{github_org}/{repo}/pull/{pr_number}")
     return (
         f"📋 **CodeRabbit reminder**\n\n"
         f"You have CodeRabbit review comments on **{repo}#{pr_number}** that are over **{after_hours} hours** old.\n\n"

--- a/src/ghdcbot/engine/notifications.py
+++ b/src/ghdcbot/engine/notifications.py
@@ -160,6 +160,97 @@ def send_notification_for_event(
     return sent
 
 
+def send_pr_opened_channel_notification(
+    event: ContributionEvent,
+    storage: Storage,
+    discord_writer: DiscordWriter,
+    policy: MutationPolicy,
+    config: NotificationConfig,
+    pr_open_channels: dict[str, str],
+    github_org: str,
+) -> bool:
+    """Post a PR-opened announcement to a repo-mapped Discord channel/thread.
+
+    Only fires for verified PR authors when notifications.pr_opened is enabled and the
+    repo has an entry in pr_open_channels.
+    """
+    if not config.enabled or not config.pr_opened:
+        return False
+    if event.event_type != "pr_opened":
+        return False
+
+    channel_id = pr_open_channels.get(event.repo)
+    if not channel_id:
+        return False
+
+    author_github = event.github_user
+    if not author_github:
+        return False
+
+    discord_user_id = _resolve_github_to_discord(storage, author_github)
+    if not discord_user_id:
+        logger.info(
+            "Skipping pr_opened channel post: author not verified",
+            extra={"github_user": author_github, "repo": event.repo},
+        )
+        return False
+
+    dedupe_key = f"pr_opened_channel:{event.repo}:{event.payload.get('pr_number')}:{channel_id}"
+    if _was_notification_sent(storage, dedupe_key):
+        return False
+
+    message = _build_pr_opened_channel_message(
+        event, github_org, author_github, discord_user_id
+    )
+    if not message:
+        return False
+
+    if not policy.allow_discord_mutations:
+        return False
+
+    send_msg = getattr(discord_writer, "send_message", None)
+    if not callable(send_msg):
+        return False
+
+    try:
+        sent = bool(send_msg(channel_id, message))
+    except Exception as exc:
+        logger.warning(
+            "Failed to send pr_opened channel notification",
+            exc_info=True,
+            extra={"error": str(exc), "channel_id": channel_id, "repo": event.repo},
+        )
+        return False
+
+    if sent:
+        _mark_notification_sent(
+            storage, dedupe_key, event, discord_user_id, channel_id, author_github
+        )
+        _audit_notification(storage, event, discord_user_id, channel_id, author_github)
+    return sent
+
+
+def _build_pr_opened_channel_message(
+    event: ContributionEvent,
+    github_org: str,
+    author_github: str,
+    discord_user_id: str,
+) -> str | None:
+    pr_number = event.payload.get("pr_number")
+    if pr_number is None:
+        return None
+    pr_title = (event.payload.get("title") or "Untitled")[:100]
+    url = f"https://github.com/{github_org}/{event.repo}/pull/{pr_number}"
+    author_display = f"<@{discord_user_id}> (`{author_github}`)"
+    return (
+        f"🆕 **New PR opened**\n\n"
+        f"**Author:** {author_display}\n"
+        f"**PR:** #{pr_number} — {pr_title}\n"
+        f"**Repository:** `{github_org}/{event.repo}`\n"
+        f"**Link:** {url}"
+    )
+
+
 def _resolve_github_to_discord(storage: Storage, github_user: str) -> str | None:
     """Resolve verified GitHub user to Discord user ID. Returns None if not verified.
     GitHub usernames are case-insensitive; comparison is done case-insensitively.

--- a/src/ghdcbot/engine/notifications.py
+++ b/src/ghdcbot/engine/notifications.py
@@ -171,8 +171,8 @@ def send_pr_opened_channel_notification(
 ) -> bool:
     """Post a PR-opened announcement to a repo-mapped Discord channel/thread.
 
-    Only fires for verified PR authors when notifications.pr_opened is enabled and the
-    repo has an entry in pr_open_channels.
+    Posts for every mapped-repo PR open when notifications.pr_opened is enabled.
+    Verified authors are @mentioned; unverified authors show a verification notice.
     """
     if not config.enabled or not config.pr_opened:
         return False
@@ -188,12 +188,6 @@ def send_pr_opened_channel_notification(
         return False
 
     discord_user_id = _resolve_github_to_discord(storage, author_github)
-    if not discord_user_id:
-        logger.info(
-            "Skipping pr_opened channel post: author not verified",
-            extra={"github_user": author_github, "repo": event.repo},
-        )
-        return False
 
     dedupe_key = f"pr_opened_channel:{event.repo}:{event.payload.get('pr_number')}:{channel_id}"
     if _was_notification_sent(storage, dedupe_key):
@@ -223,10 +217,11 @@ def send_pr_opened_channel_notification(
         return False
 
     if sent:
+        notify_discord_id = discord_user_id or ""
         _mark_notification_sent(
-            storage, dedupe_key, event, discord_user_id, channel_id, author_github
+            storage, dedupe_key, event, notify_discord_id, channel_id, author_github
         )
-        _audit_notification(storage, event, discord_user_id, channel_id, author_github)
+        _audit_notification(storage, event, notify_discord_id, channel_id, author_github)
     return sent
 
 
@@ -244,7 +239,7 @@ def _build_pr_opened_channel_message(
     event: ContributionEvent,
     github_org: str,
     author_github: str,
-    discord_user_id: str,
+    discord_user_id: str | None,
 ) -> str | None:
     pr_number = event.payload.get("pr_number")
     if pr_number is None:
@@ -253,7 +248,10 @@ def _build_pr_opened_channel_message(
     url = _suppress_discord_embed(
         f"https://github.com/{github_org}/{event.repo}/pull/{pr_number}"
     )
-    author_display = f"<@{discord_user_id}> (`{author_github}`)"
+    if discord_user_id:
+        author_display = f"<@{discord_user_id}> (`{author_github}`)"
+    else:
+        author_display = f"Contributor is not verified on gitcord (`{author_github}`)"
     return (
         f"🆕 **New PR opened**\n\n"
         f"**Author:** {author_display}\n"

--- a/src/ghdcbot/engine/open_prs.py
+++ b/src/ghdcbot/engine/open_prs.py
@@ -1,0 +1,79 @@
+"""Read-only helpers for listing a contributor's open pull requests."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Iterable, Sequence
+
+
+def list_open_prs_for_author(
+    open_prs: Iterable[dict],
+    github_user: str,
+) -> list[dict]:
+    """Return open PR dicts authored by github_user, newest first."""
+    target = github_user.strip().lower()
+    matched = [
+        pr
+        for pr in open_prs
+        if (pr.get("author") or "").strip().lower() == target
+    ]
+    return sorted(matched, key=_opened_at_sort_key, reverse=True)
+
+
+def format_open_prs_report(
+    *,
+    contributor_mention: str,
+    github_user: str,
+    prs: Sequence[dict],
+    org: str,
+    max_items: int = 20,
+) -> str:
+    """Build a Discord message listing open PRs for a contributor."""
+    header = f"Open PRs for {contributor_mention} (GitHub: {github_user})"
+    if not prs:
+        return f"{header}\n\nNo open PRs found in configured repos."
+
+    lines = [header, ""]
+    shown = list(prs[:max_items])
+    for index, pr in enumerate(shown, start=1):
+        repo = pr.get("repo", "?")
+        number = pr.get("number", "?")
+        title = (pr.get("title") or "No title").strip()
+        if len(title) > 80:
+            title = f"{title[:77]}..."
+        opened = _format_opened_at(pr.get("created_at"))
+        url = pr.get("html_url") or f"https://github.com/{org}/{repo}/pull/{number}"
+        lines.append(f"{index}. **{repo}**#{number} — {title}")
+        lines.append(f"   opened {opened}")
+        lines.append(f"   {url}")
+
+    remaining = len(prs) - len(shown)
+    if remaining > 0:
+        lines.append("")
+        lines.append(f"…and {remaining} more open PR(s) not shown.")
+    return "\n".join(lines)
+
+
+def _opened_at_sort_key(pr: dict) -> datetime:
+    parsed = _parse_created_at(pr.get("created_at"))
+    return parsed or datetime.min.replace(tzinfo=timezone.utc)
+
+
+def _parse_created_at(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    normalized = value.replace("Z", "+00:00")
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _format_opened_at(value: object) -> str:
+    parsed = _parse_created_at(value)
+    if parsed is None:
+        return "unknown time"
+    return parsed.strftime("%Y-%m-%d %H:%M UTC")

--- a/src/ghdcbot/engine/orchestrator.py
+++ b/src/ghdcbot/engine/orchestrator.py
@@ -18,7 +18,11 @@ from ghdcbot.core.interfaces import (
 from ghdcbot.core.modes import MutationPolicy, RunMode
 from ghdcbot.core.models import ContributionEvent, GitHubAssignmentPlan
 from ghdcbot.engine.assignment import RoleBasedAssignmentStrategy
-from ghdcbot.engine.notifications import run_coderabbit_reminders, send_notification_for_event
+from ghdcbot.engine.notifications import (
+    run_coderabbit_reminders,
+    send_notification_for_event,
+    send_pr_opened_channel_notification,
+)
 from ghdcbot.engine.planning import plan_discord_roles
 from ghdcbot.engine.reporting import write_reports, write_activity_report
 from ghdcbot.engine.snapshots import write_snapshots_to_github
@@ -93,6 +97,7 @@ class Orchestrator:
         # Send verified-only notifications for new events (if enabled)
         notification_config = getattr(self.config.discord, "notifications", None)
         if notification_config and notification_config.enabled:
+            pr_open_channels = getattr(self.config.discord, "pr_open_channels", None) or {}
             _send_notifications_for_new_events(
                 contributions,
                 self.storage,
@@ -100,6 +105,7 @@ class Orchestrator:
                 policy,
                 notification_config,
                 self.config.github.org,
+                pr_open_channels,
             )
             # CodeRabbit reminders: one reminder per PR for verified contributors (opt-in, non-blocking)
             if getattr(notification_config, "coderabbit_reminders", False):
@@ -267,12 +273,20 @@ def _send_notifications_for_new_events(
     policy: MutationPolicy,
     config: Any,
     github_org: str,
+    pr_open_channels: dict[str, str] | None = None,
 ) -> None:
     """Send Discord notifications for notification-worthy events (verified users only)."""
     logger = logging.getLogger("Notifications")
     sent_count = 0
     pr_reviewed_count = 0
+    channels = pr_open_channels or {}
     for event in contributions:
+        if event.event_type == "pr_opened":
+            if send_pr_opened_channel_notification(
+                event, storage, discord_writer, policy, config, channels, github_org
+            ):
+                sent_count += 1
+            continue
         if event.event_type in {"issue_assigned", "pr_reviewed", "pr_merged", "pr_closed", "issue_reopened", "pr_reopened"}:
             if event.event_type == "pr_reviewed":
                 pr_reviewed_count += 1

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -78,5 +78,6 @@ def test_aussie_config_loads_shared_repo_allowlist(monkeypatch: pytest.MonkeyPat
     config = load_config(str(config_path))
     assert config.github.repos is not None
     assert config.github.repos.mode == "allow"
-    assert len(config.github.repos.names) == 15
+    assert len(config.github.repos.names) == 19
     assert "EduAid" in config.github.repos.names
+    assert "SkillBot" in config.github.repos.names

--- a/tests/test_github_ingestion_lifecycle_events.py
+++ b/tests/test_github_ingestion_lifecycle_events.py
@@ -113,6 +113,52 @@ def test_pr_merged_emitted_not_pr_closed_when_merged(monkeypatch) -> None:
     assert len(closed) == 0
 
 
+def test_pr_closed_not_emitted_when_timeline_has_merged_and_closed(monkeypatch) -> None:
+    """A merged PR emits both merged+closed timeline events (same timestamp).
+
+    Even if the close event sorts after the merge event, pr_closed must not fire.
+    """
+    adapter = GitHubRestAdapter(token="t", org="org", api_base="https://api.github.com")
+    monkeypatch.setattr(
+        adapter,
+        "_list_repos",
+        lambda: [{"name": "repo", "owner": {"login": "owner"}, "full_name": "owner/repo"}],
+    )
+    routes = {
+        "/repos/owner/repo/issues": [],
+        "/repos/owner/repo/pulls": [
+            {
+                "number": 28,
+                "state": "closed",
+                "created_at": "2024-01-02T00:00:00Z",
+                "updated_at": "2024-01-09T00:00:00Z",
+                "closed_at": "2024-01-09T00:00:00Z",
+                "merged_at": "2024-01-09T00:00:00Z",
+                "title": "Week 6 work",
+                "html_url": "https://github.com/owner/repo/pull/28",
+                "user": {"login": "shubham5080"},
+            }
+        ],
+        "/repos/owner/repo/pulls/28/reviews": [],
+        "/repos/owner/repo/pulls/28/comments": [],
+        "/repos/owner/repo/issues/28/comments": [],
+        # Both events at the same timestamp, closed listed AFTER merged (the buggy order).
+        "/repos/owner/repo/issues/28/timeline": [
+            {"event": "merged", "created_at": "2024-01-09T00:00:00Z"},
+            {"event": "closed", "created_at": "2024-01-09T00:00:00Z"},
+        ],
+    }
+    adapter._client = _MockClient(routes)
+
+    since = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    events = list(adapter.list_contributions(since))
+    merged = [event for event in events if event.event_type == "pr_merged"]
+    closed = [event for event in events if event.event_type == "pr_closed"]
+
+    assert len(merged) == 1
+    assert len(closed) == 0
+
+
 def test_pr_closed_emitted_when_closed_then_reopened_before_sync(monkeypatch) -> None:
     adapter = GitHubRestAdapter(token="t", org="org", api_base="https://api.github.com")
     monkeypatch.setattr(

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -913,3 +913,101 @@ def test_pr_opened_channel_notification_skips_unmapped_repo() -> None:
 
     assert result is False
     assert discord_writer.messages_sent == []
+
+
+def _pr_opened_event(*, github_user: str = "alice", repo: str = "Gitcord-GithubDiscordBot") -> ContributionEvent:
+    return ContributionEvent(
+        github_user=github_user,
+        event_type="pr_opened",
+        repo=repo,
+        created_at=datetime.now(timezone.utc),
+        payload={"pr_number": 42, "title": "Test PR"},
+    )
+
+
+def test_pr_opened_channel_notification_skips_when_pr_opened_disabled() -> None:
+    storage = MockStorage()
+    storage.verified_mappings = [{"discord_user_id": "999", "github_user": "alice"}]
+    discord_writer = MockDiscordWriter()
+    config = NotificationConfig(enabled=True, pr_opened=False)
+    policy = MutationPolicy(mode=RunMode.ACTIVE, github_write_allowed=True, discord_write_allowed=True)
+
+    result = send_pr_opened_channel_notification(
+        _pr_opened_event(),
+        storage,
+        discord_writer,
+        policy,
+        config,
+        {"Gitcord-GithubDiscordBot": "1465995983791063140"},
+        "AOSSIE-Org",
+    )
+
+    assert result is False
+    assert discord_writer.messages_sent == []
+
+
+def test_pr_opened_channel_notification_skips_unverified_author() -> None:
+    storage = MockStorage()
+    storage.verified_mappings = []
+    discord_writer = MockDiscordWriter()
+    config = NotificationConfig(enabled=True, pr_opened=True)
+    policy = MutationPolicy(mode=RunMode.ACTIVE, github_write_allowed=True, discord_write_allowed=True)
+
+    result = send_pr_opened_channel_notification(
+        _pr_opened_event(github_user="stranger"),
+        storage,
+        discord_writer,
+        policy,
+        config,
+        {"Gitcord-GithubDiscordBot": "1465995983791063140"},
+        "AOSSIE-Org",
+    )
+
+    assert result is False
+    assert discord_writer.messages_sent == []
+
+
+def test_pr_opened_channel_notification_skips_duplicate() -> None:
+    storage = MockStorage()
+    storage.verified_mappings = [{"discord_user_id": "999", "github_user": "alice"}]
+    storage.notifications_sent.add(
+        "pr_opened_channel:Gitcord-GithubDiscordBot:42:1465995983791063140"
+    )
+    discord_writer = MockDiscordWriter()
+    config = NotificationConfig(enabled=True, pr_opened=True)
+    policy = MutationPolicy(mode=RunMode.ACTIVE, github_write_allowed=True, discord_write_allowed=True)
+
+    result = send_pr_opened_channel_notification(
+        _pr_opened_event(),
+        storage,
+        discord_writer,
+        policy,
+        config,
+        {"Gitcord-GithubDiscordBot": "1465995983791063140"},
+        "AOSSIE-Org",
+    )
+
+    assert result is False
+    assert discord_writer.messages_sent == []
+
+
+def test_pr_opened_channel_notification_skips_when_discord_mutations_disallowed() -> None:
+    storage = MockStorage()
+    storage.verified_mappings = [{"discord_user_id": "999", "github_user": "alice"}]
+    discord_writer = MockDiscordWriter()
+    config = NotificationConfig(enabled=True, pr_opened=True)
+    policy = MutationPolicy(mode=RunMode.DRY_RUN, github_write_allowed=True, discord_write_allowed=True)
+
+    result = send_pr_opened_channel_notification(
+        _pr_opened_event(),
+        storage,
+        discord_writer,
+        policy,
+        config,
+        {"Gitcord-GithubDiscordBot": "1465995983791063140"},
+        "AOSSIE-Org",
+    )
+
+    assert result is False
+    assert discord_writer.messages_sent == []
+    assert policy.allow_discord_mutations is False

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -946,7 +946,7 @@ def test_pr_opened_channel_notification_skips_when_pr_opened_disabled() -> None:
     assert discord_writer.messages_sent == []
 
 
-def test_pr_opened_channel_notification_skips_unverified_author() -> None:
+def test_pr_opened_channel_notification_posts_unverified_author() -> None:
     storage = MockStorage()
     storage.verified_mappings = []
     discord_writer = MockDiscordWriter()
@@ -963,8 +963,12 @@ def test_pr_opened_channel_notification_skips_unverified_author() -> None:
         "AOSSIE-Org",
     )
 
-    assert result is False
-    assert discord_writer.messages_sent == []
+    assert result is True
+    assert len(discord_writer.messages_sent) == 1
+    _, message = discord_writer.messages_sent[0]
+    assert "Contributor is not verified on gitcord" in message
+    assert "`stranger`" in message
+    assert "<@" not in message
 
 
 def test_pr_opened_channel_notification_skips_duplicate() -> None:

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -9,6 +9,7 @@ from ghdcbot.engine.notifications import (
     _build_dedupe_key,
     _build_notification_message,
     send_notification_for_event,
+    send_pr_opened_channel_notification,
 )
 
 
@@ -851,3 +852,64 @@ def test_issue_reopened_without_assignee() -> None:
 
     assert result is False
     assert len(discord_writer.dms_sent) == 0
+
+
+def test_pr_opened_channel_notification_posts_to_mapped_channel() -> None:
+    storage = MockStorage()
+    storage.verified_mappings = [{"discord_user_id": "999", "github_user": "alice"}]
+    discord_writer = MockDiscordWriter()
+    config = NotificationConfig(enabled=True, pr_opened=True)
+    policy = MutationPolicy(mode=RunMode.ACTIVE, github_write_allowed=True, discord_write_allowed=True)
+    event = ContributionEvent(
+        github_user="alice",
+        event_type="pr_opened",
+        repo="Gitcord-GithubDiscordBot",
+        created_at=datetime.now(timezone.utc),
+        payload={"pr_number": 42, "title": "Test PR"},
+    )
+
+    result = send_pr_opened_channel_notification(
+        event,
+        storage,
+        discord_writer,
+        policy,
+        config,
+        {"Gitcord-GithubDiscordBot": "1465995983791063140"},
+        "AOSSIE-Org",
+    )
+
+    assert result is True
+    assert len(discord_writer.messages_sent) == 1
+    channel_id, message = discord_writer.messages_sent[0]
+    assert channel_id == "1465995983791063140"
+    assert "New PR opened" in message
+    assert "<@999>" in message
+    assert "pull/42" in message
+
+
+def test_pr_opened_channel_notification_skips_unmapped_repo() -> None:
+    storage = MockStorage()
+    storage.verified_mappings = [{"discord_user_id": "999", "github_user": "alice"}]
+    discord_writer = MockDiscordWriter()
+    config = NotificationConfig(enabled=True, pr_opened=True)
+    policy = MutationPolicy(mode=RunMode.ACTIVE, github_write_allowed=True, discord_write_allowed=True)
+    event = ContributionEvent(
+        github_user="alice",
+        event_type="pr_opened",
+        repo="EduAid",
+        created_at=datetime.now(timezone.utc),
+        payload={"pr_number": 1, "title": "Other"},
+    )
+
+    result = send_pr_opened_channel_notification(
+        event,
+        storage,
+        discord_writer,
+        policy,
+        config,
+        {"Gitcord-GithubDiscordBot": "1465995983791063140"},
+        "AOSSIE-Org",
+    )
+
+    assert result is False
+    assert discord_writer.messages_sent == []

--- a/tests/test_open_prs.py
+++ b/tests/test_open_prs.py
@@ -1,0 +1,120 @@
+"""Tests for open PR listing helpers."""
+
+from ghdcbot.engine.open_prs import format_open_prs_report, list_open_prs_for_author
+
+
+def _pr(
+    *,
+    repo: str,
+    number: int,
+    author: str,
+    title: str,
+    created_at: str,
+    html_url: str | None = None,
+) -> dict:
+    return {
+        "repo": repo,
+        "number": number,
+        "author": author,
+        "title": title,
+        "created_at": created_at,
+        "html_url": html_url,
+    }
+
+
+def test_list_open_prs_for_author_filters_case_insensitively() -> None:
+    prs = [
+        _pr(repo="a", number=1, author="Alice", title="One", created_at="2026-07-01T10:00:00Z"),
+        _pr(repo="b", number=2, author="bob", title="Two", created_at="2026-07-02T10:00:00Z"),
+        _pr(repo="c", number=3, author="alice", title="Three", created_at="2026-07-03T10:00:00Z"),
+    ]
+
+    matched = list_open_prs_for_author(prs, "ALICE")
+
+    assert [pr["number"] for pr in matched] == [3, 1]
+
+
+def test_list_open_prs_for_author_returns_empty_for_unknown_user() -> None:
+    prs = [_pr(repo="a", number=1, author="bob", title="One", created_at="2026-07-01T10:00:00Z")]
+
+    assert list_open_prs_for_author(prs, "alice") == []
+
+
+def test_format_open_prs_report_includes_links_and_opened_dates() -> None:
+    prs = [
+        _pr(
+            repo="Gitcord",
+            number=42,
+            author="alice",
+            title="Add sync safety",
+            created_at="2026-07-05T10:14:00Z",
+            html_url="https://github.com/AOSSIE-Org/Gitcord/pull/42",
+        )
+    ]
+
+    message = format_open_prs_report(
+        contributor_mention="<@123>",
+        github_user="alice",
+        prs=prs,
+        org="AOSSIE-Org",
+    )
+
+    assert "Open PRs for <@123> (GitHub: alice)" in message
+    assert "**Gitcord**#42 — Add sync safety" in message
+    assert "opened 2026-07-05 10:14 UTC" in message
+    assert "https://github.com/AOSSIE-Org/Gitcord/pull/42" in message
+
+
+def test_format_open_prs_report_builds_url_when_html_url_missing() -> None:
+    prs = [
+        _pr(
+            repo="EduAid",
+            number=7,
+            author="alice",
+            title="Fix flow",
+            created_at="2026-07-01T08:02:00Z",
+        )
+    ]
+
+    message = format_open_prs_report(
+        contributor_mention="<@123>",
+        github_user="alice",
+        prs=prs,
+        org="AOSSIE-Org",
+    )
+
+    assert "https://github.com/AOSSIE-Org/EduAid/pull/7" in message
+
+
+def test_format_open_prs_report_empty_result() -> None:
+    message = format_open_prs_report(
+        contributor_mention="<@123>",
+        github_user="alice",
+        prs=[],
+        org="AOSSIE-Org",
+    )
+
+    assert "No open PRs found in configured repos." in message
+
+
+def test_format_open_prs_report_truncates_long_lists() -> None:
+    prs = [
+        _pr(
+            repo="repo",
+            number=i,
+            author="alice",
+            title=f"PR {i}",
+            created_at=f"2026-07-{i:02d}T10:00:00Z",
+        )
+        for i in range(1, 23)
+    ]
+
+    message = format_open_prs_report(
+        contributor_mention="<@123>",
+        github_user="alice",
+        prs=prs,
+        org="AOSSIE-Org",
+        max_items=20,
+    )
+
+    assert "…and 2 more open PR(s) not shown." in message

--- a/tests/test_open_prs_search.py
+++ b/tests/test_open_prs_search.py
@@ -1,0 +1,74 @@
+"""Tests for author-scoped open PR Search API helper."""
+
+from __future__ import annotations
+
+import httpx
+
+from ghdcbot.adapters.github.rest import GitHubRestAdapter, _repo_name_from_search_issue
+from ghdcbot.config.models import RepoFilterConfig
+
+
+class _SearchMockClient:
+    def __init__(self, payload: dict) -> None:
+        self._payload = payload
+        self.calls: list[tuple[str, str, dict | None]] = []
+
+    def request(self, method: str, path: str, params: dict | None = None) -> httpx.Response:
+        self.calls.append((method, path, params))
+        return httpx.Response(200, json=self._payload, headers={"X-RateLimit-Remaining": "10"})
+
+
+def test_repo_name_from_search_issue_prefers_repository_url() -> None:
+    assert (
+        _repo_name_from_search_issue(
+            {"repository_url": "https://api.github.com/repos/AOSSIE-Org/PictoPy"},
+            "AOSSIE-Org",
+        )
+        == "PictoPy"
+    )
+
+
+def test_list_open_pull_requests_for_author_uses_search_and_allowlist(monkeypatch) -> None:
+    adapter = GitHubRestAdapter(token="t", org="AOSSIE-Org", api_base="https://api.github.com")
+    client = _SearchMockClient(
+        {
+            "items": [
+                {
+                    "number": 10,
+                    "title": "Allowed",
+                    "html_url": "https://github.com/AOSSIE-Org/PictoPy/pull/10",
+                    "created_at": "2026-07-11T10:00:00Z",
+                    "repository_url": "https://api.github.com/repos/AOSSIE-Org/PictoPy",
+                    "user": {"login": "alice"},
+                },
+                {
+                    "number": 11,
+                    "title": "Denied",
+                    "html_url": "https://github.com/AOSSIE-Org/Other/pull/11",
+                    "created_at": "2026-07-11T11:00:00Z",
+                    "repository_url": "https://api.github.com/repos/AOSSIE-Org/Other",
+                    "user": {"login": "alice"},
+                },
+            ]
+        }
+    )
+    adapter._client = client  # type: ignore[assignment]
+    monkeypatch.setattr(
+        "ghdcbot.adapters.github.rest._load_repo_filter",
+        lambda: RepoFilterConfig(mode="allow", names=["PictoPy"]),
+    )
+
+    prs = adapter.list_open_pull_requests_for_author("alice")
+
+    assert len(client.calls) == 1
+    method, path, params = client.calls[0]
+    assert method == "GET"
+    assert path == "/search/issues"
+    assert params is not None
+    assert "author:alice" in params["q"]
+    assert "org:AOSSIE-Org" in params["q"]
+    assert len(prs) == 1
+    assert prs[0]["repo"] == "PictoPy"
+    assert prs[0]["number"] == 10
+    assert prs[0]["author"] == "alice"
+    assert prs[0]["title"] == "Allowed"


### PR DESCRIPTION
## Summary
- Add `/open-prs` slash command to list a verified contributor’s currently open PRs (title, opened date, URL) across configured repos
- Add config-driven `pr_opened` notifications that post new PRs into mapped `#projects` Discord threads (`discord.pr_open_channels`) for verified authors only
- Expand AOSSIE repo allowlist and harden ops reliability (suppress embeds on bot messages, skip false `pr_closed` after merge, Docker DNS/host-network fixes for campus networking)

## Out of scope (later)
- Feature 3: list all open PRs in a time window, grouped by contributor
- Feature 4: schedule that report on an interval

## Test plan
- [x] `pytest tests/test_open_prs.py tests/test_notifications.py tests/test_config.py tests/test_github_ingestion_lifecycle_events.py` (49 passed)
- [x] In Discord: `/open-prs contributor:@member` for a verified linked user
- [x] Open a test PR as a verified user in a mapped repo → run `/sync` or wait for scheduler → confirm post in the project thread
- [x] Confirm unverified authors do not trigger channel posts
- [x] Confirm re-sync does not duplicate the same `pr_opened` channel post (dedupe)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/open-prs` to show a contributor’s currently open pull requests.
  * Added configurable Discord notifications when pull requests are opened, routed to repository-specific channels.
  * Added four repositories to the shared synchronization allowlist.
* **Bug Fixes**
  * Improved handling of merged and closed pull requests to prevent duplicate or incorrect closure notifications.
  * Reduced link previews in bot messages and improved Discord connectivity and scheduled synchronization reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->