### PR TITLE
fix: CodeRabbit follow-ups for PR #38 notification/snapshot safety

### DIFF
--- a/src/ghdcbot/adapters/github/rest.py
+++ b/src/ghdcbot/adapters/github/rest.py
@@ -484,15 +484,26 @@ class GitHubRestAdapter:
         """Post a comment on an issue or pull request (Issues Comments API).
 
         Returns True if the comment was created (201).
+
+        Uses a single non-retrying POST: retries after an accepted-but-unread
+        response would duplicate comments. Timeouts are treated as success so
+        callers keep their SQLite dedupe claim for uncertain outcomes.
         """
         path = f"/repos/{owner}/{repo}/issues/{issue_number}/comments"
-        response = self._execute_request_with_retries(
-            "POST", path, params={}, json_body={"body": body}
-        )
-        if response is None:
+        try:
+            self._increment_sync_request_count()
+            response = self._client.post(path, json={"body": body})
+        except httpx.TimeoutException as exc:
+            # GitHub may have accepted the comment; do not retry or report failure.
             self._logger.warning(
-                "GitHub create comment failed (network/retries)",
-                extra={"path": path},
+                "GitHub create comment timed out (outcome uncertain; treating as success)",
+                extra={"path": path, "error": str(exc)},
+            )
+            return True
+        except httpx.HTTPError as exc:
+            self._logger.warning(
+                "GitHub create comment failed (network)",
+                extra={"path": path, "error": str(exc)},
             )
             return False
 
@@ -524,6 +535,78 @@ class GitHubRestAdapter:
             },
         )
         return False
+
+    def delete_file(
+        self,
+        owner: str,
+        repo: str,
+        file_path: str,
+        commit_message: str,
+        branch: str | None = None,
+    ) -> bool:
+        """Delete a file from a GitHub repo using the Contents API.
+
+        Returns True if the file was deleted (200) or already absent (404).
+        """
+        try:
+            if not branch:
+                repo_info = self._request("GET", f"/repos/{owner}/{repo}", params={})
+                if repo_info and repo_info.status_code == 200:
+                    branch = repo_info.json().get("default_branch", "main")
+                else:
+                    branch = "main"
+
+            file_response = self._request(
+                "GET",
+                f"/repos/{owner}/{repo}/contents/{file_path}",
+                params={"ref": branch},
+            )
+            if file_response is None:
+                return False
+            if file_response.status_code == 404:
+                return True
+            if file_response.status_code != 200:
+                return False
+            file_sha = file_response.json().get("sha")
+            if not file_sha:
+                return False
+
+            payload = {"message": commit_message, "sha": file_sha, "branch": branch}
+            try:
+                response = self._client.request(
+                    "DELETE",
+                    f"/repos/{owner}/{repo}/contents/{file_path}",
+                    json=payload,
+                )
+            except httpx.HTTPError as exc:
+                self._logger.warning(
+                    "GitHub delete file failed (network)",
+                    extra={"path": file_path, "error": str(exc)},
+                )
+                return False
+            if response.status_code in {200, 204}:
+                self._logger.info(
+                    "File deleted from GitHub",
+                    extra={"owner": owner, "repo": repo, "file_path": file_path},
+                )
+                return True
+            self._logger.warning(
+                "Failed to delete file from GitHub",
+                extra={
+                    "owner": owner,
+                    "repo": repo,
+                    "file_path": file_path,
+                    "status_code": response.status_code,
+                },
+            )
+            return False
+        except Exception as exc:
+            self._logger.warning(
+                "Exception deleting file from GitHub",
+                exc_info=True,
+                extra={"owner": owner, "repo": repo, "file_path": file_path, "error": str(exc)},
+            )
+            return False
 
     def get_pull_request(self, owner: str, repo: str, pr_number: int) -> dict | None:
         """Fetch a single pull request by number.

--- a/src/ghdcbot/engine/notifications.py
+++ b/src/ghdcbot/engine/notifications.py
@@ -190,8 +190,6 @@ def send_pr_opened_channel_notification(
     discord_user_id = _resolve_github_to_discord(storage, author_github)
 
     dedupe_key = f"pr_opened_channel:{event.repo}:{event.payload.get('pr_number')}:{channel_id}"
-    if _was_notification_sent(storage, dedupe_key):
-        return False
 
     message = _build_pr_opened_channel_message(
         event, github_org, author_github, discord_user_id
@@ -206,9 +204,25 @@ def send_pr_opened_channel_notification(
     if not callable(send_msg):
         return False
 
+    notify_discord_id = discord_user_id or ""
+    try:
+        claimed = _claim_notification_sent(
+            storage, dedupe_key, event, notify_discord_id, channel_id, author_github
+        )
+    except Exception as exc:
+        logger.warning(
+            "Failed to claim pr_opened channel notification",
+            exc_info=True,
+            extra={"error": str(exc), "channel_id": channel_id, "repo": event.repo},
+        )
+        return False
+    if not claimed:
+        return False
+
     try:
         sent = bool(send_msg(channel_id, message))
     except Exception as exc:
+        _release_notification_claim(storage, dedupe_key)
         logger.warning(
             "Failed to send pr_opened channel notification",
             exc_info=True,
@@ -217,12 +231,10 @@ def send_pr_opened_channel_notification(
         return False
 
     if sent:
-        notify_discord_id = discord_user_id or ""
-        _mark_notification_sent(
-            storage, dedupe_key, event, notify_discord_id, channel_id, author_github
-        )
         _audit_notification(storage, event, notify_discord_id, channel_id, author_github)
-    return sent
+        return True
+    _release_notification_claim(storage, dedupe_key)
+    return False
 
 
 def send_pr_opened_github_link_comment(
@@ -266,7 +278,18 @@ def send_pr_opened_github_link_comment(
         return False
 
     dedupe_key = f"pr_opened_github_link:{event.repo}:{pr_number}"
-    if not _claim_notification_sent(storage, dedupe_key, event, "", None, author_github):
+    try:
+        claimed = _claim_notification_sent(
+            storage, dedupe_key, event, "", None, author_github
+        )
+    except Exception as exc:
+        logger.warning(
+            "Failed to claim PR GitHub link comment notification",
+            exc_info=True,
+            extra={"error": str(exc), "repo": event.repo, "pr_number": pr_number},
+        )
+        return False
+    if not claimed:
         return False
 
     create_comment = getattr(github_writer, "create_issue_comment", None)

--- a/src/ghdcbot/engine/snapshots.py
+++ b/src/ghdcbot/engine/snapshots.py
@@ -144,10 +144,12 @@ def _write_snapshots(
     branch = snapshot_config.branch
     
     files_written = 0
+    written_paths: list[str] = []
     for filename, content in snapshot_data.items():
         file_path = f"{snapshot_dir}/{filename}"
         if _write_file_to_github(github_writer, owner, repo, file_path, content, commit_message, branch=branch):
             files_written += 1
+            written_paths.append(file_path)
     
     if files_written == len(snapshot_data):
         logger.info(
@@ -177,14 +179,19 @@ def _write_snapshots(
                 },
             })
     elif files_written > 0:
+        cleanup_message = f"Gitcord snapshot cleanup (incomplete run: {run_id[:8]})"
+        removed = _cleanup_partial_snapshot_files(
+            github_writer, owner, repo, written_paths, cleanup_message, branch=branch
+        )
         logger.warning(
-            "GitHub snapshots partially written; cursor not advanced",
+            "GitHub snapshots partially written; cleaned up and cursor not advanced",
             extra={
                 "org": config.github.org,
                 "repo": f"{owner}/{repo}",
                 "snapshot_dir": snapshot_dir,
                 "files_written": files_written,
                 "files_expected": len(snapshot_data),
+                "files_removed": removed,
             },
         )
 
@@ -388,3 +395,34 @@ def _write_file_to_github(
             extra={"file_path": file_path, "error": str(exc)},
         )
         return False
+
+
+def _cleanup_partial_snapshot_files(
+    github_writer: Any,
+    owner: str,
+    repo: str,
+    file_paths: list[str],
+    commit_message: str,
+    branch: str | None = None,
+) -> int:
+    """Best-effort removal of files written during an incomplete snapshot run."""
+    delete_file = getattr(github_writer, "delete_file", None)
+    if not callable(delete_file):
+        logger.warning(
+            "Cannot clean up partial snapshot: github writer has no delete_file",
+            extra={"owner": owner, "repo": repo, "files": len(file_paths)},
+        )
+        return 0
+
+    removed = 0
+    for file_path in file_paths:
+        try:
+            if delete_file(owner, repo, file_path, commit_message, branch=branch):
+                removed += 1
+        except Exception as exc:
+            logger.warning(
+                "Failed to delete partial snapshot file",
+                exc_info=True,
+                extra={"file_path": file_path, "error": str(exc)},
+            )
+    return removed

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1,8 +1,12 @@
 """Tests for verified-only GitHub → Discord notifications."""
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from threading import Barrier, Thread
+from unittest.mock import MagicMock
 
+import httpx
+
+from ghdcbot.adapters.github.rest import GitHubRestAdapter
 from ghdcbot.adapters.storage.sqlite import SqliteStorage
 from ghdcbot.config.models import NotificationConfig
 from ghdcbot.core.models import ContributionEvent
@@ -73,7 +77,7 @@ def test_build_dedupe_key() -> None:
         github_user="alice",
         event_type="issue_assigned",
         repo="test-repo",
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
         payload={"issue_number": 123},
     )
     key = _build_dedupe_key(event, "alice")
@@ -90,7 +94,7 @@ def test_build_notification_message_issue_assigned() -> None:
         github_user="alice",
         event_type="issue_assigned",
         repo="test-repo",
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
         payload={
             "issue_number": 123,
             "title": "Fix bug",
@@ -112,7 +116,7 @@ def test_build_notification_message_pr_approved() -> None:
         github_user="reviewer",
         event_type="pr_reviewed",
         repo="test-repo",
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
         payload={
             "pr_number": 456,
             "state": "APPROVED",
@@ -132,7 +136,7 @@ def test_build_notification_message_pr_changes_requested() -> None:
         github_user="reviewer",
         event_type="pr_reviewed",
         repo="test-repo",
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
         payload={
             "pr_number": 789,
             "state": "CHANGES_REQUESTED",
@@ -152,7 +156,7 @@ def test_build_notification_message_pr_review_comment() -> None:
         github_user="bhavik",
         event_type="pr_reviewed",
         repo="Gitcord",
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
         payload={
             "pr_number": 123,
             "state": "COMMENT",
@@ -175,7 +179,7 @@ def test_build_notification_message_pr_merged() -> None:
         github_user="contributor",
         event_type="pr_merged",
         repo="test-repo",
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
         payload={"pr_number": 999, "base_branch": "dev"},
     )
     msg = _build_notification_message(event, "pr_merged", "test-org", "contributor")
@@ -192,7 +196,7 @@ def test_build_notification_message_pr_merged_without_base_branch() -> None:
         github_user="contributor",
         event_type="pr_merged",
         repo="test-repo",
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
         payload={"pr_number": 100},
     )
     msg = _build_notification_message(event, "pr_merged", "test-org", "contributor")
@@ -207,7 +211,7 @@ def test_build_notification_message_pr_closed_template() -> None:
         github_user="contributor",
         event_type="pr_closed",
         repo="Gitcord",
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
         payload={
             "pr_number": 123,
             "pr_title": "Improve onboarding validation",
@@ -238,7 +242,7 @@ def test_send_notification_pr_closed() -> None:
         github_user="contributor",
         event_type="pr_closed",
         repo="Gitcord",
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
         payload={
             "pr_number": 123,
             "pr_title": "Improve onboarding validation",
@@ -270,7 +274,7 @@ def test_pr_closed_disabled() -> None:
         github_user="contributor",
         event_type="pr_closed",
         repo="Gitcord",
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
         payload={
             "pr_number": 123,
             "pr_author": "contributor",
@@ -299,7 +303,7 @@ def test_pr_closed_dedupe() -> None:
         github_user="contributor",
         event_type="pr_closed",
         repo="Gitcord",
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
         payload={
             "pr_number": 123,
             "pr_author": "contributor",
@@ -327,7 +331,7 @@ def test_send_notification_unverified_user() -> None:
         github_user="unverified",
         event_type="issue_assigned",
         repo="test-repo",
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
         payload={"issue_number": 123, "title": "Test"},
     )
     
@@ -353,7 +357,7 @@ def test_send_notification_verified_user() -> None:
         github_user="alice",
         event_type="issue_assigned",
         repo="test-repo",
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
         payload={"issue_number": 123, "title": "Test"},
     )
     
@@ -382,7 +386,7 @@ def test_send_notification_disabled_config() -> None:
         github_user="alice",
         event_type="issue_assigned",
         repo="test-repo",
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
         payload={"issue_number": 123, "title": "Test"},
     )
     
@@ -408,7 +412,7 @@ def test_send_notification_event_type_disabled() -> None:
         github_user="alice",
         event_type="issue_assigned",
         repo="test-repo",
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
         payload={"issue_number": 123, "title": "Test"},
     )
     
@@ -435,7 +439,7 @@ def test_send_notification_deduplication() -> None:
         github_user="alice",
         event_type="issue_assigned",
         repo="test-repo",
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
         payload={"issue_number": 123, "title": "Test"},
     )
     
@@ -461,7 +465,7 @@ def test_send_notification_dry_run() -> None:
         github_user="alice",
         event_type="issue_assigned",
         repo="test-repo",
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
         payload={"issue_number": 123, "title": "Test"},
     )
     
@@ -487,7 +491,7 @@ def test_send_notification_pr_reviewed_approved() -> None:
         github_user="reviewer",
         event_type="pr_reviewed",
         repo="test-repo",
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
         payload={
             "pr_number": 456,
             "state": "APPROVED",
@@ -519,7 +523,7 @@ def test_send_notification_pr_reviewed_comment() -> None:
         github_user="reviewer",
         event_type="pr_reviewed",
         repo="test-repo",
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
         payload={
             "pr_number": 456,
             "state": "COMMENT",
@@ -553,7 +557,7 @@ def test_send_notification_pr_reviewed_comment_disabled() -> None:
         github_user="reviewer",
         event_type="pr_reviewed",
         repo="test-repo",
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
         payload={
             "pr_number": 456,
             "state": "COMMENT",
@@ -587,7 +591,7 @@ def test_send_notification_pr_reviewed_comment_dedupe() -> None:
         github_user="reviewer",
         event_type="pr_reviewed",
         repo="test-repo",
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
         payload={
             "pr_number": 456,
             "state": "COMMENT",
@@ -618,7 +622,7 @@ def test_send_notification_channel_mode() -> None:
         github_user="alice",
         event_type="issue_assigned",
         repo="test-repo",
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
         payload={"issue_number": 123, "title": "Test"},
     )
     
@@ -646,7 +650,7 @@ def test_send_notification_audit_logging() -> None:
         github_user="alice",
         event_type="issue_assigned",
         repo="test-repo",
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
         payload={"issue_number": 123, "title": "Test"},
     )
     
@@ -675,7 +679,7 @@ def test_send_notification_issue_reopened() -> None:
         github_user="alice",
         event_type="issue_reopened",
         repo="Gitcord",
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
         payload={
             "issue_number": 123,
             "title": "Improve onboarding",
@@ -711,7 +715,7 @@ def test_send_notification_pr_reopened() -> None:
         github_user="bob",
         event_type="pr_reopened",
         repo="Gitcord",
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
         payload={
             "pr_number": 456,
             "title": "Improve onboarding validation",
@@ -747,7 +751,7 @@ def test_issue_reopened_disabled() -> None:
         github_user="alice",
         event_type="issue_reopened",
         repo="Gitcord",
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
         payload={
             "issue_number": 123,
             "title": "Improve onboarding",
@@ -777,7 +781,7 @@ def test_pr_reopened_disabled() -> None:
         github_user="bob",
         event_type="pr_reopened",
         repo="Gitcord",
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
         payload={
             "pr_number": 456,
             "title": "Improve onboarding validation",
@@ -807,7 +811,7 @@ def test_issue_reopened_dedupe() -> None:
         github_user="alice",
         event_type="issue_reopened",
         repo="Gitcord",
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
         payload={
             "issue_number": 123,
             "title": "Improve onboarding",
@@ -839,7 +843,7 @@ def test_pr_reopened_dedupe() -> None:
         github_user="bob",
         event_type="pr_reopened",
         repo="Gitcord",
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
         payload={
             "pr_number": 456,
             "title": "Improve onboarding validation",
@@ -871,7 +875,7 @@ def test_issue_reopened_without_assignee() -> None:
         github_user="",
         event_type="issue_reopened",
         repo="Gitcord",
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
         payload={
             "issue_number": 123,
             "title": "Improve onboarding",
@@ -897,7 +901,7 @@ def test_pr_opened_channel_notification_posts_to_mapped_channel() -> None:
         github_user="alice",
         event_type="pr_opened",
         repo="Gitcord-GithubDiscordBot",
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
         payload={"pr_number": 42, "title": "Test PR"},
     )
 
@@ -931,7 +935,7 @@ def test_pr_opened_channel_notification_skips_unmapped_repo() -> None:
         github_user="alice",
         event_type="pr_opened",
         repo="EduAid",
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
         payload={"pr_number": 1, "title": "Other"},
     )
 
@@ -954,7 +958,7 @@ def _pr_opened_event(*, github_user: str = "alice", repo: str = "Gitcord-GithubD
         github_user=github_user,
         event_type="pr_opened",
         repo=repo,
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
         payload={"pr_number": 42, "title": "Test PR"},
     )
 
@@ -1193,7 +1197,7 @@ def test_sanitize_discord_pr_title_neutralizes_injection() -> None:
             github_user="alice",
             event_type="pr_opened",
             repo="repo",
-            created_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
             payload={"pr_number": 7, "title": dirty},
         ),
         "AOSSIE-Org",
@@ -1210,7 +1214,7 @@ def test_sanitize_discord_pr_title_neutralizes_injection() -> None:
             github_user="alice",
             event_type="pr_opened",
             repo="repo",
-            created_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
             payload={"pr_number": 8, "title": "Normal title"},
         ),
         "AOSSIE-Org",
@@ -1254,5 +1258,69 @@ def test_pr_opened_github_link_comment_concurrent_claim(tmp_path) -> None:
 
     assert sorted(results) == [False, True]
     assert len(github_writer.comments) == 1
+    assert storage.was_notification_sent("pr_opened_github_link:Gitcord-GithubDiscordBot:42")
+
+
+def test_pr_opened_github_link_comment_claim_storage_failure() -> None:
+    storage = MockStorage()
+    storage.claim_notification_sent = MagicMock(  # type: ignore[method-assign]
+        side_effect=RuntimeError("database is locked")
+    )
+    github_writer = MockGithubWriter()
+    config = NotificationConfig(enabled=True, pr_opened_github_comment=True)
+    policy = MutationPolicy(mode=RunMode.ACTIVE, github_write_allowed=True, discord_write_allowed=True)
+
+    result = send_pr_opened_github_link_comment(
+        _pr_opened_event(github_user="stranger"),
+        storage,
+        github_writer,
+        policy,
+        config,
+        "AOSSIE-Org",
+        "https://discord.gg/hjUhu33uAn",
+    )
+
+    assert result is False
+    assert github_writer.comments == []
+
+
+def test_link_comment_timeout_preserves_claim_prevents_duplicate(tmp_path) -> None:
+    """Timeout after GitHub may have accepted must not create a duplicate /link comment."""
+    storage = SqliteStorage(str(tmp_path))
+    storage.init_schema()
+    adapter = GitHubRestAdapter(token="t", org="AOSSIE-Org", api_base="https://api.github.com")
+    client = MagicMock()
+    client.post.side_effect = httpx.TimeoutException(
+        "timeout",
+        request=httpx.Request("POST", "https://api.github.com/repos/o/r/issues/1/comments"),
+    )
+    adapter._client = client  # type: ignore[assignment]
+
+    config = NotificationConfig(enabled=True, pr_opened_github_comment=True)
+    policy = MutationPolicy(mode=RunMode.ACTIVE, github_write_allowed=True, discord_write_allowed=True)
+    event = _pr_opened_event(github_user="stranger")
+
+    first = send_pr_opened_github_link_comment(
+        event,
+        storage,
+        adapter,
+        policy,
+        config,
+        "AOSSIE-Org",
+        "https://discord.gg/hjUhu33uAn",
+    )
+    second = send_pr_opened_github_link_comment(
+        event,
+        storage,
+        adapter,
+        policy,
+        config,
+        "AOSSIE-Org",
+        "https://discord.gg/hjUhu33uAn",
+    )
+
+    assert first is True
+    assert second is False
+    assert client.post.call_count == 1
     assert storage.was_notification_sent("pr_opened_github_link:Gitcord-GithubDiscordBot:42")
 

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -44,9 +44,22 @@ class MockGitHubWriter:
     
     def __init__(self) -> None:
         self.files_written: list[tuple[str, str, str, str]] = []  # (owner, repo, path, content)
+        self.files_deleted: list[str] = []
     
     def write_file(self, owner: str, repo: str, file_path: str, content: str, commit_message: str, branch: str | None = None) -> bool:
         self.files_written.append((owner, repo, file_path, content))
+        return True
+
+    def delete_file(
+        self,
+        owner: str,
+        repo: str,
+        file_path: str,
+        commit_message: str,
+        branch: str | None = None,
+    ) -> bool:
+        self.files_deleted.append(file_path)
+        self.files_written = [entry for entry in self.files_written if entry[2] != file_path]
         return True
 
 
@@ -334,11 +347,20 @@ def test_write_snapshots_partial_write_does_not_advance_cursor() -> None:
     """Cursor advances only when every snapshot file write succeeds."""
 
     class PartialWriter(MockGitHubWriter):
+        def __init__(self) -> None:
+            super().__init__()
+            self.write_attempts: list[str] = []
+            self.successful_writes = 0
+
         def write_file(self, owner: str, repo: str, file_path: str, content: str, commit_message: str, branch: str | None = None) -> bool:
+            self.write_attempts.append(file_path)
             # Fail the second write attempt.
-            if len(self.files_written) >= 1:
+            if self.successful_writes >= 1:
                 return False
-            return super().write_file(owner, repo, file_path, content, commit_message, branch)
+            ok = super().write_file(owner, repo, file_path, content, commit_message, branch)
+            if ok:
+                self.successful_writes += 1
+            return ok
 
     class CursorStorage(MockStorage):
         def __init__(self) -> None:
@@ -379,5 +401,8 @@ def test_write_snapshots_partial_write_does_not_advance_cursor() -> None:
         period_end=datetime(2024, 1, 31, tzinfo=timezone.utc),
     )
 
-    assert len(github_writer.files_written) >= 1
+    assert len(github_writer.write_attempts) >= 2
+    assert github_writer.successful_writes == 1
+    assert len(github_writer.files_deleted) == 1
+    assert len(github_writer.files_written) == 0  # cleaned up after partial failure
     assert "snapshots" not in storage.cursors


### PR DESCRIPTION
## Summary
- Use a single non-retrying `create_issue_comment` POST and treat timeouts as success so SQLite claims prevent duplicate `/link` comments
- Make `send_pr_opened_channel_notification` use atomic claim/release (mirroring the GitHub comment path), with claim failures handled safely
- Clean up partially written snapshot files on failure and keep the snapshots cursor unchanged
- Add regression coverage for timeout/no-duplicate, claim storage failures, and stronger partial snapshot assertions

## Test plan
- [x] `pytest tests/test_notifications.py tests/test_snapshots.py`
- [ ] Confirm opening an unverified PR still posts at most one `/link` GitHub comment across concurrent syncs
- [ ] Confirm a failed mid-run snapshot write does not leave a partial directory and does not advance the cursor


Made with [Cursor](https://cursor.com)