### PR TITLE
fix: unbreak Python Tests after PR #38 json= client.request

### DIFF
--- a/tests/test_github_ingestion_comments.py
+++ b/tests/test_github_ingestion_comments.py
@@ -12,7 +12,9 @@ class _MockClient:
     def __init__(self, routes: dict[str, list]) -> None:
         self._routes = routes
 
-    def request(self, method: str, path: str, params: dict | None = None) -> httpx.Response:
+    def request(
+        self, method: str, path: str, params: dict | None = None, **kwargs: object
+    ) -> httpx.Response:
         data = self._routes.get(path, [])
         headers = {"X-RateLimit-Remaining": "10"}
         return httpx.Response(200, json=data, headers=headers)

--- a/tests/test_github_ingestion_lifecycle_events.py
+++ b/tests/test_github_ingestion_lifecycle_events.py
@@ -16,7 +16,9 @@ class _MockClient:
     def __init__(self, routes: dict[str, list]) -> None:
         self._routes = routes
 
-    def request(self, method: str, path: str, params: dict | None = None) -> httpx.Response:
+    def request(
+        self, method: str, path: str, params: dict | None = None, **kwargs: object
+    ) -> httpx.Response:
         data = self._routes.get(path, [])
         headers = {"X-RateLimit-Remaining": "10"}
         return httpx.Response(200, json=data, headers=headers)

--- a/tests/test_github_rate_limit.py
+++ b/tests/test_github_rate_limit.py
@@ -14,7 +14,9 @@ class _SequenceMockClient:
         self._outcomes = list(outcomes)
         self.call_count = 0
 
-    def request(self, method: str, path: str, params: dict | None = None) -> httpx.Response:
+    def request(
+        self, method: str, path: str, params: dict | None = None, **kwargs: object
+    ) -> httpx.Response:
         self.call_count += 1
         outcome = self._outcomes.pop(0)
         if isinstance(outcome, Exception):

--- a/tests/test_github_retry.py
+++ b/tests/test_github_retry.py
@@ -11,7 +11,9 @@ class _SequenceMockClient:
         self._outcomes = list(outcomes)
         self.call_count = 0
 
-    def request(self, method: str, path: str, params: dict | None = None) -> httpx.Response:
+    def request(
+        self, method: str, path: str, params: dict | None = None, **kwargs: object
+    ) -> httpx.Response:
         self.call_count += 1
         outcome = self._outcomes.pop(0)
         if isinstance(outcome, Exception):


### PR DESCRIPTION
## Summary
- After merging #38, `GitHubRestAdapter` calls `_client.request(..., json=json_body)`.
- Several unit-test mock clients only accepted `method/path/params`, so CI on `main` failed with 23 `TypeError: unexpected keyword argument 'json'`.
- Updated mocks in retry / rate-limit / ingestion tests to accept `**kwargs` (same pattern as `test_open_prs_search.py`).

## Test plan
- [x] `pytest tests/test_github_retry.py tests/test_github_rate_limit.py tests/test_github_ingestion_comments.py tests/test_github_ingestion_lifecycle_events.py`
- [ ] Confirm GitHub Actions **Python Tests** is green on this PR
- [ ] After merge, confirm **Python Tests** is green on `main`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage compatibility for requests that include additional optional parameters.
  * Preserved existing mocked response, sequencing, and exception behavior across ingestion, rate-limit, and retry scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->