### PR TITLE
fix: chronological Discord PR-open notification order

### DIFF
--- a/src/ghdcbot/engine/orchestrator.py
+++ b/src/ghdcbot/engine/orchestrator.py
@@ -283,6 +283,8 @@ def _notification_event_sort_key(event: ContributionEvent) -> tuple:
         event.repo,
         str(payload.get("pr_number") or payload.get("issue_number") or ""),
         event.github_user or "",
+        # Final tie-breaker: equal-time pr_reviewed rows stay deterministic across ingest order.
+        str(payload.get("review_id") or ""),
     )
 
 

--- a/src/ghdcbot/engine/orchestrator.py
+++ b/src/ghdcbot/engine/orchestrator.py
@@ -270,6 +270,22 @@ class Orchestrator:
                 close()
 
 
+def _notification_event_sort_key(event: ContributionEvent) -> tuple:
+    """Sort key so Discord notifications go out in chronological open/activity order.
+
+    Ingestion often yields GitHub API order (newest-first within a repo). Sorting only
+    affects the notification pass — storage/cursor still use the original list.
+    """
+    payload = event.payload or {}
+    return (
+        event.created_at,
+        event.event_type,
+        event.repo,
+        str(payload.get("pr_number") or payload.get("issue_number") or ""),
+        event.github_user or "",
+    )
+
+
 def _send_notifications_for_new_events(
     contributions: list[ContributionEvent],
     storage: Storage,
@@ -287,7 +303,9 @@ def _send_notifications_for_new_events(
     sent_count = 0
     pr_reviewed_count = 0
     channels = pr_open_channels or {}
-    for event in contributions:
+    # Copy + sort so batch syncs post older events first (e.g. PR #41 before #42).
+    ordered_events = sorted(contributions, key=_notification_event_sort_key)
+    for event in ordered_events:
         if event.event_type == "pr_opened":
             if send_pr_opened_channel_notification(
                 event, storage, discord_writer, policy, config, channels, github_org

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1353,8 +1353,9 @@ def test_batch_pr_opened_notifications_sent_oldest_first() -> None:
     )
 
     # Newest-first (GitHub list order) — notifications should still post #41 then #42.
+    events = [newer, older]
     _send_notifications_for_new_events(
-        [newer, older],
+        events,
         storage,
         discord_writer,
         policy,
@@ -1362,6 +1363,11 @@ def test_batch_pr_opened_notifications_sent_oldest_first() -> None:
         "AOSSIE-Org",
         channels,
     )
+
+    # Notification pass must not mutate the caller's ingestion list.
+    assert events[0] is newer
+    assert events[1] is older
+    assert events == [newer, older]
 
     assert len(discord_writer.messages_sent) == 2
     assert "#41" in discord_writer.messages_sent[0][1]

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1324,3 +1324,46 @@ def test_link_comment_timeout_preserves_claim_prevents_duplicate(tmp_path) -> No
     assert client.post.call_count == 1
     assert storage.was_notification_sent("pr_opened_github_link:Gitcord-GithubDiscordBot:42")
 
+
+def test_batch_pr_opened_notifications_sent_oldest_first() -> None:
+    """Batch sync must post channel PR-open notices in created_at order (not API newest-first)."""
+    from ghdcbot.engine.orchestrator import _send_notifications_for_new_events
+
+    storage = MockStorage()
+    discord_writer = MockDiscordWriter()
+    config = NotificationConfig(enabled=True, pr_opened=True)
+    policy = MutationPolicy(
+        mode=RunMode.ACTIVE, github_write_allowed=True, discord_write_allowed=True
+    )
+    channels = {"Gitcord-GithubDiscordBot": "1465995983791063140"}
+
+    newer = ContributionEvent(
+        github_user="alice",
+        event_type="pr_opened",
+        repo="Gitcord-GithubDiscordBot",
+        created_at=datetime(2026, 8, 4, 18, 57, tzinfo=UTC),
+        payload={"pr_number": 42, "title": "Week 11 remote config"},
+    )
+    older = ContributionEvent(
+        github_user="alice",
+        event_type="pr_opened",
+        repo="Gitcord-GithubDiscordBot",
+        created_at=datetime(2026, 8, 4, 18, 13, tzinfo=UTC),
+        payload={"pr_number": 41, "title": "CI mock fix"},
+    )
+
+    # Newest-first (GitHub list order) — notifications should still post #41 then #42.
+    _send_notifications_for_new_events(
+        [newer, older],
+        storage,
+        discord_writer,
+        policy,
+        config,
+        "AOSSIE-Org",
+        channels,
+    )
+
+    assert len(discord_writer.messages_sent) == 2
+    assert "#41" in discord_writer.messages_sent[0][1]
+    assert "#42" in discord_writer.messages_sent[1][1]
+


### PR DESCRIPTION
## Summary
- Batch `run-once` could post newer PR-open channel notices before older ones (GitHub list order is newest-first).
- Sort a **copy** of contribution events by `created_at` only inside the notification pass.
- Storage, cursor advance, and ingestion order are unchanged.

## Test plan
- [x] `pytest tests/test_notifications.py` (includes new oldest-first batch test)
- [ ] Confirm CI Python Tests green


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected notification ordering so contribution events are posted from oldest to newest.
  * Ensured event ordering is consistent when multiple events share the same creation time.

* **Tests**
  * Added coverage confirming that pull request notifications are delivered chronologically, regardless of input order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->