### PR TITLE
fix: /pr search misses PRs when allowlist is large

### DIFF
--- a/src/ghdcbot/adapters/github/rest.py
+++ b/src/ghdcbot/adapters/github/rest.py
@@ -76,6 +76,60 @@ def _rate_limit_sleep_seconds(headers: dict) -> float | None:
 
 
 _GITHUB_SEARCH_QUERY_MAX_LEN = 256
+_GITHUB_SEARCH_MAX_PAGES = 5
+
+
+def _partition_allowlist_repo_terms(
+    query: str,
+    *,
+    org: str,
+    allowed_names: set[str],
+) -> list[str]:
+    """Split allowlisted ``repo:`` terms into queries that each fit the length budget."""
+    terms = [f"repo:{org}/{name}" for name in sorted(allowed_names)]
+    batches: list[list[str]] = []
+    current: list[str] = []
+    for term in terms:
+        trial_parts = current + [term]
+        trial = f"{query} ({' OR '.join(trial_parts)})"
+        if current and len(trial) > _GITHUB_SEARCH_QUERY_MAX_LEN:
+            batches.append(current)
+            current = [term]
+            continue
+        if not current and len(trial) > _GITHUB_SEARCH_QUERY_MAX_LEN:
+            # Single repo qualifier alone exceeds the budget; skip rather than truncate.
+            continue
+        current.append(term)
+    if current:
+        batches.append(current)
+    return [f"{query} ({' OR '.join(batch)})" for batch in batches]
+
+
+def _build_repo_scoped_search_queries(
+    query: str,
+    *,
+    org: str,
+    allowed_names: set[str] | None,
+    denied_names: set[str],
+) -> list[str]:
+    """Build one or more Search API queries covering the full allow/deny set.
+
+    Oversized allowlists are partitioned into complete batches (no partial truncation,
+    no org-wide fallback) so every allowed repo remains searchable within the page cap.
+    """
+    if allowed_names is not None and allowed_names:
+        return _partition_allowlist_repo_terms(
+            query, org=org, allowed_names=allowed_names
+        )
+    if denied_names:
+        result = query
+        for name in sorted(denied_names):
+            candidate = f"{result} -repo:{org}/{name}"
+            if len(candidate) > _GITHUB_SEARCH_QUERY_MAX_LEN:
+                break
+            result = candidate
+        return [result]
+    return [query]
 
 
 def _append_repo_search_qualifiers(
@@ -85,28 +139,14 @@ def _append_repo_search_qualifiers(
     allowed_names: set[str] | None,
     denied_names: set[str],
 ) -> str:
-    """Add allow/deny ``repo:`` qualifiers while staying within GitHub's query length limit.
-
-    If an allowlist cannot fit fully, return the base ``org:`` query unchanged and rely on
-    the caller's local allowlist filter. Partial ``repo:`` truncation silently drops repos
-    (e.g. Gitcord when many A* repos fill the budget) and breaks ``/pr``.
-    """
-    if allowed_names is not None and allowed_names:
-        repo_terms = [f"repo:{org}/{name}" for name in sorted(allowed_names)]
-        joined = " OR ".join(repo_terms)
-        candidate = f"{query} ({joined})"
-        if len(candidate) <= _GITHUB_SEARCH_QUERY_MAX_LEN:
-            return candidate
-        return query
-    if denied_names:
-        result = query
-        for name in sorted(denied_names):
-            candidate = f"{result} -repo:{org}/{name}"
-            if len(candidate) > _GITHUB_SEARCH_QUERY_MAX_LEN:
-                break
-            result = candidate
-        return result
-    return query
+    """Backward-compatible single-query helper; prefer ``_build_repo_scoped_search_queries``."""
+    queries = _build_repo_scoped_search_queries(
+        query,
+        org=org,
+        allowed_names=allowed_names,
+        denied_names=denied_names,
+    )
+    return queries[0] if queries else query
 
 
 class GitHubRestAdapter:
@@ -228,71 +268,77 @@ class GitHubRestAdapter:
                 denied_names = names
 
         extra = (query_extra or "").strip()
-        query = f"is:pr author:{author} org:{self._org}"
+        base_query = f"is:pr author:{author} org:{self._org}"
         if extra:
-            query = f"is:pr {extra} author:{author} org:{self._org}"
-        query = _append_repo_search_qualifiers(
-            query,
+            base_query = f"is:pr {extra} author:{author} org:{self._org}"
+        queries = _build_repo_scoped_search_queries(
+            base_query,
             org=self._org,
             allowed_names=allowed_names,
             denied_names=denied_names,
         )
 
         results: list[dict] = []
-        page = 1
-        while page <= 5:
-            params: dict[str, str | int] = {"q": query, "per_page": 100, "page": page}
-            if sort:
-                params["sort"] = sort
-            if order:
-                params["order"] = order
-            response = self._request(
-                "GET",
-                "/search/issues",
-                params=params,
-            )
-            if response is None or response.status_code != 200:
-                if response is not None:
-                    self._logger.warning(
-                        "GitHub search failed",
-                        extra={
-                            "status_code": response.status_code,
-                            "github_user": author,
-                            "org": self._org,
-                            "log_label": log_label,
-                        },
-                    )
-                break
-            payload = response.json()
-            items = payload.get("items") if isinstance(payload, dict) else None
-            if not isinstance(items, list) or not items:
-                break
-            for item in items:
-                if not isinstance(item, dict):
-                    continue
-                repo_name = _repo_name_from_search_issue(item, self._org)
-                if not repo_name:
-                    continue
-                if allowed_names is not None and repo_name not in allowed_names:
-                    continue
-                if repo_name in denied_names:
-                    continue
-                user = item.get("user") if isinstance(item.get("user"), dict) else {}
-                row: dict = {
-                    "repo": repo_name,
-                    "number": item.get("number"),
-                    "author": user.get("login") or author,
-                    "title": item.get("title"),
-                    "html_url": item.get("html_url"),
-                    "created_at": item.get("created_at"),
-                    "updated_at": item.get("updated_at"),
-                }
-                if include_status:
-                    row["status"] = _pr_status_from_search_issue(item)
-                results.append(row)
-            if len(items) < 100:
-                break
-            page += 1
+        seen: set[tuple[str, object]] = set()
+        for query in queries:
+            page = 1
+            while page <= _GITHUB_SEARCH_MAX_PAGES:
+                params: dict[str, str | int] = {"q": query, "per_page": 100, "page": page}
+                if sort:
+                    params["sort"] = sort
+                if order:
+                    params["order"] = order
+                response = self._request(
+                    "GET",
+                    "/search/issues",
+                    params=params,
+                )
+                if response is None or response.status_code != 200:
+                    if response is not None:
+                        self._logger.warning(
+                            "GitHub search failed",
+                            extra={
+                                "status_code": response.status_code,
+                                "github_user": author,
+                                "org": self._org,
+                                "log_label": log_label,
+                            },
+                        )
+                    break
+                payload = response.json()
+                items = payload.get("items") if isinstance(payload, dict) else None
+                if not isinstance(items, list) or not items:
+                    break
+                for item in items:
+                    if not isinstance(item, dict):
+                        continue
+                    repo_name = _repo_name_from_search_issue(item, self._org)
+                    if not repo_name:
+                        continue
+                    if allowed_names is not None and repo_name not in allowed_names:
+                        continue
+                    if repo_name in denied_names:
+                        continue
+                    dedupe_key = (repo_name, item.get("number"))
+                    if dedupe_key in seen:
+                        continue
+                    seen.add(dedupe_key)
+                    user = item.get("user") if isinstance(item.get("user"), dict) else {}
+                    row: dict = {
+                        "repo": repo_name,
+                        "number": item.get("number"),
+                        "author": user.get("login") or author,
+                        "title": item.get("title"),
+                        "html_url": item.get("html_url"),
+                        "created_at": item.get("created_at"),
+                        "updated_at": item.get("updated_at"),
+                    }
+                    if include_status:
+                        row["status"] = _pr_status_from_search_issue(item)
+                    results.append(row)
+                if len(items) < 100:
+                    break
+                page += 1
         return results
 
     def assign_issue(self, owner: str, repo: str, issue_number: int, assignee: str) -> bool:

--- a/src/ghdcbot/adapters/github/rest.py
+++ b/src/ghdcbot/adapters/github/rest.py
@@ -75,60 +75,17 @@ def _rate_limit_sleep_seconds(headers: dict) -> float | None:
     return max(sleep_seconds, _GITHUB_MIN_RATE_LIMIT_SLEEP_SECONDS)
 
 
-_GITHUB_SEARCH_QUERY_MAX_LEN = 256
 _GITHUB_SEARCH_MAX_PAGES = 5
 
 
-def _partition_allowlist_repo_terms(
-    query: str,
-    *,
-    org: str,
-    allowed_names: set[str],
-) -> list[str]:
-    """Split allowlisted ``repo:`` terms into queries that each fit the length budget."""
-    terms = [f"repo:{org}/{name}" for name in sorted(allowed_names)]
-    batches: list[list[str]] = []
-    current: list[str] = []
-    for term in terms:
-        trial_parts = current + [term]
-        trial = f"{query} ({' OR '.join(trial_parts)})"
-        if current and len(trial) > _GITHUB_SEARCH_QUERY_MAX_LEN:
-            batches.append(current)
-            current = [term]
-            continue
-        if not current and len(trial) > _GITHUB_SEARCH_QUERY_MAX_LEN:
-            # Single repo qualifier alone exceeds the budget; skip rather than truncate.
-            continue
-        current.append(term)
-    if current:
-        batches.append(current)
-    return [f"{query} ({' OR '.join(batch)})" for batch in batches]
+def _build_author_pr_search_queries(query: str) -> list[str]:
+    """Return Search API queries for author PR listing.
 
-
-def _build_repo_scoped_search_queries(
-    query: str,
-    *,
-    org: str,
-    allowed_names: set[str] | None,
-    denied_names: set[str],
-) -> list[str]:
-    """Build one or more Search API queries covering the full allow/deny set.
-
-    Oversized allowlists are partitioned into complete batches (no partial truncation,
-    no org-wide fallback) so every allowed repo remains searchable within the page cap.
+    Repo allow/deny lists are applied to results in Python. Embedding ``repo:`` OR
+    groups in the query is unreliable on GitHub's issue search (parenthesized
+    ``repo:a OR repo:b`` often returns empty or incomplete hits), and truncating
+    long allowlists silently drops repos such as Gitcord.
     """
-    if allowed_names is not None and allowed_names:
-        return _partition_allowlist_repo_terms(
-            query, org=org, allowed_names=allowed_names
-        )
-    if denied_names:
-        result = query
-        for name in sorted(denied_names):
-            candidate = f"{result} -repo:{org}/{name}"
-            if len(candidate) > _GITHUB_SEARCH_QUERY_MAX_LEN:
-                break
-            result = candidate
-        return [result]
     return [query]
 
 
@@ -139,14 +96,9 @@ def _append_repo_search_qualifiers(
     allowed_names: set[str] | None,
     denied_names: set[str],
 ) -> str:
-    """Backward-compatible single-query helper; prefer ``_build_repo_scoped_search_queries``."""
-    queries = _build_repo_scoped_search_queries(
-        query,
-        org=org,
-        allowed_names=allowed_names,
-        denied_names=denied_names,
-    )
-    return queries[0] if queries else query
+    """Backward-compatible no-op; allow/deny filtering happens on search results."""
+    _ = (org, allowed_names, denied_names)
+    return query
 
 
 class GitHubRestAdapter:
@@ -271,12 +223,8 @@ class GitHubRestAdapter:
         base_query = f"is:pr author:{author} org:{self._org}"
         if extra:
             base_query = f"is:pr {extra} author:{author} org:{self._org}"
-        queries = _build_repo_scoped_search_queries(
-            base_query,
-            org=self._org,
-            allowed_names=allowed_names,
-            denied_names=denied_names,
-        )
+        # Org-scoped search only; allow/deny applied below per result.
+        queries = _build_author_pr_search_queries(base_query)
 
         results: list[dict] = []
         seen: set[tuple[str, object]] = set()

--- a/src/ghdcbot/adapters/github/rest.py
+++ b/src/ghdcbot/adapters/github/rest.py
@@ -85,22 +85,18 @@ def _append_repo_search_qualifiers(
     allowed_names: set[str] | None,
     denied_names: set[str],
 ) -> str:
-    """Add allow/deny ``repo:`` qualifiers while staying within GitHub's query length limit."""
+    """Add allow/deny ``repo:`` qualifiers while staying within GitHub's query length limit.
+
+    If an allowlist cannot fit fully, return the base ``org:`` query unchanged and rely on
+    the caller's local allowlist filter. Partial ``repo:`` truncation silently drops repos
+    (e.g. Gitcord when many A* repos fill the budget) and breaks ``/pr``.
+    """
     if allowed_names is not None and allowed_names:
         repo_terms = [f"repo:{org}/{name}" for name in sorted(allowed_names)]
         joined = " OR ".join(repo_terms)
         candidate = f"{query} ({joined})"
         if len(candidate) <= _GITHUB_SEARCH_QUERY_MAX_LEN:
             return candidate
-        # Fit as many repos as possible; local filter remains the safety net.
-        parts: list[str] = []
-        for term in repo_terms:
-            trial = f"{query} ({' OR '.join(parts + [term])})"
-            if len(trial) > _GITHUB_SEARCH_QUERY_MAX_LEN:
-                break
-            parts.append(term)
-        if parts:
-            return f"{query} ({' OR '.join(parts)})"
         return query
     if denied_names:
         result = query

--- a/tests/test_open_prs_search.py
+++ b/tests/test_open_prs_search.py
@@ -81,6 +81,70 @@ def test_list_open_pull_requests_for_author_uses_search_and_allowlist(monkeypatc
     assert "status" not in prs[0]
 
 
+def test_large_allowlist_falls_back_to_org_search_then_local_filter(monkeypatch) -> None:
+    """Oversized allowlists must not truncate to A* repos only (breaks /pr for Gitcord)."""
+    from ghdcbot.adapters.github.rest import _append_repo_search_qualifiers
+
+    adapter = GitHubRestAdapter(token="t", org="AOSSIE-Org", api_base="https://api.github.com")
+    client = _SearchMockClient(
+        {
+            "items": [
+                {
+                    "number": 40,
+                    "title": "who-is",
+                    "state": "open",
+                    "html_url": "https://github.com/AOSSIE-Org/Gitcord-GithubDiscordBot/pull/40",
+                    "created_at": "2026-08-03T07:00:00Z",
+                    "updated_at": "2026-08-05T05:00:00Z",
+                    "repository_url": "https://api.github.com/repos/AOSSIE-Org/Gitcord-GithubDiscordBot",
+                    "user": {"login": "PrithvijitBose"},
+                    "pull_request": {},
+                },
+                {
+                    "number": 1,
+                    "title": "Outside allowlist",
+                    "state": "open",
+                    "html_url": "https://github.com/AOSSIE-Org/Other/pull/1",
+                    "created_at": "2026-08-01T00:00:00Z",
+                    "updated_at": "2026-08-01T00:00:00Z",
+                    "repository_url": "https://api.github.com/repos/AOSSIE-Org/Other",
+                    "user": {"login": "PrithvijitBose"},
+                    "pull_request": {},
+                },
+            ]
+        }
+    )
+    adapter._client = client  # type: ignore[assignment]
+
+    # Many names so repo: OR list cannot fit in the 256-char budget.
+    huge_allow = [f"Repo{i:02d}-With-A-Long-Name" for i in range(40)] + [
+        "Gitcord-GithubDiscordBot"
+    ]
+    monkeypatch.setattr(
+        "ghdcbot.adapters.github.rest._load_repo_filter",
+        lambda: RepoFilterConfig(mode="allow", names=huge_allow),
+    )
+
+    base = "is:pr author:PrithvijitBose org:AOSSIE-Org"
+    narrowed = _append_repo_search_qualifiers(
+        base,
+        org="AOSSIE-Org",
+        allowed_names=set(huge_allow),
+        denied_names=set(),
+    )
+    assert narrowed == base
+    assert "repo:AOSSIE-Org/Repo00" not in narrowed
+
+    prs = adapter.list_pull_requests_for_author("PrithvijitBose")
+    assert len(client.calls) == 1
+    _method, _path, params = client.calls[0]
+    assert params is not None
+    assert params["q"] == "is:pr author:PrithvijitBose org:AOSSIE-Org"
+    assert len(prs) == 1
+    assert prs[0]["repo"] == "Gitcord-GithubDiscordBot"
+    assert prs[0]["number"] == 40
+
+
 def test_pr_status_from_search_issue() -> None:
     assert _pr_status_from_search_issue({"state": "open", "pull_request": {}}) == "open"
     assert (

--- a/tests/test_open_prs_search.py
+++ b/tests/test_open_prs_search.py
@@ -13,13 +13,17 @@ from ghdcbot.config.models import RepoFilterConfig
 
 
 class _SearchMockClient:
-    def __init__(self, payload: dict) -> None:
-        self._payload = payload
+    def __init__(self, payload: dict | None = None, *, by_query: dict[str, dict] | None = None) -> None:
+        self._payload = payload or {"items": []}
+        self._by_query = by_query or {}
         self.calls: list[tuple[str, str, dict | None]] = []
 
     def request(self, method: str, path: str, params: dict | None = None, **kwargs: object) -> httpx.Response:
         self.calls.append((method, path, params))
-        return httpx.Response(200, json=self._payload, headers={"X-RateLimit-Remaining": "10"})
+        payload = self._payload
+        if params and isinstance(params.get("q"), str) and params["q"] in self._by_query:
+            payload = self._by_query[params["q"]]
+        return httpx.Response(200, json=payload, headers={"X-RateLimit-Remaining": "10"})
 
 
 def test_repo_name_from_search_issue_prefers_repository_url() -> None:
@@ -81,68 +85,65 @@ def test_list_open_pull_requests_for_author_uses_search_and_allowlist(monkeypatc
     assert "status" not in prs[0]
 
 
-def test_large_allowlist_falls_back_to_org_search_then_local_filter(monkeypatch) -> None:
-    """Oversized allowlists must not truncate to A* repos only (breaks /pr for Gitcord)."""
-    from ghdcbot.adapters.github.rest import _append_repo_search_qualifiers
+def test_large_allowlist_is_partitioned_into_repo_batches(monkeypatch) -> None:
+    """Oversized allowlists must batch complete repo: queries (not org-wide fallback)."""
+    from ghdcbot.adapters.github.rest import _build_repo_scoped_search_queries
 
-    adapter = GitHubRestAdapter(token="t", org="AOSSIE-Org", api_base="https://api.github.com")
-    client = _SearchMockClient(
-        {
-            "items": [
-                {
-                    "number": 40,
-                    "title": "who-is",
-                    "state": "open",
-                    "html_url": "https://github.com/AOSSIE-Org/Gitcord-GithubDiscordBot/pull/40",
-                    "created_at": "2026-08-03T07:00:00Z",
-                    "updated_at": "2026-08-05T05:00:00Z",
-                    "repository_url": "https://api.github.com/repos/AOSSIE-Org/Gitcord-GithubDiscordBot",
-                    "user": {"login": "PrithvijitBose"},
-                    "pull_request": {},
-                },
-                {
-                    "number": 1,
-                    "title": "Outside allowlist",
-                    "state": "open",
-                    "html_url": "https://github.com/AOSSIE-Org/Other/pull/1",
-                    "created_at": "2026-08-01T00:00:00Z",
-                    "updated_at": "2026-08-01T00:00:00Z",
-                    "repository_url": "https://api.github.com/repos/AOSSIE-Org/Other",
-                    "user": {"login": "PrithvijitBose"},
-                    "pull_request": {},
-                },
-            ]
-        }
-    )
-    adapter._client = client  # type: ignore[assignment]
-
-    # Many names so repo: OR list cannot fit in the 256-char budget.
-    huge_allow = [f"Repo{i:02d}-With-A-Long-Name" for i in range(40)] + [
+    # Names long enough that more than one batch is required under the 256-char cap.
+    huge_allow = [f"Repo{i:02d}-With-A-Long-Name" for i in range(20)] + [
         "Gitcord-GithubDiscordBot"
     ]
-    monkeypatch.setattr(
-        "ghdcbot.adapters.github.rest._load_repo_filter",
-        lambda: RepoFilterConfig(mode="allow", names=huge_allow),
-    )
-
     base = "is:pr author:PrithvijitBose org:AOSSIE-Org"
-    narrowed = _append_repo_search_qualifiers(
+    queries = _build_repo_scoped_search_queries(
         base,
         org="AOSSIE-Org",
         allowed_names=set(huge_allow),
         denied_names=set(),
     )
-    assert narrowed == base
-    assert "repo:AOSSIE-Org/Repo00" not in narrowed
+    assert len(queries) >= 2
+    assert all(len(q) <= 256 for q in queries)
+    assert all("repo:AOSSIE-Org/" in q for q in queries)
+    assert sum(q.count("repo:AOSSIE-Org/") for q in queries) == len(huge_allow)
+    assert any("Gitcord-GithubDiscordBot" in q for q in queries)
+
+    adapter = GitHubRestAdapter(token="t", org="AOSSIE-Org", api_base="https://api.github.com")
+    by_query = {
+        q: {
+            "items": [
+                {
+                    "number": 40 if "Gitcord-GithubDiscordBot" in q else 1,
+                    "title": "who-is" if "Gitcord-GithubDiscordBot" in q else "other",
+                    "state": "open",
+                    "html_url": (
+                        "https://github.com/AOSSIE-Org/Gitcord-GithubDiscordBot/pull/40"
+                        if "Gitcord-GithubDiscordBot" in q
+                        else "https://github.com/AOSSIE-Org/Repo00-With-A-Long-Name/pull/1"
+                    ),
+                    "created_at": "2026-08-03T07:00:00Z",
+                    "updated_at": "2026-08-05T05:00:00Z",
+                    "repository_url": (
+                        "https://api.github.com/repos/AOSSIE-Org/Gitcord-GithubDiscordBot"
+                        if "Gitcord-GithubDiscordBot" in q
+                        else "https://api.github.com/repos/AOSSIE-Org/Repo00-With-A-Long-Name"
+                    ),
+                    "user": {"login": "PrithvijitBose"},
+                    "pull_request": {},
+                }
+            ]
+        }
+        for q in queries
+    }
+    client = _SearchMockClient(by_query=by_query)
+    adapter._client = client  # type: ignore[assignment]
+    monkeypatch.setattr(
+        "ghdcbot.adapters.github.rest._load_repo_filter",
+        lambda: RepoFilterConfig(mode="allow", names=huge_allow),
+    )
 
     prs = adapter.list_pull_requests_for_author("PrithvijitBose")
-    assert len(client.calls) == 1
-    _method, _path, params = client.calls[0]
-    assert params is not None
-    assert params["q"] == "is:pr author:PrithvijitBose org:AOSSIE-Org"
-    assert len(prs) == 1
-    assert prs[0]["repo"] == "Gitcord-GithubDiscordBot"
-    assert prs[0]["number"] == 40
+    assert len(client.calls) == len(queries)
+    assert {pr["repo"] for pr in prs} >= {"Gitcord-GithubDiscordBot"}
+    assert any(pr["number"] == 40 and pr["repo"] == "Gitcord-GithubDiscordBot" for pr in prs)
 
 
 def test_pr_status_from_search_issue() -> None:

--- a/tests/test_open_prs_search.py
+++ b/tests/test_open_prs_search.py
@@ -75,7 +75,8 @@ def test_list_open_pull_requests_for_author_uses_search_and_allowlist(monkeypatc
     assert method == "GET"
     assert path == "/search/issues"
     assert params is not None
-    assert params["q"] == "is:pr is:open author:alice org:AOSSIE-Org (repo:AOSSIE-Org/PictoPy)"
+    assert params["q"] == "is:pr is:open author:alice org:AOSSIE-Org"
+    assert "repo:" not in params["q"]
     assert len(prs) == 1
     assert prs[0]["repo"] == "PictoPy"
     assert prs[0]["number"] == 10
@@ -85,55 +86,40 @@ def test_list_open_pull_requests_for_author_uses_search_and_allowlist(monkeypatc
     assert "status" not in prs[0]
 
 
-def test_large_allowlist_is_partitioned_into_repo_batches(monkeypatch) -> None:
-    """Oversized allowlists must batch complete repo: queries (not org-wide fallback)."""
-    from ghdcbot.adapters.github.rest import _build_repo_scoped_search_queries
-
-    # Names long enough that more than one batch is required under the 256-char cap.
-    huge_allow = [f"Repo{i:02d}-With-A-Long-Name" for i in range(20)] + [
+def test_large_allowlist_filters_org_search_client_side(monkeypatch) -> None:
+    """Large allowlists must not use repo: OR queries; filter org search in Python."""
+    huge_allow = [f"Repo{i:02d}-With-A-Long-Name" for i in range(40)] + [
         "Gitcord-GithubDiscordBot"
     ]
-    base = "is:pr author:PrithvijitBose org:AOSSIE-Org"
-    queries = _build_repo_scoped_search_queries(
-        base,
-        org="AOSSIE-Org",
-        allowed_names=set(huge_allow),
-        denied_names=set(),
-    )
-    assert len(queries) >= 2
-    assert all(len(q) <= 256 for q in queries)
-    assert all("repo:AOSSIE-Org/" in q for q in queries)
-    assert sum(q.count("repo:AOSSIE-Org/") for q in queries) == len(huge_allow)
-    assert any("Gitcord-GithubDiscordBot" in q for q in queries)
-
     adapter = GitHubRestAdapter(token="t", org="AOSSIE-Org", api_base="https://api.github.com")
-    by_query = {
-        q: {
+    client = _SearchMockClient(
+        {
             "items": [
                 {
-                    "number": 40 if "Gitcord-GithubDiscordBot" in q else 1,
-                    "title": "who-is" if "Gitcord-GithubDiscordBot" in q else "other",
+                    "number": 40,
+                    "title": "who-is",
                     "state": "open",
-                    "html_url": (
-                        "https://github.com/AOSSIE-Org/Gitcord-GithubDiscordBot/pull/40"
-                        if "Gitcord-GithubDiscordBot" in q
-                        else "https://github.com/AOSSIE-Org/Repo00-With-A-Long-Name/pull/1"
-                    ),
+                    "html_url": "https://github.com/AOSSIE-Org/Gitcord-GithubDiscordBot/pull/40",
                     "created_at": "2026-08-03T07:00:00Z",
                     "updated_at": "2026-08-05T05:00:00Z",
-                    "repository_url": (
-                        "https://api.github.com/repos/AOSSIE-Org/Gitcord-GithubDiscordBot"
-                        if "Gitcord-GithubDiscordBot" in q
-                        else "https://api.github.com/repos/AOSSIE-Org/Repo00-With-A-Long-Name"
-                    ),
+                    "repository_url": "https://api.github.com/repos/AOSSIE-Org/Gitcord-GithubDiscordBot",
                     "user": {"login": "PrithvijitBose"},
                     "pull_request": {},
-                }
+                },
+                {
+                    "number": 99,
+                    "title": "outside allowlist",
+                    "state": "open",
+                    "html_url": "https://github.com/AOSSIE-Org/NotAllowed/pull/99",
+                    "created_at": "2026-08-03T07:00:00Z",
+                    "updated_at": "2026-08-05T06:00:00Z",
+                    "repository_url": "https://api.github.com/repos/AOSSIE-Org/NotAllowed",
+                    "user": {"login": "PrithvijitBose"},
+                    "pull_request": {},
+                },
             ]
         }
-        for q in queries
-    }
-    client = _SearchMockClient(by_query=by_query)
+    )
     adapter._client = client  # type: ignore[assignment]
     monkeypatch.setattr(
         "ghdcbot.adapters.github.rest._load_repo_filter",
@@ -141,9 +127,14 @@ def test_large_allowlist_is_partitioned_into_repo_batches(monkeypatch) -> None:
     )
 
     prs = adapter.list_pull_requests_for_author("PrithvijitBose")
-    assert len(client.calls) == len(queries)
-    assert {pr["repo"] for pr in prs} >= {"Gitcord-GithubDiscordBot"}
-    assert any(pr["number"] == 40 and pr["repo"] == "Gitcord-GithubDiscordBot" for pr in prs)
+    assert len(client.calls) == 1
+    _method, _path, params = client.calls[0]
+    assert params is not None
+    assert params["q"] == "is:pr author:PrithvijitBose org:AOSSIE-Org"
+    assert "repo:" not in params["q"]
+    assert len(prs) == 1
+    assert prs[0]["repo"] == "Gitcord-GithubDiscordBot"
+    assert prs[0]["number"] == 40
 
 
 def test_pr_status_from_search_issue() -> None:


### PR DESCRIPTION
## Summary
- `/pr` was empty for linked contributors (e.g. Prithvi) after the allowlist grew, because GitHub Search returns empty/incomplete hits for parenthesized `repo:… OR repo:…` queries.
- Stop embedding allowlist `repo:` OR groups in the Search query; use org-scoped `is:pr author:… org:…` and apply allow/deny filters on the results in Python.
- Update unit tests to match the client-side filter approach.

## Test plan
- [x] `pytest tests/test_open_prs_search.py tests/test_pr_list.py`
- [x] Live AOSSIE bot: `list_pull_requests_for_author('PrithvijitBose')` returns Gitcord `#40` / `#37`
- [x] Discord: `/pr @Prithvi` shows recent PRs (not “No PRs found”)
- [x] Confirm non-allowlisted repos still do not appear in `/pr` output