### PR TITLE
who-is slash command to lookup Discord user by GitHub user…

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ Wait 30 seconds for commands to sync.
 - `/link` - Link your Discord account to GitHub (creates verification code)
 - `/verify-link` - Verify your GitHub link after adding code to bio/gist
 - `/profile` - Show contributor profile (GitHub, verification, socials, roles); optional Discord member
+- `/who-is` - Lookup a GitHub username to find their verified Discord account
 - `/unlink` - Unlink your GitHub identity
 - `/connect-social` - Connect X or LinkedIn (enter your username or profile URL)
 - `/disconnect-social` - Disconnect X or LinkedIn from Gitcord

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ Wait 30 seconds for commands to sync.
 - `/link` - Link your Discord account to GitHub (creates verification code)
 - `/verify-link` - Verify your GitHub link after adding code to bio/gist
 - `/profile` - Show contributor profile (GitHub, verification, socials, roles); optional Discord member
-- `/who-is` - Lookup a GitHub username to find their verified Discord account
+- `/who-is` - Look up a GitHub username, find the verified Discord account, and see whether verification is current or stale
 - `/unlink` - Unlink your GitHub identity
 - `/connect-social` - Connect X or LinkedIn (enter your username or profile URL)
 - `/disconnect-social` - Disconnect X or LinkedIn from Gitcord

--- a/src/ghdcbot/bot.py
+++ b/src/ghdcbot/bot.py
@@ -28,6 +28,7 @@ from ghdcbot.engine.metrics import (
 )
 from ghdcbot.engine.issue_assignment import (
     resolve_discord_to_github,
+    resolve_github_to_discord,
 )
 from ghdcbot.engine.open_prs import format_open_prs_report, list_open_prs_for_author
 from ghdcbot.engine.pr_list import (
@@ -815,6 +816,30 @@ def run_bot(config_path: str) -> None:
                 suppress_embeds=True,
             )
 
+    @tree.command(
+        name="who-is",
+        description="Lookup a GitHub username to find their verified Discord account",
+        guild=discord.Object(id=guild_id)
+    )
+    @app_commands.describe(github_username = "text")
+    async def who_is_cmd(interaction: discord.Interaction, github_username: str) -> None:
+        await interaction.response.defer(ephemeral=True)
+        # Pass storage into the standalone resolve_github_to_discord helper function
+        discord_user_id = resolve_github_to_discord(storage, github_username)
+        if discord_user_id:
+            status_info = storage.get_identity_status(discord_user_id) if hasattr(storage, "get_identity_status") else {}
+            is_stale = status_info.get("is_stale", False)
+            status_badge = "✅ Verified" if not is_stale else "⚠️ Verification may be outdated"
+            await interaction.followup.send(
+                f"GitHub user **{github_username}** is **{status_badge}** as Discord member <@{discord_user_id}>.",
+                ephemeral=True
+            )
+        else:
+            await interaction.followup.send(
+                f"❌ GitHub user **{github_username}** is not linked or verified with any Discord account.",
+                ephemeral=True
+            )
+        
     def command_permission_check(command_name: str):
         """Restrict slash commands via discord.command_permissions or legacy issue_assignees."""
 

--- a/src/ghdcbot/bot.py
+++ b/src/ghdcbot/bot.py
@@ -362,6 +362,7 @@ def run_bot(config_path: str) -> None:
     @app_commands.describe(github_username="Your GitHub username")
     async def link_cmd(interaction: discord.Interaction, github_username: str) -> None:
         await interaction.response.defer(ephemeral=True)
+        github_username = github_username.strip()
         discord_user_id = str(interaction.user.id)
         max_age_days = None
         if getattr(config, "identity", None) is not None:
@@ -392,6 +393,7 @@ def run_bot(config_path: str) -> None:
     @app_commands.describe(github_username="Your GitHub username")
     async def verify_link_cmd(interaction: discord.Interaction, github_username: str) -> None:
         await interaction.response.defer(ephemeral=True)
+        github_username = github_username.strip()
         discord_user_id = str(interaction.user.id)
         try:
             ok, location = await asyncio.to_thread(
@@ -821,14 +823,26 @@ def run_bot(config_path: str) -> None:
         description="Lookup a GitHub username to find their verified Discord account",
         guild=discord.Object(id=guild_id)
     )
-    @app_commands.describe(github_username = "text")
+    @app_commands.describe(github_username="GitHub username to look up")
     async def who_is_cmd(interaction: discord.Interaction, github_username: str) -> None:
         await interaction.response.defer(ephemeral=True)
+        github_username = github_username.strip()
         # Pass storage into the standalone resolve_github_to_discord helper function
         discord_user_id = resolve_github_to_discord(storage, github_username)
         if discord_user_id:
-            status_info = storage.get_identity_status(discord_user_id) if hasattr(storage, "get_identity_status") else {}
-            is_stale = status_info.get("is_stale", False)
+            get_status = getattr(storage, "get_identity_status", None)
+            max_age_days = None
+            if getattr(config, "identity", None) is not None:
+                max_age_days = getattr(config.identity, "verified_max_age_days", None)
+            
+            status_info = {}
+            if callable(get_status):
+                try:
+                    status_info = get_status(discord_user_id, max_age_days=max_age_days) or {}
+                except Exception:
+                    status_info = {}
+            
+            is_stale = status_info.get("is_stale", True) if status_info else True
             status_badge = "✅ Verified" if not is_stale else "⚠️ Verification may be outdated"
             await interaction.followup.send(
                 f"GitHub user **{github_username}** is **{status_badge}** as Discord member <@{discord_user_id}>.",

--- a/src/ghdcbot/engine/issue_assignment.py
+++ b/src/ghdcbot/engine/issue_assignment.py
@@ -78,8 +78,9 @@ def resolve_github_to_discord(
     if not callable(verified):
         return None
     
+    target = (github_user or "").strip().lower()
     for mapping in verified():
-        if mapping.github_user == github_user:
+        if (mapping.github_user or "").strip().lower() == target:
             return mapping.discord_user_id
     
     return None

--- a/tests/test_who_is_command.py
+++ b/tests/test_who_is_command.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -175,4 +175,30 @@ async def test_who_is_case_insensitive_matching() -> None:
 
     assert len(interaction.followup.messages) == 1
     assert "as Discord member <@999888777>" in interaction.followup.messages[0]["content"]
+
+
+@pytest.mark.asyncio
+async def test_who_is_mocked_resolver_dependency() -> None:
+    """Test /who-is by explicitly mocking resolve_github_to_discord dependency."""
+    storage = MagicMock()
+    config = MagicMock()
+    config.identity.verified_max_age_days = 30
+    storage.get_identity_status.return_value = {
+        "status": "verified",
+        "is_stale": False,
+        "github_user": "mock_user",
+    }
+
+    interaction = _FakeInteraction()
+    with patch("ghdcbot.engine.issue_assignment.resolve_github_to_discord", return_value="555666777") as mock_resolve:
+        await _run_who_is_handler(interaction, storage, config, "mock_user")
+        mock_resolve.assert_called_once_with(storage, "mock_user")
+
+    assert len(interaction.followup.messages) == 1
+    assert (
+        interaction.followup.messages[0]["content"]
+        == "GitHub user **mock_user** is **✅ Verified** as Discord member <@555666777>."
+    )
+    assert interaction.followup.messages[0]["ephemeral"] is True
+
 

--- a/tests/test_who_is_command.py
+++ b/tests/test_who_is_command.py
@@ -177,6 +177,9 @@ async def test_who_is_case_insensitive_matching() -> None:
     assert "as Discord member <@999888777>" in interaction.followup.messages[0]["content"]
 
 
+import sys
+
+
 @pytest.mark.asyncio
 async def test_who_is_mocked_resolver_dependency() -> None:
     """Test /who-is by explicitly mocking resolve_github_to_discord dependency."""
@@ -190,7 +193,7 @@ async def test_who_is_mocked_resolver_dependency() -> None:
     }
 
     interaction = _FakeInteraction()
-    with patch("ghdcbot.engine.issue_assignment.resolve_github_to_discord", return_value="555666777") as mock_resolve:
+    with patch.object(sys.modules[__name__], "resolve_github_to_discord", return_value="555666777") as mock_resolve:
         await _run_who_is_handler(interaction, storage, config, "mock_user")
         mock_resolve.assert_called_once_with(storage, "mock_user")
 

--- a/tests/test_who_is_command.py
+++ b/tests/test_who_is_command.py
@@ -1,0 +1,152 @@
+"""Tests for the /who-is slash command handler and freshness calculation."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from ghdcbot.engine.issue_assignment import resolve_github_to_discord
+
+
+class _FakeFollowup:
+    def __init__(self) -> None:
+        self.messages: list[dict] = []
+
+    async def send(self, content: str | None = None, **kwargs) -> None:
+        self.messages.append({"content": content, **kwargs})
+
+
+class _FakeResponse:
+    def __init__(self) -> None:
+        self.deferred = False
+        self.ephemeral = False
+
+    async def defer(self, *, ephemeral: bool = False) -> None:
+        self.deferred = True
+        self.ephemeral = ephemeral
+
+
+class _FakeInteraction:
+    def __init__(self, user_id: int = 123) -> None:
+        self.user = MagicMock(id=user_id)
+        self.response = _FakeResponse()
+        self.followup = _FakeFollowup()
+
+
+async def _run_who_is_handler(
+    interaction: _FakeInteraction,
+    storage: MagicMock,
+    config: MagicMock,
+    github_username: str,
+) -> None:
+    """Helper representing the who_is_cmd handler logic in bot.py."""
+    await interaction.response.defer(ephemeral=True)
+    github_username = github_username.strip()
+    discord_user_id = resolve_github_to_discord(storage, github_username)
+
+    if discord_user_id:
+        get_status = getattr(storage, "get_identity_status", None)
+        max_age_days = None
+        if getattr(config, "identity", None) is not None:
+            max_age_days = getattr(config.identity, "verified_max_age_days", None)
+
+        status_info = {}
+        if callable(get_status):
+            try:
+                status_info = get_status(discord_user_id, max_age_days=max_age_days) or {}
+            except Exception:
+                status_info = {}
+
+        is_stale = status_info.get("is_stale", True) if status_info else True
+        status_badge = "✅ Verified" if not is_stale else "⚠️ Verification may be outdated"
+        await interaction.followup.send(
+            f"GitHub user **{github_username}** is **{status_badge}** as Discord member <@{discord_user_id}>.",
+            ephemeral=True,
+        )
+    else:
+        await interaction.followup.send(
+            f"❌ GitHub user **{github_username}** is not linked or verified with any Discord account.",
+            ephemeral=True,
+        )
+
+
+@pytest.mark.asyncio
+async def test_who_is_current_verified_mapping() -> None:
+    """Test /who-is returns ✅ Verified badge for active fresh mappings."""
+    storage = MagicMock()
+    config = MagicMock()
+    config.identity.verified_max_age_days = 30
+
+    mapping_record = MagicMock()
+    mapping_record.github_user = "octocat"
+    mapping_record.discord_user_id = "999888777"
+    storage.list_verified_identity_mappings.return_value = [mapping_record]
+
+    storage.get_identity_status.return_value = {
+        "status": "verified",
+        "is_stale": False,
+        "github_user": "octocat",
+    }
+
+    interaction = _FakeInteraction()
+    await _run_who_is_handler(interaction, storage, config, "octocat")
+
+    storage.get_identity_status.assert_called_once_with("999888777", max_age_days=30)
+    assert interaction.response.deferred is True
+    assert interaction.response.ephemeral is True
+    assert len(interaction.followup.messages) == 1
+    assert (
+        interaction.followup.messages[0]["content"]
+        == "GitHub user **octocat** is **✅ Verified** as Discord member <@999888777>."
+    )
+    assert interaction.followup.messages[0]["ephemeral"] is True
+
+
+@pytest.mark.asyncio
+async def test_who_is_stale_mapping_non_default_freshness_window() -> None:
+    """Test /who-is passes non-default verified_max_age_days and outputs ⚠️ Verification may be outdated badge."""
+    storage = MagicMock()
+    config = MagicMock()
+    # Non-default freshness window of 14 days
+    config.identity.verified_max_age_days = 14
+
+    mapping_record = MagicMock()
+    mapping_record.github_user = "stale_dev"
+    mapping_record.discord_user_id = "111222333"
+    storage.list_verified_identity_mappings.return_value = [mapping_record]
+
+    storage.get_identity_status.return_value = {
+        "status": "verified_stale",
+        "is_stale": True,
+        "github_user": "stale_dev",
+    }
+
+    interaction = _FakeInteraction()
+    await _run_who_is_handler(interaction, storage, config, "  stale_dev  ")
+
+    storage.get_identity_status.assert_called_once_with("111222333", max_age_days=14)
+    assert len(interaction.followup.messages) == 1
+    assert (
+        interaction.followup.messages[0]["content"]
+        == "GitHub user **stale_dev** is **⚠️ Verification may be outdated** as Discord member <@111222333>."
+    )
+    assert interaction.followup.messages[0]["ephemeral"] is True
+
+
+@pytest.mark.asyncio
+async def test_who_is_missing_github_link() -> None:
+    """Test /who-is returns failure message when no GitHub link exists in storage."""
+    storage = MagicMock()
+    config = MagicMock()
+    storage.list_verified_identity_mappings.return_value = []
+
+    interaction = _FakeInteraction()
+    await _run_who_is_handler(interaction, storage, config, "unknown_user")
+
+    assert len(interaction.followup.messages) == 1
+    assert (
+        interaction.followup.messages[0]["content"]
+        == "❌ GitHub user **unknown_user** is not linked or verified with any Discord account."
+    )
+    assert interaction.followup.messages[0]["ephemeral"] is True

--- a/tests/test_who_is_command.py
+++ b/tests/test_who_is_command.py
@@ -150,3 +150,29 @@ async def test_who_is_missing_github_link() -> None:
         == "❌ GitHub user **unknown_user** is not linked or verified with any Discord account."
     )
     assert interaction.followup.messages[0]["ephemeral"] is True
+
+
+@pytest.mark.asyncio
+async def test_who_is_case_insensitive_matching() -> None:
+    """Test /who-is resolves GitHub username regardless of character case."""
+    storage = MagicMock()
+    config = MagicMock()
+    config.identity.verified_max_age_days = 30
+
+    mapping_record = MagicMock()
+    mapping_record.github_user = "OctoCat"
+    mapping_record.discord_user_id = "999888777"
+    storage.list_verified_identity_mappings.return_value = [mapping_record]
+
+    storage.get_identity_status.return_value = {
+        "status": "verified",
+        "is_stale": False,
+        "github_user": "OctoCat",
+    }
+
+    interaction = _FakeInteraction()
+    await _run_who_is_handler(interaction, storage, config, "octocat")
+
+    assert len(interaction.followup.messages) == 1
+    assert "as Discord member <@999888777>" in interaction.followup.messages[0]["content"]
+


### PR DESCRIPTION
### Description

Introduces the `/who-is <github_username>` slash command for Gitcord. 

In large organizations with hundreds of contributors, maintainers and mentors often review pull requests or issue comments on GitHub (e.g., from `@PrithvijitBose`) and need to discuss urgent details on Discord. `/who-is` allows maintainers to look up any GitHub handle directly in Discord to immediately find their verified Discord account mention (`<@discord_user_id>`) and check whether their verification status is active or stale.

---

### Screenshots/Recordings:


https://github.com/user-attachments/assets/eecd14ac-71c5-46c1-b68e-19d5116c398c

---

### Additional Notes:

- **Reverse Resolution**: Utilizes `resolve_github_to_discord(storage, github_username)` to query verified identity mappings stored in SQLite.
- **Documentation**: Updated `README.md` under the **Identity Linking** slash commands section.

---

### AI Usage Disclosure:

We encourage contributors to use AI tools responsibly when creating Pull Requests. While AI can be a valuable aid, it is essential to ensure that your contributions meet the task requirements, build successfully, include relevant tests, and pass all linters. Submissions that do not meet these standards may be closed without warning to maintain the quality and integrity of the project. Please take the time to understand the changes you are proposing and their impact. AI slop is strongly discouraged and may lead to banning and blocking. Do not spam our repos with AI slop.




---

## Checklist

- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions
- [x] If applicable, I have made corresponding changes or additions to the documentation
- [x] If applicable, I have made corresponding changes or additions to tests
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [x] I have filled this PR template completely and carefully, and I understand that my PR may be closed without review otherwise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `/who-is` command for looking up a GitHub username.
  * Displays the associated verified Discord account and whether verification is current or stale.
  * Reports when no verified account link is found.
  * Improved username matching by ignoring surrounding whitespace and letter case.

* **Documentation**
  * Added `/who-is` command information to the README.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->