### PR TITLE
feat: Week 11 remote gitcord.yaml org config

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -267,13 +267,17 @@ Your active config is always **`config/config.yaml`** (gitignored — create it 
 |--------------|-----------|
 | Docker | `config/docker-example.yaml` |
 | Local Python | `config/example.yaml` |
+| Remote org settings (AOSSIE) | `config/examples/bootstrap-remote-aossie.yaml` + publish `config/examples/remote-gitcord-aossie.yaml` to `AOSSIE-Org/.github/gitcord.yaml` |
+| Remote org settings (Stability Nexus) | `config/examples/bootstrap-remote-stability-nexus.yaml` + publish `config/examples/remote-gitcord-stability-nexus.yaml` to `StabilityNexus/.github/gitcord.yaml` |
 
-**Minimum edits:**
+**Minimum edits (local full config):**
 
 1. `github.org` — your GitHub organization name
 2. `discord.guild_id` — server ID from [Step 3.6](#36-copy-server-id-guild-id)
 3. `role_mappings` / `assignments.issue_assignees` — use **exact Discord role names** that exist in your server
 4. Local only: `runtime.data_dir: "./data"`
+
+**Remote config:** with `remote_config.enabled: true`, org settings (channels, repos, notifications, guild id) load from GitHub. The local file only needs `runtime.data_dir`, `remote_config`, and token placeholders. Edit channel maps on GitHub, then restart Gitcord to pick up changes. Tokens never go in the remote file.
 
 Start with defaults in the template:
 
@@ -283,7 +287,7 @@ Start with defaults in the template:
 
 Optional blocks (`notifications`, `snapshots`, `repos` filter) are commented in `config/example.yaml` — enable only when needed.
 
-**Reference configs** (not used automatically): `config/examples/` (e.g. AOSSIE sample).
+**Reference configs** (not used automatically): `config/examples/` (e.g. AOSSIE sample, remote bootstrap templates).
 
 ### 6.3 Validate setup (recommended)
 

--- a/config/docker-example.yaml
+++ b/config/docker-example.yaml
@@ -1,5 +1,14 @@
 # Gitcord config for Docker: data_dir must be /data (mounted volume).
 # Copy to config/config.yaml and set github.org, discord.guild_id, and tokens in .env.
+#
+# Optional (Week 11+): load non-secret org settings from GitHub instead of this file.
+# See config/examples/bootstrap-remote-aossie.yaml and docs/DOCKER.md → Remote config.
+# remote_config:
+#   enabled: true
+#   owner: "Your-Org"
+#   repo: ".github"
+#   path: "gitcord.yaml"
+#   ref: "main"
 
 runtime:
   mode: "dry-run"

--- a/config/examples/bootstrap-remote-aossie.yaml
+++ b/config/examples/bootstrap-remote-aossie.yaml
@@ -1,0 +1,23 @@
+# Thin local bootstrap for AOSSIE when using remote gitcord.yaml.
+# Copy to config/config.yaml for Docker:
+#   cp config/examples/bootstrap-remote-aossie.yaml config/config.yaml
+#
+# Org settings load from: https://github.com/AOSSIE-Org/.github/gitcord.yaml
+# Secrets stay in .env (GITHUB_TOKEN / Discord token / GitHub App key).
+
+runtime:
+  data_dir: "/data"
+
+remote_config:
+  enabled: true
+  owner: "AOSSIE-Org"
+  repo: ".github"
+  path: "gitcord.yaml"
+  ref: "master"
+
+github:
+  token: "${GITHUB_TOKEN}"
+  api_base: "https://api.github.com"
+
+discord:
+  token: "${DISCORD_TOKEN}"

--- a/config/examples/bootstrap-remote-stability-nexus.yaml
+++ b/config/examples/bootstrap-remote-stability-nexus.yaml
@@ -1,0 +1,23 @@
+# Thin local bootstrap for Stability Nexus when using remote gitcord.yaml.
+# Copy for the SN compose stack (gitignored local compose may point here), or:
+#   cp config/examples/bootstrap-remote-stability-nexus.yaml config/stability-nexus.yaml
+#
+# Org settings load from: https://github.com/StabilityNexus/.github/gitcord.yaml
+# Secrets stay in .env.stability-nexus.
+
+runtime:
+  data_dir: "/data"
+
+remote_config:
+  enabled: true
+  owner: "StabilityNexus"
+  repo: ".github"
+  path: "gitcord.yaml"
+  ref: "main"
+
+github:
+  token: "${GITHUB_TOKEN}"
+  api_base: "https://api.github.com"
+
+discord:
+  token: "${DISCORD_TOKEN}"

--- a/config/examples/remote-gitcord-aossie.yaml
+++ b/config/examples/remote-gitcord-aossie.yaml
@@ -1,0 +1,105 @@
+# Publish this file to: https://github.com/AOSSIE-Org/.github/gitcord.yaml
+# Non-secret org settings for Gitcord. Tokens stay in each machine's .env.
+# Local Docker uses config/examples/bootstrap-remote-aossie.yaml as a thin pointer.
+
+runtime:
+  mode: active
+  log_level: INFO
+  data_dir: /data
+  github_adapter: ghdcbot.adapters.github.rest:GitHubRestAdapter
+  discord_adapter: ghdcbot.adapters.discord.api:DiscordApiAdapter
+  storage_adapter: ghdcbot.adapters.storage.sqlite:SqliteStorage
+  activity_period_days: 7
+  enable_discord_role_updates: false
+github:
+  org: AOSSIE-Org
+  api_base: https://api.github.com
+  permissions:
+    read: true
+    write: true
+  user_fallback: false
+  repos:
+    mode: allow
+    names:
+    - Agora-Blockchain
+    - BabyNest
+    - DebateAI
+    - Devr.AI
+    - EduAid
+    - Ell-ena
+    - Gitcord-GithubDiscordBot
+    - Gitcord-Test
+    - InPactAI
+    - NeuroTrack
+    - Perspective
+    - PictoPy
+    - PullRequestDashboard
+    - Rein
+    - Resonate
+    - Resonate-Website
+    - SkillBot
+    - Skills
+    - Template-Repo
+discord:
+  guild_id: '1022871757289422898'
+  permissions:
+    read: true
+    write: true
+  invite_url: https://discord.gg/hjUhu33uAn
+  unrestricted_slash_commands: false
+  command_permissions:
+    assign-issue:
+      role_names:
+      - Mentor
+      allow_discord_administrators: true
+    issue-requests:
+      role_names:
+      - Mentor
+      allow_discord_administrators: true
+    sync:
+      role_names:
+      - Mentor
+      allow_discord_administrators: true
+  activity_channel_id: null
+  pr_preview_channels: []
+  pr_open_channels:
+    Agora-Blockchain: '1331983948175380581'
+    BabyNest: '1339225155481763882'
+    DebateAI: '1312986807914463252'
+    Devr.AI: '1345044976794472498'
+    EduAid: '1317912993786499072'
+    Ell-ena: '1349032611267477586'
+    Gitcord-GithubDiscordBot: '1465995983791063140'
+    Gitcord-Test: '1524006041677729823'
+    InPactAI: '1345044736515379210'
+    NeuroTrack: '1347053043711082507'
+    Perspective: '1339226574276268144'
+    PictoPy: '1311271974630330388'
+    Rein: '1467370739152846899'
+    Resonate: '1317913663360864346'
+    Resonate-Website: '1317913663360864346'
+  notifications:
+    enabled: true
+    issue_assignment: false
+    pr_review_requested: true
+    pr_review_result: true
+    pr_review_comment: true
+    pr_merged: true
+    pr_closed: true
+    issue_reopened: true
+    pr_reopened: true
+    pr_opened: true
+    pr_opened_github_comment: true
+    coderabbit_reminders: false
+    coderabbit_reminder_after_hours: 48
+    channel_id: null
+assignments:
+  review_roles: []
+  issue_assignees: []
+  issue_request_eligible_roles: []
+repo_contributor_roles: {}
+snapshots:
+  enabled: true
+  repo_path: AOSSIE-Org/.gitcord
+  branch: main
+  min_interval_hours: 24

--- a/config/examples/remote-gitcord-stability-nexus.yaml
+++ b/config/examples/remote-gitcord-stability-nexus.yaml
@@ -1,0 +1,118 @@
+# Publish this file to: https://github.com/StabilityNexus/.github/gitcord.yaml
+# Non-secret org settings for Gitcord. Tokens stay in each machine's .env.
+# Local Docker uses config/examples/bootstrap-remote-stability-nexus.yaml as a thin pointer.
+
+runtime:
+  mode: active
+  log_level: INFO
+  data_dir: /data
+  github_adapter: ghdcbot.adapters.github.rest:GitHubRestAdapter
+  discord_adapter: ghdcbot.adapters.discord.api:DiscordApiAdapter
+  storage_adapter: ghdcbot.adapters.storage.sqlite:SqliteStorage
+  activity_period_days: 7
+  enable_discord_role_updates: false
+github:
+  org: StabilityNexus
+  api_base: https://api.github.com
+  permissions:
+    read: true
+    write: false
+  user_fallback: false
+  repos:
+    mode: allow
+    names:
+    - MiniChain
+    - WalletLink
+    - OrbOracle-EVM-Frontend
+    - OrbOracle-Formalization
+    - OrbOracle-Poster
+    - OrbOracle-Solana
+    - Fate-EVM-Frontend
+    - Fate-LandingPage
+    - Fate-Solana
+    - Fate-Solana-WebUI
+    - Fate-Sui-Frontend
+    - Tectonic-EVM-WebUI
+    - Chainvoice
+    - Bene-FundRaising-EVM-Contracts
+    - Bene-FundRaising-EVM-Frontend
+    - Bene-LandingPage
+    - Windmill-EVM-Contracts
+    - Windmill-EVM-Keeper
+    - Windmill-EVM-WebUI
+    - Gluon-EVM
+    - Gluon-EVM-WebUI
+    - Gluon-Ergo-Contracts
+    - Gluon-Ergo-SDK
+    - Gluon-Ergo-UI
+    - Gluon-Formalization-Coq
+    - Gluon-LandingPage
+    - IdentityTokens-EVM-Contracts
+    - IdentityTokens-EVM-Frontend
+discord:
+  guild_id: '995968619034984528'
+  permissions:
+    read: true
+    write: true
+  unrestricted_slash_commands: false
+  command_permissions:
+    sync:
+      role_names:
+      - Mentor
+      allow_discord_administrators: true
+  activity_channel_id: null
+  pr_preview_channels: []
+  pr_open_channels:
+    MiniChain: '1471163521877410045'
+    WalletLink: '1525366355682000948'
+    OrbOracle-EVM-Frontend: '1504406274693922837'
+    OrbOracle-Formalization: '1504406274693922837'
+    OrbOracle-Poster: '1504406274693922837'
+    OrbOracle-Solana: '1504406274693922837'
+    Fate-EVM-Frontend: '1324064370883301386'
+    Fate-LandingPage: '1324064370883301386'
+    Fate-Solana: '1324064370883301386'
+    Fate-Solana-WebUI: '1324064370883301386'
+    Fate-Sui-Frontend: '1324064370883301386'
+    Tectonic-EVM-WebUI: '1503320626096635935'
+    Chainvoice: '1328282666335993856'
+    Bene-FundRaising-EVM-Contracts: '1311251432359591967'
+    Bene-FundRaising-EVM-Frontend: '1311251432359591967'
+    Bene-LandingPage: '1311251432359591967'
+    Windmill-EVM-Contracts: '1458849723296256050'
+    Windmill-EVM-Keeper: '1458849723296256050'
+    Windmill-EVM-WebUI: '1458849723296256050'
+    Gluon-EVM: '1283781488587837492'
+    Gluon-EVM-WebUI: '1283781488587837492'
+    Gluon-Ergo-Contracts: '1283794841482035224'
+    Gluon-Ergo-SDK: '1283794841482035224'
+    Gluon-Ergo-UI: '1283794841482035224'
+    Gluon-Formalization-Coq: '1283791094651420734'
+    Gluon-LandingPage: '1283791094651420734'
+    IdentityTokens-EVM-Contracts: '1461697098767532269'
+    IdentityTokens-EVM-Frontend: '1461697098767532269'
+  notifications:
+    enabled: true
+    issue_assignment: false
+    pr_review_requested: true
+    pr_review_result: true
+    pr_review_comment: true
+    pr_merged: true
+    pr_closed: true
+    issue_reopened: true
+    pr_reopened: true
+    pr_opened: true
+    pr_opened_github_comment: true
+    coderabbit_reminders: false
+    coderabbit_reminder_after_hours: 48
+    channel_id: null
+assignments:
+  review_roles: []
+  issue_assignees: []
+  issue_request_eligible_roles: []
+repo_contributor_roles: {}
+snapshots:
+  enabled: true
+  repo_path: StabilityNexus/.gitcord
+  branch: main
+  min_interval_hours: 24

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -38,6 +38,17 @@ For GitHub PAT setup, Discord bot creation, and first-time configuration, start 
 
    Edit `config/config.yaml`: set `github.org`, `discord.guild_id`, and any other options. **Do not change `data_dir`**; it must stay `/data` so the mounted volume is used.
 
+   **Remote org config (optional):** mentors can keep non-secret settings in the org’s `.github` repo (`gitcord.yaml`) so every Gitcord instance shares one source of truth. Secrets stay in `.env`.
+
+   ```bash
+   # Example AOSSIE bootstrap (tokens still from .env)
+   cp config/examples/bootstrap-remote-aossie.yaml config/config.yaml
+   # Publish org settings once:
+   #   config/examples/remote-gitcord-aossie.yaml → AOSSIE-Org/.github/gitcord.yaml
+   ```
+
+   On startup Gitcord fetches the remote YAML, caches it under `/data/remote_config_cache.yaml`, and expands `${GITHUB_TOKEN}` / `${DISCORD_TOKEN}` from `.env`. If GitHub is temporarily unreachable, the last cache is used. Set `remote_config.ref` to the `.github` repo’s default branch (`master` for AOSSIE-Org/.github, `main` for StabilityNexus/.github), or omit `ref` to use the repo default.
+
 3. **Start the bot**:
 
    ```bash

--- a/environment_variables.md
+++ b/environment_variables.md
@@ -21,6 +21,8 @@ Missing required environment variable: GITHUB_TOKEN
 
 **Note:** Empty values (`GITHUB_TOKEN=`) are rejected at startup. Run `ghdcbot --config config/config.yaml validate` to confirm both tokens work against the live APIs before starting the bot.
 
+When `remote_config.enabled: true`, the same `GITHUB_TOKEN` (or GitHub App installation credentials) is also used to fetch `gitcord.yaml` from the org `.github` repo at startup.
+
 ---
 
 ## Preflight validation

--- a/src/ghdcbot/config/loader.py
+++ b/src/ghdcbot/config/loader.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import os
 import re
 from pathlib import Path
@@ -9,8 +10,16 @@ import yaml
 from dotenv import load_dotenv
 from pydantic import ValidationError
 
-from ghdcbot.config.models import BotConfig
+from ghdcbot.config.models import BotConfig, RemoteConfigSettings
+from ghdcbot.config.remote import (
+    CACHE_FILENAME,
+    CACHE_META_FILENAME,
+    apply_bootstrap_overlays,
+    fetch_remote_config_yaml,
+)
 from ghdcbot.core.errors import ConfigError
+
+logger = logging.getLogger(__name__)
 
 _ACTIVE_CONFIG: BotConfig | None = None
 _ENV_PATTERN = re.compile(r"\$\{([A-Z0-9_]+)\}")
@@ -52,15 +61,137 @@ def _load_yaml(config_path: Path) -> Any:
         raise ConfigError(f"Failed to read config file: {config_path}") from exc
 
 
+def _load_yaml_mapping(path: Path) -> dict[str, Any]:
+    raw = _load_yaml(path)
+    if raw is None:
+        raise ConfigError(f"Config file is empty: {path}")
+    if not isinstance(raw, dict):
+        raise ConfigError(f"Config file must be a YAML mapping: {path}")
+    return raw
+
+
+def _write_remote_cache(
+    data_dir: str,
+    remote_data: dict[str, Any],
+    *,
+    source: str,
+    sha: str | None,
+) -> None:
+    cache_dir = Path(data_dir)
+    try:
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        cache_path = cache_dir / CACHE_FILENAME
+        meta_path = cache_dir / CACHE_META_FILENAME
+        with cache_path.open("w", encoding="utf-8") as handle:
+            yaml.safe_dump(remote_data, handle, sort_keys=False, allow_unicode=True)
+        with meta_path.open("w", encoding="utf-8") as handle:
+            yaml.safe_dump({"source": source, "sha": sha}, handle, sort_keys=False)
+    except OSError as exc:
+        logger.warning(
+            "Failed to write remote config cache",
+            extra={"data_dir": data_dir, "error": str(exc)},
+        )
+
+
+def _read_remote_cache(data_dir: str) -> tuple[dict[str, Any], str | None, str | None] | None:
+    cache_path = Path(data_dir) / CACHE_FILENAME
+    if not cache_path.is_file():
+        return None
+    try:
+        data = _load_yaml_mapping(cache_path)
+    except ConfigError:
+        return None
+    source = None
+    sha = None
+    meta_path = Path(data_dir) / CACHE_META_FILENAME
+    if meta_path.is_file():
+        try:
+            meta = _load_yaml_mapping(meta_path)
+            source = meta.get("source") if isinstance(meta.get("source"), str) else None
+            sha = meta.get("sha") if isinstance(meta.get("sha"), str) else None
+        except ConfigError:
+            pass
+    return data, source, sha
+
+
+def _resolve_remote_settings(bootstrap: dict[str, Any]) -> RemoteConfigSettings | None:
+    raw = bootstrap.get("remote_config")
+    if raw is None:
+        return None
+    try:
+        return RemoteConfigSettings.model_validate(raw)
+    except ValidationError as exc:
+        raise ConfigError(f"Invalid remote_config: {exc}") from exc
+
+
+def _merge_remote_into_bootstrap(bootstrap: dict[str, Any]) -> dict[str, Any]:
+    settings = _resolve_remote_settings(bootstrap)
+    if settings is None or not settings.enabled:
+        return bootstrap
+
+    data_dir = ""
+    runtime = bootstrap.get("runtime")
+    if isinstance(runtime, dict):
+        data_dir = str(runtime.get("data_dir") or "")
+
+    api_base = "https://api.github.com"
+    github = bootstrap.get("github")
+    if isinstance(github, dict) and github.get("api_base"):
+        api_base = str(github["api_base"]).rstrip("/")
+
+    pat = (os.getenv("GITHUB_TOKEN") or "").strip()
+
+    try:
+        fetched = fetch_remote_config_yaml(
+            owner=settings.owner.strip(),
+            repo=settings.repo.strip(),
+            path=settings.path.strip(),
+            ref=(settings.ref.strip() if settings.ref else None),
+            api_base=api_base,
+            pat=pat,
+        )
+        if data_dir:
+            _write_remote_cache(
+                data_dir,
+                fetched.data,
+                source=fetched.source,
+                sha=fetched.sha,
+            )
+        logger.info(
+            "Loaded remote config from %s%s",
+            fetched.source,
+            f" sha={fetched.sha}" if fetched.sha else "",
+        )
+        return apply_bootstrap_overlays(fetched.data, bootstrap)
+    except ConfigError as fetch_exc:
+        if not data_dir:
+            raise
+        cached = _read_remote_cache(data_dir)
+        if cached is None:
+            raise ConfigError(
+                f"{fetch_exc} No local remote_config_cache.yaml under {data_dir}."
+            ) from fetch_exc
+        remote_data, source, sha = cached
+        logger.warning(
+            "Remote config fetch failed; using cached config",
+            extra={
+                "error": str(fetch_exc),
+                "cache_source": source,
+                "cache_sha": sha,
+                "data_dir": data_dir,
+            },
+        )
+        return apply_bootstrap_overlays(remote_data, bootstrap)
+
+
 def load_config(path: str) -> BotConfig:
     load_dotenv()
     config_path = Path(path)
     if not config_path.exists() or not config_path.is_file():
         raise ConfigError(f"Config file does not exist: {path}")
 
-    raw = _load_yaml(config_path)
-    if raw is None:
-        raise ConfigError("Config file is empty")
+    bootstrap = _load_yaml_mapping(config_path)
+    raw = _merge_remote_into_bootstrap(bootstrap)
 
     try:
         expanded = _expand_env_vars(raw)

--- a/src/ghdcbot/config/models.py
+++ b/src/ghdcbot/config/models.py
@@ -210,6 +210,28 @@ class SnapshotConfig(BaseModel):
         return value
 
 
+class RemoteConfigSettings(BaseModel):
+    """Load non-secret org settings from a GitHub repo (e.g. AOSSIE-Org/.github/gitcord.yaml)."""
+
+    enabled: bool = False
+    owner: str = ""
+    repo: str = ".github"
+    path: str = "gitcord.yaml"
+    ref: str | None = None
+
+    @model_validator(mode="after")
+    def validate_remote_fields(self) -> RemoteConfigSettings:
+        if not self.enabled:
+            return self
+        if not (self.owner and self.owner.strip()):
+            raise ValueError("remote_config.owner is required when enabled")
+        if not (self.repo and self.repo.strip()):
+            raise ValueError("remote_config.repo is required when enabled")
+        if not (self.path and self.path.strip()):
+            raise ValueError("remote_config.path is required when enabled")
+        return self
+
+
 class BotConfig(BaseModel):
     runtime: RuntimeConfig
     github: GitHubConfig
@@ -221,6 +243,8 @@ class BotConfig(BaseModel):
     merge_role_rules: MergeRoleRulesConfig | None = None
     # Optional: GitHub snapshot storage
     snapshots: SnapshotConfig | None = None
+    # Optional: load org settings from GitHub (.github/gitcord.yaml); secrets stay local
+    remote_config: RemoteConfigSettings | None = None
     # Optional: repo name -> Discord role for "Contributor-X" (PR merged in repo X grants role)
     repo_contributor_roles: dict[str, str] | None = None
 

--- a/src/ghdcbot/config/remote.py
+++ b/src/ghdcbot/config/remote.py
@@ -1,0 +1,159 @@
+"""Fetch Gitcord YAML configuration from a GitHub repository (Contents API)."""
+
+from __future__ import annotations
+
+import base64
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+import yaml
+
+from ghdcbot.adapters.github.app_auth import build_github_httpx_client, resolve_github_token
+from ghdcbot.core.errors import ConfigError
+
+logger = logging.getLogger(__name__)
+
+CACHE_FILENAME = "remote_config_cache.yaml"
+CACHE_META_FILENAME = "remote_config_cache.meta.yaml"
+
+
+@dataclass(frozen=True)
+class RemoteConfigFetchResult:
+    """Parsed remote config plus provenance for logging/caching."""
+
+    data: dict[str, Any]
+    sha: str | None
+    source: str
+
+
+def deep_merge(base: dict[str, Any], overlay: dict[str, Any]) -> dict[str, Any]:
+    """Recursively merge overlay onto base; overlay values win for non-dict keys."""
+    result: dict[str, Any] = dict(base)
+    for key, value in overlay.items():
+        existing = result.get(key)
+        if isinstance(existing, dict) and isinstance(value, dict):
+            result[key] = deep_merge(existing, value)
+        else:
+            result[key] = value
+    return result
+
+
+def fetch_remote_config_yaml(
+    *,
+    owner: str,
+    repo: str,
+    path: str,
+    ref: str | None = None,
+    api_base: str = "https://api.github.com",
+    pat: str = "",
+) -> RemoteConfigFetchResult:
+    """Download and parse a YAML file from GitHub Contents API."""
+    token = resolve_github_token(pat=pat, api_base=api_base)
+    source = f"{owner}/{repo}/{path}"
+    if ref:
+        source = f"{source}@{ref}"
+
+    client = build_github_httpx_client(token, api_base=api_base.rstrip("/"), timeout=30.0)
+    try:
+        params: dict[str, str] = {}
+        if ref:
+            params["ref"] = ref
+        response = client.get(f"/repos/{owner}/{repo}/contents/{path.lstrip('/')}", params=params)
+    except httpx.HTTPError as exc:
+        raise ConfigError(f"Failed to fetch remote config {source}: {exc}") from exc
+    finally:
+        client.close()
+
+    if response.status_code == 404:
+        raise ConfigError(
+            f"Remote config not found: {source}. "
+            "Create gitcord.yaml in the org .github repo (or fix remote_config.path)."
+        )
+    if response.status_code in {401, 403}:
+        raise ConfigError(
+            f"Permission denied fetching remote config {source} "
+            f"(HTTP {response.status_code}). Check GitHub token/App installation access."
+        )
+    if response.status_code != 200:
+        raise ConfigError(
+            f"Failed to fetch remote config {source}: "
+            f"HTTP {response.status_code} {(response.text or '')[:200]}"
+        )
+
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        raise ConfigError(f"Invalid JSON from GitHub Contents API for {source}") from exc
+
+    if not isinstance(payload, dict):
+        raise ConfigError(f"Unexpected Contents API payload for {source}")
+
+    encoding = payload.get("encoding")
+    content_b64 = payload.get("content")
+    if encoding != "base64" or not isinstance(content_b64, str):
+        raise ConfigError(
+            f"Remote config {source} is not a regular file (encoding={encoding!r}). "
+            "Directories and symlinks are not supported."
+        )
+
+    try:
+        raw_text = base64.b64decode(content_b64).decode("utf-8")
+    except (ValueError, UnicodeDecodeError) as exc:
+        raise ConfigError(f"Failed to decode remote config {source}: {exc}") from exc
+
+    try:
+        data = yaml.safe_load(raw_text)
+    except yaml.YAMLError as exc:
+        raise ConfigError(f"Failed to parse remote config YAML {source}: {exc}") from exc
+
+    if data is None:
+        raise ConfigError(f"Remote config is empty: {source}")
+    if not isinstance(data, dict):
+        raise ConfigError(f"Remote config must be a YAML mapping: {source}")
+
+    sha = payload.get("sha") if isinstance(payload.get("sha"), str) else None
+    logger.info(
+        "Fetched remote Gitcord config",
+        extra={"source": source, "sha": sha},
+    )
+    return RemoteConfigFetchResult(data=data, sha=sha, source=source)
+
+
+def apply_bootstrap_overlays(
+    remote_data: dict[str, Any],
+    bootstrap: dict[str, Any],
+) -> dict[str, Any]:
+    """Merge remote org settings with local bootstrap secrets and machine paths.
+
+    Remote wins for shared org keys; bootstrap then overlays:
+    - remote_config
+    - runtime.data_dir
+    - github.token / discord.token
+    """
+    merged = deep_merge(bootstrap, remote_data)
+
+    remote_cfg = bootstrap.get("remote_config")
+    if isinstance(remote_cfg, dict):
+        merged["remote_config"] = dict(remote_cfg)
+
+    bootstrap_runtime = bootstrap.get("runtime")
+    if isinstance(bootstrap_runtime, dict) and bootstrap_runtime.get("data_dir"):
+        runtime = merged.setdefault("runtime", {})
+        if isinstance(runtime, dict):
+            runtime["data_dir"] = bootstrap_runtime["data_dir"]
+
+    bootstrap_github = bootstrap.get("github")
+    if isinstance(bootstrap_github, dict) and "token" in bootstrap_github:
+        github = merged.setdefault("github", {})
+        if isinstance(github, dict):
+            github["token"] = bootstrap_github["token"]
+
+    bootstrap_discord = bootstrap.get("discord")
+    if isinstance(bootstrap_discord, dict) and "token" in bootstrap_discord:
+        discord = merged.setdefault("discord", {})
+        if isinstance(discord, dict):
+            discord["token"] = bootstrap_discord["token"]
+
+    return merged

--- a/tests/test_remote_config.py
+++ b/tests/test_remote_config.py
@@ -1,0 +1,286 @@
+"""Tests for remote gitcord.yaml loading, merge, and cache fallback."""
+
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+import yaml
+
+from ghdcbot.config.loader import load_config
+from ghdcbot.config.remote import (
+    apply_bootstrap_overlays,
+    deep_merge,
+    fetch_remote_config_yaml,
+)
+from ghdcbot.core.errors import ConfigError
+
+
+def _contents_response(text: str, *, sha: str = "abc123") -> httpx.Response:
+    payload = {
+        "encoding": "base64",
+        "content": base64.b64encode(text.encode("utf-8")).decode("ascii"),
+        "sha": sha,
+        "type": "file",
+        "name": "gitcord.yaml",
+        "path": "gitcord.yaml",
+    }
+    return httpx.Response(200, json=payload)
+
+
+def test_deep_merge_nested_overlay_wins() -> None:
+    base = {"runtime": {"data_dir": "/data", "mode": "dry-run"}, "github": {"token": "local"}}
+    overlay = {"runtime": {"mode": "active"}, "github": {"org": "AOSSIE-Org"}}
+    merged = deep_merge(base, overlay)
+    assert merged["runtime"]["data_dir"] == "/data"
+    assert merged["runtime"]["mode"] == "active"
+    assert merged["github"]["token"] == "local"
+    assert merged["github"]["org"] == "AOSSIE-Org"
+
+
+def test_apply_bootstrap_overlays_keeps_secrets_and_data_dir() -> None:
+    remote = {
+        "runtime": {
+            "mode": "active",
+            "log_level": "INFO",
+            "data_dir": "/should-not-win",
+            "github_adapter": "ghdcbot.adapters.github.rest:GitHubRestAdapter",
+            "discord_adapter": "ghdcbot.adapters.discord.api:DiscordApiAdapter",
+            "storage_adapter": "ghdcbot.adapters.storage.sqlite:SqliteStorage",
+        },
+        "github": {"org": "AOSSIE-Org", "permissions": {"read": True, "write": True}},
+        "discord": {"guild_id": "1", "permissions": {"read": True, "write": True}},
+    }
+    bootstrap = {
+        "runtime": {"data_dir": "/data"},
+        "remote_config": {
+            "enabled": True,
+            "owner": "AOSSIE-Org",
+            "repo": ".github",
+            "path": "gitcord.yaml",
+        },
+        "github": {"token": "${GITHUB_TOKEN}"},
+        "discord": {"token": "${DISCORD_TOKEN}"},
+    }
+    merged = apply_bootstrap_overlays(remote, bootstrap)
+    assert merged["runtime"]["data_dir"] == "/data"
+    assert merged["runtime"]["mode"] == "active"
+    assert merged["github"]["token"] == "${GITHUB_TOKEN}"
+    assert merged["github"]["org"] == "AOSSIE-Org"
+    assert merged["discord"]["token"] == "${DISCORD_TOKEN}"
+    assert merged["remote_config"]["enabled"] is True
+
+
+def test_fetch_remote_config_yaml_decodes_contents(monkeypatch: pytest.MonkeyPatch) -> None:
+    remote_yaml = "runtime:\n  mode: active\ngithub:\n  org: AOSSIE-Org\n"
+    client = MagicMock()
+    client.get.return_value = _contents_response(remote_yaml, sha="deadbeef")
+    client.close = MagicMock()
+    monkeypatch.setattr(
+        "ghdcbot.config.remote.build_github_httpx_client",
+        lambda *args, **kwargs: client,
+    )
+    monkeypatch.setattr(
+        "ghdcbot.config.remote.resolve_github_token",
+        lambda **kwargs: "tok",
+    )
+
+    result = fetch_remote_config_yaml(
+        owner="AOSSIE-Org",
+        repo=".github",
+        path="gitcord.yaml",
+        ref="main",
+        pat="tok",
+    )
+    assert result.sha == "deadbeef"
+    assert result.data["github"]["org"] == "AOSSIE-Org"
+    assert "AOSSIE-Org/.github/gitcord.yaml" in result.source
+
+
+def test_fetch_remote_config_yaml_404(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = MagicMock()
+    client.get.return_value = httpx.Response(404, text="Not Found")
+    client.close = MagicMock()
+    monkeypatch.setattr(
+        "ghdcbot.config.remote.build_github_httpx_client",
+        lambda *args, **kwargs: client,
+    )
+    monkeypatch.setattr(
+        "ghdcbot.config.remote.resolve_github_token",
+        lambda **kwargs: "tok",
+    )
+    with pytest.raises(ConfigError, match="not found"):
+        fetch_remote_config_yaml(owner="AOSSIE-Org", repo=".github", path="missing.yaml")
+
+
+def _minimal_remote_dict() -> dict[str, Any]:
+    return {
+        "runtime": {
+            "mode": "dry-run",
+            "log_level": "INFO",
+            "data_dir": "/ignored",
+            "github_adapter": "ghdcbot.adapters.github.rest:GitHubRestAdapter",
+            "discord_adapter": "ghdcbot.adapters.discord.api:DiscordApiAdapter",
+            "storage_adapter": "ghdcbot.adapters.storage.sqlite:SqliteStorage",
+            "activity_period_days": 7,
+        },
+        "github": {
+            "org": "AOSSIE-Org",
+            "api_base": "https://api.github.com",
+            "permissions": {"read": True, "write": False},
+        },
+        "discord": {
+            "guild_id": "123456789012345678",
+            "permissions": {"read": True, "write": False},
+        },
+        "assignments": {},
+    }
+
+
+def test_load_config_remote_merge_and_env_expand(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    bootstrap = {
+        "runtime": {"data_dir": str(data_dir)},
+        "remote_config": {
+            "enabled": True,
+            "owner": "AOSSIE-Org",
+            "repo": ".github",
+            "path": "gitcord.yaml",
+            "ref": "main",
+        },
+        "github": {"token": "${GITHUB_TOKEN}"},
+        "discord": {"token": "${DISCORD_TOKEN}"},
+    }
+    bootstrap_path = tmp_path / "bootstrap.yaml"
+    bootstrap_path.write_text(yaml.safe_dump(bootstrap), encoding="utf-8")
+
+    monkeypatch.setenv("GITHUB_TOKEN", "ghp_test")
+    monkeypatch.setenv("DISCORD_TOKEN", "discord_test")
+    monkeypatch.setattr(
+        "ghdcbot.config.loader.fetch_remote_config_yaml",
+        lambda **kwargs: MagicMock(
+            data=_minimal_remote_dict(),
+            sha="cafef00d",
+            source="AOSSIE-Org/.github/gitcord.yaml@main",
+        ),
+    )
+
+    config = load_config(str(bootstrap_path))
+    assert config.github.org == "AOSSIE-Org"
+    assert config.github.token == "ghp_test"
+    assert config.discord.token == "discord_test"
+    assert config.runtime.data_dir == str(data_dir)
+    assert config.remote_config is not None
+    assert config.remote_config.enabled is True
+    assert (data_dir / "remote_config_cache.yaml").is_file()
+
+
+def test_load_config_uses_cache_when_fetch_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    cache = _minimal_remote_dict()
+    (data_dir / "remote_config_cache.yaml").write_text(
+        yaml.safe_dump(cache), encoding="utf-8"
+    )
+    (data_dir / "remote_config_cache.meta.yaml").write_text(
+        yaml.safe_dump({"source": "cached", "sha": "old"}),
+        encoding="utf-8",
+    )
+
+    bootstrap = {
+        "runtime": {"data_dir": str(data_dir)},
+        "remote_config": {
+            "enabled": True,
+            "owner": "AOSSIE-Org",
+            "repo": ".github",
+            "path": "gitcord.yaml",
+        },
+        "github": {"token": "${GITHUB_TOKEN}"},
+        "discord": {"token": "${DISCORD_TOKEN}"},
+    }
+    bootstrap_path = tmp_path / "bootstrap.yaml"
+    bootstrap_path.write_text(yaml.safe_dump(bootstrap), encoding="utf-8")
+
+    monkeypatch.setenv("GITHUB_TOKEN", "ghp_test")
+    monkeypatch.setenv("DISCORD_TOKEN", "discord_test")
+
+    def _boom(**kwargs: object) -> None:
+        raise ConfigError("network down")
+
+    monkeypatch.setattr("ghdcbot.config.loader.fetch_remote_config_yaml", _boom)
+
+    config = load_config(str(bootstrap_path))
+    assert config.github.org == "AOSSIE-Org"
+    assert config.github.token == "ghp_test"
+
+
+def test_load_config_fetch_failure_without_cache(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    bootstrap = {
+        "runtime": {"data_dir": str(data_dir)},
+        "remote_config": {
+            "enabled": True,
+            "owner": "AOSSIE-Org",
+            "repo": ".github",
+            "path": "gitcord.yaml",
+        },
+        "github": {"token": "${GITHUB_TOKEN}"},
+        "discord": {"token": "${DISCORD_TOKEN}"},
+    }
+    bootstrap_path = tmp_path / "bootstrap.yaml"
+    bootstrap_path.write_text(yaml.safe_dump(bootstrap), encoding="utf-8")
+    monkeypatch.setenv("GITHUB_TOKEN", "ghp_test")
+    monkeypatch.setenv("DISCORD_TOKEN", "discord_test")
+
+    def _boom(**kwargs: object) -> None:
+        raise ConfigError("network down")
+
+    monkeypatch.setattr("ghdcbot.config.loader.fetch_remote_config_yaml", _boom)
+
+    with pytest.raises(ConfigError, match="No local remote_config_cache"):
+        load_config(str(bootstrap_path))
+
+
+def test_load_config_local_only_still_works(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("GITHUB_TOKEN", "ghp_test")
+    monkeypatch.setenv("DISCORD_TOKEN", "discord_test")
+    cfg = {
+        "runtime": {
+            "mode": "dry-run",
+            "log_level": "INFO",
+            "data_dir": str(tmp_path / "data"),
+            "github_adapter": "ghdcbot.adapters.github.rest:GitHubRestAdapter",
+            "discord_adapter": "ghdcbot.adapters.discord.api:DiscordApiAdapter",
+            "storage_adapter": "ghdcbot.adapters.storage.sqlite:SqliteStorage",
+        },
+        "github": {
+            "org": "example-org",
+            "token": "${GITHUB_TOKEN}",
+            "api_base": "https://api.github.com",
+            "permissions": {"read": True, "write": False},
+        },
+        "discord": {
+            "guild_id": "123456789012345678",
+            "token": "${DISCORD_TOKEN}",
+            "permissions": {"read": True, "write": False},
+        },
+    }
+    path = tmp_path / "local.yaml"
+    path.write_text(yaml.safe_dump(cfg), encoding="utf-8")
+    config = load_config(str(path))
+    assert config.github.org == "example-org"
+    assert config.remote_config is None


### PR DESCRIPTION
## Summary
- Load non-secret org settings from `org/.github/gitcord.yaml` via the GitHub Contents API on startup.
- Thin local bootstrap keeps `runtime.data_dir`, `remote_config.*`, and `${TOKEN}` placeholders; secrets stay in `.env`.
- Cache successful fetches under `data_dir/remote_config_cache.yaml` and fall back if GitHub is down.
- Docs + AOSSIE/SN example remote YAML and bootstrap templates.
- `remote_config.enabled: false` / missing keeps today’s local-only path.

Already cut over on the live AOSSIE + Stability Nexus stacks (published org files + thin bootstraps).

## Test plan
- [x] `pytest tests/test_remote_config.py tests/test_config.py`
- [x] Confirm GitHub Actions **Python Tests** green
- [x] Optional: with `remote_config.enabled: true`, bot starts and logs remote source / writes cache
- [x] With GitHub unreachable and a cache present, bot still starts (warning)
- [x] With `remote_config` missing, existing local YAML configs still load


