### PR TITLE
docs: one-file local handover (pack / restore)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,5 +7,9 @@ DISCORD_TOKEN=your_discord_token
 # GITHUB_APP_INSTALLATION_ID=your_installation_id
 # GITHUB_APP_PRIVATE_KEY_PATH=/secrets/gitcordapp.pem
 
+# Host path to the App private key file (docker compose mounts it).
+# Handover restore sets this automatically. Example:
+# GITCORD_PEM_HOST=/home/you/privateKeys/gitcordapp.pem
+
 # Optional: scheduled sync interval in seconds (default 21600 = 6 hours)
 # GITCORD_SYNC_INTERVAL_SECONDS=21600

--- a/.env.example
+++ b/.env.example
@@ -7,9 +7,9 @@ DISCORD_TOKEN=your_discord_token
 # GITHUB_APP_INSTALLATION_ID=your_installation_id
 # GITHUB_APP_PRIVATE_KEY_PATH=/secrets/gitcordapp.pem
 
-# Host path to the App private key file (docker compose mounts it).
+# Host path to the App private key file (required for Docker Compose mounts).
 # Handover restore sets this automatically. Example:
-# GITCORD_PEM_HOST=/home/you/privateKeys/gitcordapp.pem
+GITCORD_PEM_HOST=/home/you/privateKeys/gitcordapp.pem
 
 # Optional: scheduled sync interval in seconds (default 21600 = 6 hours)
 # GITCORD_SYNC_INTERVAL_SECONDS=21600

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ gitcord-portfolio-thumbnail.jpg
 # Local handover packs (never commit)
 gitcord-handover-SECRET/
 **/gitcord-handover-*/
+gitcord-handover-*.tar.gz
+**/gitcord-handover-*.tar.gz
+*.pem

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ package-lock.json
 venv/
 gitcord_status.pdf
 gitcord-portfolio-thumbnail.jpg
+# Local handover packs (never commit)
+gitcord-handover-SECRET/
+**/gitcord-handover-*/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,10 @@ When the user is **taking over** Gitcord or **moving bots to another PC**:
 4. Do not commit secrets; do not mix AOSSIE/SN; warn if both PCs might run the same Discord tokens.
 5. After restore: `check` → user tests `/profile` + `/who-is` → `stop-old` on the previous PC.
 
+---
+
+## Testing expectations
+
 - Add/adjust tests under `tests/` for engine and adapter behavior.
 - CI: `.github/workflows/tests.yml` runs `pytest` on PRs.
 - Do not commit credentials or production SQLite DBs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,10 +68,19 @@ tests/          # pytest suite
 4. **Keep changes scoped** — match existing patterns; update tests + docs when behavior changes.
 5. **Remote config** — org settings may live in `org/.github/gitcord.yaml`; local bootstrap stays thin (`remote_config` + tokens + `data_dir`).
 6. **Multi-org** — AOSSIE and Stability Nexus use **separate** Compose projects, env files, and volumes.
+7. **Local handover** — use `./scripts/gitcord-handover pack|restore` and [`HANDOVER-EASY.txt`](HANDOVER-EASY.txt). AI paste prompt: [`docs/HANDOVER_AI_PROMPT.md`](docs/HANDOVER_AI_PROMPT.md). Never treat “git clone alone” as a full handover.
 
 ---
 
-## Testing expectations
+## Local handover (for AI agents)
+
+When the user is **taking over** Gitcord or **moving bots to another PC**:
+
+1. Prefer `./scripts/gitcord-handover` (`pack` / `restore FILE.tar.gz` / `check` / `stop-old`).
+2. Follow [`HANDOVER-EASY.txt`](HANDOVER-EASY.txt) and [`docs/HANDOVER_AI_PROMPT.md`](docs/HANDOVER_AI_PROMPT.md).
+3. Ask for the absolute path to `gitcord-handover-*.tar.gz` if missing.
+4. Do not commit secrets; do not mix AOSSIE/SN; warn if both PCs might run the same Discord tokens.
+5. After restore: `check` → user tests `/profile` + `/who-is` → `stop-old` on the previous PC.
 
 - Add/adjust tests under `tests/` for engine and adapter behavior.
 - CI: `.github/workflows/tests.yml` runs `pytest` on PRs.

--- a/HANDOVER-EASY.txt
+++ b/HANDOVER-EASY.txt
@@ -1,0 +1,62 @@
+GITCORD HANDOVER — SUPER EASY (local PC only)
+============================================
+
+You are moving the running bots from one computer to another.
+No cloud. One USB file. Two commands.
+
+
+ON THE OLD COMPUTER
+-------------------
+1. Open a terminal in the Gitcord folder
+2. Run:
+
+     ./scripts/gitcord-handover pack
+
+3. Find the new file on your Desktop (or Downloads):
+
+     gitcord-handover-________.tar.gz
+
+4. Copy that ONE file to a USB stick
+5. Give the new person:
+     - the USB file
+     - access to both Discord bots + GitHub App
+
+
+ON THE NEW COMPUTER
+-------------------
+1. Install Docker and start it
+2. Clone the repo:
+
+     git clone https://github.com/AOSSIE-Org/Gitcord-GithubDiscordBot.git
+     cd Gitcord-GithubDiscordBot
+
+3. Run (put the real path to the USB file):
+
+     ./scripts/gitcord-handover restore /path/to/gitcord-handover-________.tar.gz
+
+4. Press Enter when asked
+5. In Discord try:  /profile   and   /who-is
+
+
+THEN STOP THE OLD COMPUTER
+--------------------------
+On the OLD PC:
+
+     ./scripts/gitcord-handover stop-old
+
+Only one computer should run the bots.
+
+
+USING AI (Cursor)
+-----------------
+Open docs/HANDOVER_AI_PROMPT.md and paste the prompt into the chat.
+Tell the AI the path to the .tar.gz file.
+
+
+CHECK IF BOTS ARE UP
+--------------------
+
+     ./scripts/gitcord-handover check
+
+
+NEVER put the .tar.gz on public GitHub — it has secret tokens.

--- a/HANDOVER-EASY.txt
+++ b/HANDOVER-EASY.txt
@@ -12,6 +12,8 @@ ON THE OLD COMPUTER
 
      ./scripts/gitcord-handover pack
 
+   (It briefly stops the bots so the database copy is safe, then starts them again.)
+
 3. Find the new file on your Desktop (or Downloads):
 
      gitcord-handover-________.tar.gz

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -24,3 +24,5 @@ This document lists the individuals fulfilling the key roles of [Maintainer](htt
 | Name | GitHub Username | Discord Username | Area / Focus |
 | ---- | --------------- | ---------------- | ------------ |
 | Shubham Shinde | [@shubham5080](https://github.com/shubham5080) | shubham_5080 | Repository maintenance, GSoC implementation, AOSSIE + Stability Nexus live stacks |
+
+When transferring live **local** bots PC → PC, start with **[HANDOVER-EASY.txt](HANDOVER-EASY.txt)** (`./scripts/gitcord-handover pack` → USB → `restore`).

--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ Gitcord is a local, offline‑first automation engine that reads GitHub activity
 6. [AOSSIE Discord — Gitcord thread](https://discord.com/channels/1022871757289422898/1465995983791063140)
 4. [Technical Documentation](TECHNICAL_DOCUMENTATION.md) - Architecture and design
 5. [Docker Guide](docs/DOCKER.md) - Docker setup and mentor-friendly deployment
+6. [Handover (easy)](HANDOVER-EASY.txt) - One USB file: `gitcord-handover pack` → `restore`
+7. [Handover AI prompt](docs/HANDOVER_AI_PROMPT.md) - Paste into Cursor on the new PC
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -84,10 +84,10 @@ Gitcord is a local, offline‑first automation engine that reads GitHub activity
 4. [Brand kit](brand/Brand.md) - Logo, colors, typography, icons
 5. [Maintainers](MAINTAINERS.md) · [Contributing](CONTRIBUTING.md) · [Security](SECURITY.md) · [Best Practices](BestPracticesChecklist.md)
 6. [AOSSIE Discord — Gitcord thread](https://discord.com/channels/1022871757289422898/1465995983791063140)
-4. [Technical Documentation](TECHNICAL_DOCUMENTATION.md) - Architecture and design
-5. [Docker Guide](docs/DOCKER.md) - Docker setup and mentor-friendly deployment
-6. [Handover (easy)](HANDOVER-EASY.txt) - One USB file: `gitcord-handover pack` → `restore`
-7. [Handover AI prompt](docs/HANDOVER_AI_PROMPT.md) - Paste into Cursor on the new PC
+7. [Technical Documentation](TECHNICAL_DOCUMENTATION.md) - Architecture and design
+8. [Docker Guide](docs/DOCKER.md) - Docker setup and mentor-friendly deployment
+9. [Handover (easy)](HANDOVER-EASY.txt) - One USB file: `gitcord-handover pack` → `restore`
+10. [Handover AI prompt](docs/HANDOVER_AI_PROMPT.md) - Paste into Cursor on the new PC
 
 ---
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,8 +32,8 @@ services:
       - ./config:/app/config:ro
       # Persist SQLite state, reports, and audit logs between restarts.
       - gitcord_data:/data
-      # GitHub App private key (GitcordApp[bot] auth — not Bruno PAT).
-      - /home/shubham/privateKeys/gitcordapp.2026-07-29.private-key.pem:/secrets/gitcordapp.pem:ro
+      # GitHub App private key (set GITCORD_PEM_HOST in .env — see handover scripts).
+      - ${GITCORD_PEM_HOST:-${HOME}/privateKeys/gitcordapp.pem}:/secrets/gitcordapp.pem:ro
     command: ["--config", "/app/config/config.yaml", "bot"]
     restart: unless-stopped
 
@@ -55,7 +55,7 @@ services:
       - ./config:/app/config:ro
       - ./scripts:/app/scripts:ro
       - gitcord_data:/data
-      - /home/shubham/privateKeys/gitcordapp.2026-07-29.private-key.pem:/secrets/gitcordapp.pem:ro
+      - ${GITCORD_PEM_HOST:-${HOME}/privateKeys/gitcordapp.pem}:/secrets/gitcordapp.pem:ro
     environment:
       GITCORD_CONFIG: /app/config/config.yaml
       GITCORD_SYNC_INTERVAL_SECONDS: ${GITCORD_SYNC_INTERVAL_SECONDS:-21600}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,8 +32,8 @@ services:
       - ./config:/app/config:ro
       # Persist SQLite state, reports, and audit logs between restarts.
       - gitcord_data:/data
-      # GitHub App private key (set GITCORD_PEM_HOST in .env — see handover scripts).
-      - ${GITCORD_PEM_HOST:-${HOME}/privateKeys/gitcordapp.pem}:/secrets/gitcordapp.pem:ro
+      # GitHub App private key (set GITCORD_PEM_HOST in .env — required).
+      - ${GITCORD_PEM_HOST:?Set GITCORD_PEM_HOST to the host path of the GitHub App PEM}:/secrets/gitcordapp.pem:ro
     command: ["--config", "/app/config/config.yaml", "bot"]
     restart: unless-stopped
 
@@ -55,7 +55,7 @@ services:
       - ./config:/app/config:ro
       - ./scripts:/app/scripts:ro
       - gitcord_data:/data
-      - ${GITCORD_PEM_HOST:-${HOME}/privateKeys/gitcordapp.pem}:/secrets/gitcordapp.pem:ro
+      - ${GITCORD_PEM_HOST:?Set GITCORD_PEM_HOST to the host path of the GitHub App PEM}:/secrets/gitcordapp.pem:ro
     environment:
       GITCORD_CONFIG: /app/config/config.yaml
       GITCORD_SYNC_INTERVAL_SECONDS: ${GITCORD_SYNC_INTERVAL_SECONDS:-21600}

--- a/docs/HANDOVER.md
+++ b/docs/HANDOVER.md
@@ -13,10 +13,12 @@
 
 **AI:** paste [`HANDOVER_AI_PROMPT.md`](HANDOVER_AI_PROMPT.md) into Cursor and give the `.tar.gz` path.
 
-### Rules
+## Rules
+
 - Do not commit the `.tar.gz` or `.env` / `.pem`
 - Do not run bots on two PCs with the same Discord token
 - Keep AOSSIE and Stability Nexus separate (the script already does)
 
-### Details
+## Details
+
 Docker background: [DOCKER.md](DOCKER.md). Safety: [AGENTS.md](../AGENTS.md).

--- a/docs/HANDOVER.md
+++ b/docs/HANDOVER.md
@@ -1,0 +1,22 @@
+# Gitcord — Local handover
+
+**Start here:** [`HANDOVER-EASY.txt`](../HANDOVER-EASY.txt) (plain language).
+
+**One tool:** `./scripts/gitcord-handover`
+
+| Who | Command |
+| --- | --- |
+| Old PC | `./scripts/gitcord-handover pack` → one `.tar.gz` on Desktop |
+| New PC | `./scripts/gitcord-handover restore /path/to/that.tar.gz` |
+| Old PC after move | `./scripts/gitcord-handover stop-old` |
+| Anyone | `./scripts/gitcord-handover check` |
+
+**AI:** paste [`HANDOVER_AI_PROMPT.md`](HANDOVER_AI_PROMPT.md) into Cursor and give the `.tar.gz` path.
+
+### Rules
+- Do not commit the `.tar.gz` or `.env` / `.pem`
+- Do not run bots on two PCs with the same Discord token
+- Keep AOSSIE and Stability Nexus separate (the script already does)
+
+### Details
+Docker background: [DOCKER.md](DOCKER.md). Safety: [AGENTS.md](../AGENTS.md).

--- a/docs/HANDOVER_AI_PROMPT.md
+++ b/docs/HANDOVER_AI_PROMPT.md
@@ -14,7 +14,7 @@ I will give you the path to: gitcord-handover-*.tar.gz
 Do exactly:
 1. Confirm Docker is installed and running.
 2. From repo root run:
-   ./scripts/gitcord-handover restore /ABS/PATH/TO/gitcord-handover-*.tar.gz
+   ./scripts/gitcord-handover restore --force /ABS/PATH/TO/gitcord-handover-*.tar.gz
 3. Run: ./scripts/gitcord-handover check
 4. Tell me to test in Discord: /profile and /who-is (AOSSIE + Stability Nexus).
 5. After I confirm OK, tell me to run on the OLD PC:
@@ -25,8 +25,10 @@ Rules:
 - Never invent tokens or skip restore (empty DB is wrong).
 - Never mix AOSSIE and Stability Nexus.
 - Warn if old PC might still be running the same Discord tokens.
+- Use --force only when I already confirmed wipe/replace is OK.
 - Explain in simple language.
 - If pack is needed on old PC: ./scripts/gitcord-handover pack
+  (pack briefly stops bots for a consistent DB snapshot, then restarts them)
 ```
 
 ---

--- a/docs/HANDOVER_AI_PROMPT.md
+++ b/docs/HANDOVER_AI_PROMPT.md
@@ -1,0 +1,39 @@
+# AI prompt — easy Gitcord handover
+
+Paste into Cursor on the **new** PC (inside this repo). Human cheat sheet: [`HANDOVER-EASY.txt`](../HANDOVER-EASY.txt).
+
+---
+
+```text
+Help me install the live Gitcord bots on this PC from ONE handover file.
+
+Read HANDOVER-EASY.txt and docs/HANDOVER.md.
+
+I will give you the path to: gitcord-handover-*.tar.gz
+
+Do exactly:
+1. Confirm Docker is installed and running.
+2. From repo root run:
+   ./scripts/gitcord-handover restore /ABS/PATH/TO/gitcord-handover-*.tar.gz
+3. Run: ./scripts/gitcord-handover check
+4. Tell me to test in Discord: /profile and /who-is (AOSSIE + Stability Nexus).
+5. After I confirm OK, tell me to run on the OLD PC:
+   ./scripts/gitcord-handover stop-old
+
+Rules:
+- Never commit .env, .pem, .tar.gz, or databases.
+- Never invent tokens or skip restore (empty DB is wrong).
+- Never mix AOSSIE and Stability Nexus.
+- Warn if old PC might still be running the same Discord tokens.
+- Explain in simple language.
+- If pack is needed on old PC: ./scripts/gitcord-handover pack
+```
+
+---
+
+Short:
+
+```text
+Run ./scripts/gitcord-handover restore <my.tar.gz> per HANDOVER-EASY.txt.
+Then check, Discord smoke-test, then stop-old on the previous PC. No secrets in git.
+```

--- a/docs/HANDOVER_AI_PROMPT.md
+++ b/docs/HANDOVER_AI_PROMPT.md
@@ -13,11 +13,12 @@ I will give you the path to: gitcord-handover-*.tar.gz
 
 Do exactly:
 1. Confirm Docker is installed and running.
-2. From repo root run:
-   ./scripts/gitcord-handover restore --force /ABS/PATH/TO/gitcord-handover-*.tar.gz
-3. Run: ./scripts/gitcord-handover check
-4. Tell me to test in Discord: /profile and /who-is (AOSSIE + Stability Nexus).
-5. After I confirm OK, tell me to run on the OLD PC:
+2. Ask me whether replacing existing .env/config/volumes is OK.
+3. From repo root run (only add --force after I explicitly approve replace):
+   ./scripts/gitcord-handover restore /ABS/PATH/TO/gitcord-handover-*.tar.gz
+4. Run: ./scripts/gitcord-handover check
+5. Tell me to test in Discord: /profile and /who-is (AOSSIE + Stability Nexus).
+6. After I confirm OK, tell me to run on the OLD PC:
    ./scripts/gitcord-handover stop-old
 
 Rules:
@@ -25,7 +26,7 @@ Rules:
 - Never invent tokens or skip restore (empty DB is wrong).
 - Never mix AOSSIE and Stability Nexus.
 - Warn if old PC might still be running the same Discord tokens.
-- Use --force only when I already confirmed wipe/replace is OK.
+- Never pass --force unless I explicitly confirm wipe/replace.
 - Explain in simple language.
 - If pack is needed on old PC: ./scripts/gitcord-handover pack
   (pack briefly stops bots for a consistent DB snapshot, then restarts them)

--- a/scripts/gitcord-handover
+++ b/scripts/gitcord-handover
@@ -1,0 +1,285 @@
+#!/usr/bin/env bash
+# Gitcord easy handover — one file in, one file out (local Docker only).
+#
+# OLD PC:   ./scripts/gitcord-handover pack
+#           → creates ONE file on Desktop/Downloads (copy via USB)
+#
+# NEW PC:   git clone … && cd Gitcord-GithubDiscordBot
+#           ./scripts/gitcord-handover restore /path/to/gitcord-handover-*.tar.gz
+#
+# Check:    ./scripts/gitcord-handover check
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+AOSSIE_VOL=gitcord-githubdiscordbot_gitcord_data
+SN_VOL=gitcord-stability_gitcord_stability_data
+DEFAULT_PEM="${HOME}/privateKeys/gitcordapp.pem"
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+ok() { echo "✓ $*"; }
+info() { echo "→ $*"; }
+
+need_docker() {
+  command -v docker >/dev/null 2>&1 || die "Docker is not installed. Install Docker Desktop (or Docker Engine), then retry."
+  docker info >/dev/null 2>&1 || die "Docker is installed but not running. Start Docker, then retry."
+}
+
+detect_pem() {
+  if [[ -n "${GITCORD_PEM_HOST:-}" && -f "${GITCORD_PEM_HOST}" ]]; then
+    printf '%s' "$GITCORD_PEM_HOST"
+    return
+  fi
+  if [[ -f "$DEFAULT_PEM" ]]; then
+    printf '%s' "$DEFAULT_PEM"
+    return
+  fi
+  # Legacy / current maintainer path from older compose mounts
+  local legacy
+  for legacy in \
+    "${HOME}/privateKeys/gitcordapp.2026-07-29.private-key.pem" \
+    /home/shubham/privateKeys/gitcordapp.2026-07-29.private-key.pem
+  do
+    if [[ -f "$legacy" ]]; then
+      printf '%s' "$legacy"
+      return
+    fi
+  done
+  printf ''
+}
+
+pick_out_dir() {
+  if [[ -d "${HOME}/Desktop" ]]; then
+    printf '%s' "${HOME}/Desktop"
+  elif [[ -d "${HOME}/Downloads" ]]; then
+    printf '%s' "${HOME}/Downloads"
+  else
+    printf '%s' "${HOME}"
+  fi
+}
+
+ensure_pem_host_in_env() {
+  local pem_path="$1"
+  local envfile="$2"
+  if [[ ! -f "$envfile" ]]; then
+    return
+  fi
+  if grep -q '^GITCORD_PEM_HOST=' "$envfile" 2>/dev/null; then
+    # portable replace
+    local tmp
+    tmp="$(mktemp)"
+    grep -v '^GITCORD_PEM_HOST=' "$envfile" >"$tmp"
+    echo "GITCORD_PEM_HOST=${pem_path}" >>"$tmp"
+    mv "$tmp" "$envfile"
+  else
+    printf '\n# Host path to GitHub App PEM (used by docker compose mount)\nGITCORD_PEM_HOST=%s\n' "$pem_path" >>"$envfile"
+  fi
+}
+
+cmd_pack() {
+  need_docker
+  [[ -f .env ]] || die "Missing .env — is this the machine that already runs Gitcord?"
+  [[ -f .env.stability-nexus ]] || die "Missing .env.stability-nexus"
+  [[ -f config/config.yaml ]] || die "Missing config/config.yaml"
+  [[ -f config/stability-nexus.yaml ]] || die "Missing config/stability-nexus.yaml"
+
+  local pem
+  pem="$(detect_pem)"
+  [[ -n "$pem" ]] || die "GitHub App key (.pem) not found. Set GITCORD_PEM_HOST=/full/path/to/key.pem"
+
+  local out_dir stamp work archive
+  out_dir="${1:-$(pick_out_dir)}"
+  stamp="$(date -u +%Y%m%dT%H%M%SZ)"
+  work="$(mktemp -d "${TMPDIR:-/tmp}/gitcord-handover.XXXXXX")"
+  archive="${out_dir}/gitcord-handover-${stamp}.tar.gz"
+  mkdir -p "$out_dir" "$work/bundle/volumes"
+
+  info "Packing secrets + databases (this is the whole live bot state)…"
+  cp .env "$work/bundle/aossie.env"
+  cp .env.stability-nexus "$work/bundle/stability-nexus.env"
+  cp config/config.yaml "$work/bundle/config.yaml"
+  cp config/stability-nexus.yaml "$work/bundle/stability-nexus.yaml"
+  cp "$pem" "$work/bundle/gitcordapp.pem"
+  # SN compose is usually gitignored on the maintainer machine — ship it in the pack.
+  if [[ -f docker-compose.stability-nexus.yml ]]; then
+    cp docker-compose.stability-nexus.yml "$work/bundle/docker-compose.stability-nexus.yml"
+  fi
+
+  docker volume inspect "$AOSSIE_VOL" >/dev/null 2>&1 || die "AOSSIE volume missing ($AOSSIE_VOL). Are the bots on this PC?"
+  docker volume inspect "$SN_VOL" >/dev/null 2>&1 || die "Stability Nexus volume missing ($SN_VOL)."
+
+  docker run --rm \
+    -v "${AOSSIE_VOL}:/data:ro" \
+    -v "$work/bundle/volumes:/out" \
+    alpine tar czf /out/aossie-data.tgz -C /data .
+
+  docker run --rm \
+    -v "${SN_VOL}:/data:ro" \
+    -v "$work/bundle/volumes:/out" \
+    alpine tar czf /out/stability-data.tgz -C /data .
+
+  cat >"$work/bundle/README.txt" <<EOF
+Gitcord handover bundle (${stamp})
+Give this .tar.gz to the next person with Discord + GitHub App access.
+
+On their PC:
+  1. Install Docker and start it
+  2. git clone https://github.com/AOSSIE-Org/Gitcord-GithubDiscordBot.git
+  3. cd Gitcord-GithubDiscordBot
+  4. ./scripts/gitcord-handover restore /path/to/this-file.tar.gz
+EOF
+
+  tar -czf "$archive" -C "$work/bundle" .
+  rm -rf "$work"
+
+  echo
+  ok "DONE — one file created:"
+  echo "    $archive"
+  echo
+  echo "Next:"
+  echo "  1) Copy that file to a USB (or send encrypted)."
+  echo "  2) On the new PC run:  ./scripts/gitcord-handover restore <that-file>"
+  echo "  3) After Discord works there, stop bots on THIS PC."
+  echo
+  echo "Do NOT upload this file to public GitHub."
+}
+
+cmd_restore() {
+  need_docker
+  local archive="${1:-}"
+  [[ -n "$archive" ]] || die "Usage: ./scripts/gitcord-handover restore /path/to/gitcord-handover-*.tar.gz"
+  [[ -f "$archive" ]] || die "File not found: $archive"
+
+  local work pem_host
+  work="$(mktemp -d "${TMPDIR:-/tmp}/gitcord-restore.XXXXXX")"
+  info "Opening handover file…"
+  tar -xzf "$archive" -C "$work"
+
+  [[ -f "$work/aossie.env" ]] || die "Bad handover file (missing aossie.env)."
+  [[ -f "$work/stability-nexus.env" ]] || die "Bad handover file (missing stability-nexus.env)."
+  [[ -f "$work/config.yaml" ]] || die "Bad handover file (missing config.yaml)."
+  [[ -f "$work/stability-nexus.yaml" ]] || die "Bad handover file (missing stability-nexus.yaml)."
+  [[ -f "$work/gitcordapp.pem" ]] || die "Bad handover file (missing gitcordapp.pem)."
+  [[ -f "$work/volumes/aossie-data.tgz" ]] || die "Bad handover file (missing volumes/aossie-data.tgz)."
+  [[ -f "$work/volumes/stability-data.tgz" ]] || die "Bad handover file (missing volumes/stability-data.tgz)."
+
+  pem_host="${GITCORD_PEM_HOST:-$DEFAULT_PEM}"
+  mkdir -p "$(dirname "$pem_host")"
+  cp "$work/gitcordapp.pem" "$pem_host"
+  chmod 600 "$pem_host"
+  ok "Saved GitHub App key to $pem_host"
+
+  cp "$work/aossie.env" .env
+  cp "$work/stability-nexus.env" .env.stability-nexus
+  mkdir -p config
+  cp "$work/config.yaml" config/config.yaml
+  cp "$work/stability-nexus.yaml" config/stability-nexus.yaml
+  if [[ -f "$work/docker-compose.stability-nexus.yml" ]]; then
+    cp "$work/docker-compose.stability-nexus.yml" docker-compose.stability-nexus.yml
+  elif [[ ! -f docker-compose.stability-nexus.yml ]]; then
+    die "Missing docker-compose.stability-nexus.yml (not in repo clone or handover file)."
+  fi
+  # Ensure PEM mount uses GITCORD_PEM_HOST on both compose files.
+  for compose in docker-compose.yml docker-compose.stability-nexus.yml; do
+    if [[ -f "$compose" ]] && ! grep -q 'GITCORD_PEM_HOST' "$compose"; then
+      sed -i -E "s#- [^:]+:/secrets/gitcordapp\.pem:ro#- \$\{GITCORD_PEM_HOST:-$\{HOME\}/privateKeys/gitcordapp.pem\}:/secrets/gitcordapp.pem:ro#g" "$compose"
+    fi
+  done
+  ensure_pem_host_in_env "$pem_host" .env
+  ensure_pem_host_in_env "$pem_host" .env.stability-nexus
+  ok "Installed env + config"
+
+  info "Restoring bot databases (verified users + sync progress)…"
+  docker volume create "$AOSSIE_VOL" >/dev/null
+  docker volume create "$SN_VOL" >/dev/null
+  docker run --rm \
+    -v "${AOSSIE_VOL}:/data" \
+    -v "$work/volumes:/in:ro" \
+    alpine sh -c 'find /data -mindepth 1 -maxdepth 1 -exec rm -rf {} +; tar xzf /in/aossie-data.tgz -C /data'
+  docker run --rm \
+    -v "${SN_VOL}:/data" \
+    -v "$work/volumes:/in:ro" \
+    alpine sh -c 'find /data -mindepth 1 -maxdepth 1 -exec rm -rf {} +; tar xzf /in/stability-data.tgz -C /data'
+  ok "Databases restored"
+  rm -rf "$work"
+
+  echo
+  info "IMPORTANT: Only one PC should run the bots."
+  echo "  If the old PC is still running Gitcord, stop it first, then press Enter."
+  echo "  If this is the only PC, just press Enter."
+  read -r -p "Press Enter to start both bots… " _
+
+  export GITCORD_PEM_HOST="$pem_host"
+  info "Starting AOSSIE…"
+  docker compose -p gitcord-githubdiscordbot --profile scheduler up -d --build
+  info "Starting Stability Nexus…"
+  docker compose -p gitcord-stability \
+    -f docker-compose.stability-nexus.yml \
+    --env-file .env.stability-nexus \
+    --profile scheduler up -d --build
+
+  echo
+  cmd_check
+  echo
+  ok "Bots should be starting."
+  echo "In Discord (AOSSIE + Stability Nexus) try:  /profile   and   /who-is"
+  echo "If that works, on the OLD PC run:"
+  echo "  ./scripts/gitcord-handover stop-old"
+}
+
+cmd_check() {
+  need_docker
+  echo "Containers:"
+  docker ps --filter name=gitcord --format 'table {{.Names}}\t{{.Status}}' || true
+  local n
+  n="$(docker ps --filter name=gitcord --format '{{.Names}}' | wc -l | tr -d ' ')"
+  if [[ "$n" -lt 4 ]]; then
+    echo
+    echo "Expected 4 running containers (2 bots + 2 schedulers). Got: $n"
+    echo "Check logs:"
+    echo "  docker compose -p gitcord-githubdiscordbot logs --tail 40 bot sync-scheduler"
+    echo "  docker compose -p gitcord-stability -f docker-compose.stability-nexus.yml logs --tail 40 bot sync-scheduler"
+  else
+    ok "All 4 Gitcord containers look up"
+  fi
+}
+
+cmd_stop_old() {
+  need_docker
+  info "Stopping AOSSIE + Stability Nexus on this machine…"
+  docker compose -p gitcord-githubdiscordbot --profile scheduler down || true
+  docker compose -p gitcord-stability \
+    -f docker-compose.stability-nexus.yml \
+    --env-file .env.stability-nexus \
+    --profile scheduler down || true
+  ok "Stopped. Safe for the other PC to be the only host."
+}
+
+usage() {
+  cat <<EOF
+Gitcord easy handover (local PC → local PC)
+
+  ./scripts/gitcord-handover pack              Create ONE handover file (USB this)
+  ./scripts/gitcord-handover restore FILE.tar.gz   Install on a new PC and start bots
+  ./scripts/gitcord-handover check             See if bots are running
+  ./scripts/gitcord-handover stop-old          Stop bots on this PC (after move)
+
+Need help? Open HANDOVER-EASY.txt or docs/HANDOVER.md
+AI users: paste docs/HANDOVER_AI_PROMPT.md into Cursor
+EOF
+}
+
+main() {
+  local cmd="${1:-}"
+  case "$cmd" in
+    pack) shift; cmd_pack "${1:-}" ;;
+    restore) shift; cmd_restore "${1:-}" ;;
+    check) cmd_check ;;
+    stop-old|stop) cmd_stop_old ;;
+    -h|--help|help|"") usage ;;
+    *) die "Unknown command: $cmd (try: pack | restore | check | stop-old)" ;;
+  esac
+}
+
+main "$@"

--- a/scripts/gitcord-handover
+++ b/scripts/gitcord-handover
@@ -16,10 +16,25 @@ cd "$ROOT"
 AOSSIE_VOL=gitcord-githubdiscordbot_gitcord_data
 SN_VOL=gitcord-stability_gitcord_stability_data
 DEFAULT_PEM="${HOME}/privateKeys/gitcordapp.pem"
+PEM_COMPOSE_LINE='- ${GITCORD_PEM_HOST:?Set GITCORD_PEM_HOST to the host path of the GitHub App PEM}:/secrets/gitcordapp.pem:ro'
+FORCE=0
 
 die() { echo "ERROR: $*" >&2; exit 1; }
 ok() { echo "✓ $*"; }
 info() { echo "→ $*"; }
+
+confirm() {
+  local prompt="$1"
+  if [[ "$FORCE" -eq 1 ]]; then
+    return 0
+  fi
+  if [[ ! -t 0 ]]; then
+    die "$prompt (non-interactive: pass --force to confirm)"
+  fi
+  local ans=""
+  read -r -p "$prompt [y/N] " ans || true
+  [[ "$ans" == "y" || "$ans" == "Y" || "$ans" == "yes" ]]
+}
 
 need_docker() {
   command -v docker >/dev/null 2>&1 || die "Docker is not installed. Install Docker Desktop (or Docker Engine), then retry."
@@ -35,14 +50,11 @@ detect_pem() {
     printf '%s' "$DEFAULT_PEM"
     return
   fi
-  # Legacy / current maintainer path from older compose mounts
-  local legacy
-  for legacy in \
-    "${HOME}/privateKeys/gitcordapp.2026-07-29.private-key.pem" \
-    /home/shubham/privateKeys/gitcordapp.2026-07-29.private-key.pem
-  do
-    if [[ -f "$legacy" ]]; then
-      printf '%s' "$legacy"
+  # Dated App key filenames under ~/privateKeys/
+  local candidate
+  for candidate in "${HOME}/privateKeys"/gitcordapp*.pem "${HOME}/privateKeys"/*.private-key.pem; do
+    if [[ -f "$candidate" ]]; then
+      printf '%s' "$candidate"
       return
     fi
   done
@@ -65,16 +77,75 @@ ensure_pem_host_in_env() {
   if [[ ! -f "$envfile" ]]; then
     return
   fi
+  local tmp
+  tmp="$(mktemp)"
   if grep -q '^GITCORD_PEM_HOST=' "$envfile" 2>/dev/null; then
-    # portable replace
-    local tmp
-    tmp="$(mktemp)"
     grep -v '^GITCORD_PEM_HOST=' "$envfile" >"$tmp"
-    echo "GITCORD_PEM_HOST=${pem_path}" >>"$tmp"
-    mv "$tmp" "$envfile"
   else
-    printf '\n# Host path to GitHub App PEM (used by docker compose mount)\nGITCORD_PEM_HOST=%s\n' "$pem_path" >>"$envfile"
+    cp "$envfile" "$tmp"
   fi
+  printf '\n# Host path to GitHub App PEM (required by docker compose mount)\nGITCORD_PEM_HOST=%s\n' "$pem_path" >>"$tmp"
+  mv "$tmp" "$envfile"
+}
+
+rewrite_compose_pem_mount() {
+  local compose="$1"
+  [[ -f "$compose" ]] || return 0
+  local tmp
+  tmp="$(mktemp)"
+  # Replace any host-path PEM mount with the required GITCORD_PEM_HOST form.
+  sed -E "s#- [^:]+:/secrets/gitcordapp\\.pem:ro#${PEM_COMPOSE_LINE}#g" "$compose" >"$tmp"
+  mv "$tmp" "$compose"
+}
+
+volume_nonempty() {
+  local vol="$1"
+  docker volume inspect "$vol" >/dev/null 2>&1 || return 1
+  local count
+  count="$(
+    docker run --rm -v "${vol}:/data:ro" alpine \
+      sh -c 'find /data -mindepth 1 -maxdepth 1 | wc -l' | tr -d ' '
+  )"
+  [[ "${count:-0}" -gt 0 ]]
+}
+
+stop_stacks() {
+  info "Stopping AOSSIE + Stability Nexus (safe DB snapshot / cutover)…"
+  docker compose -p gitcord-githubdiscordbot --profile scheduler down || true
+  if [[ -f docker-compose.stability-nexus.yml ]]; then
+    docker compose -p gitcord-stability \
+      -f docker-compose.stability-nexus.yml \
+      --env-file .env.stability-nexus \
+      --profile scheduler down || true
+  fi
+}
+
+start_stacks() {
+  local pem_host="${1:-${GITCORD_PEM_HOST:-}}"
+  [[ -n "$pem_host" ]] || die "GITCORD_PEM_HOST is not set"
+  export GITCORD_PEM_HOST="$pem_host"
+  info "Starting AOSSIE…"
+  docker compose -p gitcord-githubdiscordbot --profile scheduler up -d --build
+  info "Starting Stability Nexus…"
+  docker compose -p gitcord-stability \
+    -f docker-compose.stability-nexus.yml \
+    --env-file .env.stability-nexus \
+    --profile scheduler up -d --build
+}
+
+install_pem() {
+  local src="$1"
+  local dest="$2"
+  mkdir -p "$(dirname "$dest")"
+  if [[ -f "$dest" ]]; then
+    local bak="${dest}.bak.$(date -u +%Y%m%dT%H%M%SZ)"
+    info "Backing up existing PEM to $bak"
+    cp -p "$dest" "$bak"
+    chmod 600 "$bak" 2>/dev/null || true
+  fi
+  # Create with mode 600 immediately (no world-readable window).
+  (umask 077 && cat "$src" >"$dest")
+  chmod 600 "$dest"
 }
 
 cmd_pack() {
@@ -88,12 +159,19 @@ cmd_pack() {
   pem="$(detect_pem)"
   [[ -n "$pem" ]] || die "GitHub App key (.pem) not found. Set GITCORD_PEM_HOST=/full/path/to/key.pem"
 
+  confirm "Pack will briefly STOP both bots so the database copy is consistent. Continue?" \
+    || die "Pack cancelled."
+
   local out_dir stamp work archive
   out_dir="${1:-$(pick_out_dir)}"
   stamp="$(date -u +%Y%m%dT%H%M%SZ)"
+  umask 077
   work="$(mktemp -d "${TMPDIR:-/tmp}/gitcord-handover.XXXXXX")"
+  trap 'rm -rf "$work"' EXIT INT TERM
   archive="${out_dir}/gitcord-handover-${stamp}.tar.gz"
   mkdir -p "$out_dir" "$work/bundle/volumes"
+
+  stop_stacks
 
   info "Packing secrets + databases (this is the whole live bot state)…"
   cp .env "$work/bundle/aossie.env"
@@ -101,7 +179,6 @@ cmd_pack() {
   cp config/config.yaml "$work/bundle/config.yaml"
   cp config/stability-nexus.yaml "$work/bundle/stability-nexus.yaml"
   cp "$pem" "$work/bundle/gitcordapp.pem"
-  # SN compose is usually gitignored on the maintainer machine — ship it in the pack.
   if [[ -f docker-compose.stability-nexus.yml ]]; then
     cp docker-compose.stability-nexus.yml "$work/bundle/docker-compose.stability-nexus.yml"
   fi
@@ -131,7 +208,14 @@ On their PC:
 EOF
 
   tar -czf "$archive" -C "$work/bundle" .
+  chmod 600 "$archive" 2>/dev/null || true
   rm -rf "$work"
+  trap - EXIT INT TERM
+
+  # Bring bots back so the old PC keeps serving until cutover.
+  ensure_pem_host_in_env "$pem" .env
+  ensure_pem_host_in_env "$pem" .env.stability-nexus
+  start_stacks "$pem" || info "Could not auto-restart bots — start them manually if needed."
 
   echo
   ok "DONE — one file created:"
@@ -140,7 +224,8 @@ EOF
   echo "Next:"
   echo "  1) Copy that file to a USB (or send encrypted)."
   echo "  2) On the new PC run:  ./scripts/gitcord-handover restore <that-file>"
-  echo "  3) After Discord works there, stop bots on THIS PC."
+  echo "  3) After Discord works there, stop bots on THIS PC:"
+  echo "       ./scripts/gitcord-handover stop-old"
   echo
   echo "Do NOT upload this file to public GitHub."
 }
@@ -148,11 +233,13 @@ EOF
 cmd_restore() {
   need_docker
   local archive="${1:-}"
-  [[ -n "$archive" ]] || die "Usage: ./scripts/gitcord-handover restore /path/to/gitcord-handover-*.tar.gz"
+  [[ -n "$archive" ]] || die "Usage: ./scripts/gitcord-handover restore [--force] /path/to/gitcord-handover-*.tar.gz"
   [[ -f "$archive" ]] || die "File not found: $archive"
 
   local work pem_host
+  umask 077
   work="$(mktemp -d "${TMPDIR:-/tmp}/gitcord-restore.XXXXXX")"
+  trap 'rm -rf "$work"' EXIT INT TERM
   info "Opening handover file…"
   tar -xzf "$archive" -C "$work"
 
@@ -164,10 +251,13 @@ cmd_restore() {
   [[ -f "$work/volumes/aossie-data.tgz" ]] || die "Bad handover file (missing volumes/aossie-data.tgz)."
   [[ -f "$work/volumes/stability-data.tgz" ]] || die "Bad handover file (missing volumes/stability-data.tgz)."
 
+  if volume_nonempty "$AOSSIE_VOL" || volume_nonempty "$SN_VOL"; then
+    confirm "Existing Gitcord data found on this PC. Restore will REPLACE it. Continue?" \
+      || die "Restore cancelled (existing volumes left untouched)."
+  fi
+
   pem_host="${GITCORD_PEM_HOST:-$DEFAULT_PEM}"
-  mkdir -p "$(dirname "$pem_host")"
-  cp "$work/gitcordapp.pem" "$pem_host"
-  chmod 600 "$pem_host"
+  install_pem "$work/gitcordapp.pem" "$pem_host"
   ok "Saved GitHub App key to $pem_host"
 
   cp "$work/aossie.env" .env
@@ -180,15 +270,20 @@ cmd_restore() {
   elif [[ ! -f docker-compose.stability-nexus.yml ]]; then
     die "Missing docker-compose.stability-nexus.yml (not in repo clone or handover file)."
   fi
-  # Ensure PEM mount uses GITCORD_PEM_HOST on both compose files.
-  for compose in docker-compose.yml docker-compose.stability-nexus.yml; do
-    if [[ -f "$compose" ]] && ! grep -q 'GITCORD_PEM_HOST' "$compose"; then
-      sed -i -E "s#- [^:]+:/secrets/gitcordapp\.pem:ro#- \$\{GITCORD_PEM_HOST:-$\{HOME\}/privateKeys/gitcordapp.pem\}:/secrets/gitcordapp.pem:ro#g" "$compose"
-    fi
-  done
+  rewrite_compose_pem_mount docker-compose.yml
+  rewrite_compose_pem_mount docker-compose.stability-nexus.yml
   ensure_pem_host_in_env "$pem_host" .env
   ensure_pem_host_in_env "$pem_host" .env.stability-nexus
   ok "Installed env + config"
+
+  echo
+  info "IMPORTANT: Only one PC should run the bots."
+  echo "  If the old PC is still running Gitcord, stop it first."
+  if [[ -t 0 ]]; then
+    read -r -p "Press Enter to wipe local volumes (if any) and start both bots… " _ || true
+  else
+    info "Non-interactive shell: continuing without confirmation."
+  fi
 
   info "Restoring bot databases (verified users + sync progress)…"
   docker volume create "$AOSSIE_VOL" >/dev/null
@@ -203,21 +298,9 @@ cmd_restore() {
     alpine sh -c 'find /data -mindepth 1 -maxdepth 1 -exec rm -rf {} +; tar xzf /in/stability-data.tgz -C /data'
   ok "Databases restored"
   rm -rf "$work"
+  trap - EXIT INT TERM
 
-  echo
-  info "IMPORTANT: Only one PC should run the bots."
-  echo "  If the old PC is still running Gitcord, stop it first, then press Enter."
-  echo "  If this is the only PC, just press Enter."
-  read -r -p "Press Enter to start both bots… " _
-
-  export GITCORD_PEM_HOST="$pem_host"
-  info "Starting AOSSIE…"
-  docker compose -p gitcord-githubdiscordbot --profile scheduler up -d --build
-  info "Starting Stability Nexus…"
-  docker compose -p gitcord-stability \
-    -f docker-compose.stability-nexus.yml \
-    --env-file .env.stability-nexus \
-    --profile scheduler up -d --build
+  start_stacks "$pem_host"
 
   echo
   cmd_check
@@ -247,12 +330,7 @@ cmd_check() {
 
 cmd_stop_old() {
   need_docker
-  info "Stopping AOSSIE + Stability Nexus on this machine…"
-  docker compose -p gitcord-githubdiscordbot --profile scheduler down || true
-  docker compose -p gitcord-stability \
-    -f docker-compose.stability-nexus.yml \
-    --env-file .env.stability-nexus \
-    --profile scheduler down || true
+  stop_stacks
   ok "Stopped. Safe for the other PC to be the only host."
 }
 
@@ -260,10 +338,12 @@ usage() {
   cat <<EOF
 Gitcord easy handover (local PC → local PC)
 
-  ./scripts/gitcord-handover pack              Create ONE handover file (USB this)
-  ./scripts/gitcord-handover restore FILE.tar.gz   Install on a new PC and start bots
-  ./scripts/gitcord-handover check             See if bots are running
-  ./scripts/gitcord-handover stop-old          Stop bots on this PC (after move)
+  ./scripts/gitcord-handover pack [--force]              Create ONE handover file (USB this)
+  ./scripts/gitcord-handover restore [--force] FILE.tar.gz   Install on a new PC and start bots
+  ./scripts/gitcord-handover check                       See if bots are running
+  ./scripts/gitcord-handover stop-old                    Stop bots on this PC (after move)
+
+  --force   Skip y/N confirms (for AI / non-interactive use)
 
 Need help? Open HANDOVER-EASY.txt or docs/HANDOVER.md
 AI users: paste docs/HANDOVER_AI_PROMPT.md into Cursor
@@ -271,6 +351,16 @@ EOF
 }
 
 main() {
+  local args=()
+  local arg
+  for arg in "$@"; do
+    case "$arg" in
+      --force) FORCE=1 ;;
+      *) args+=("$arg") ;;
+    esac
+  done
+  set -- "${args[@]+"${args[@]}"}"
+
   local cmd="${1:-}"
   case "$cmd" in
     pack) shift; cmd_pack "${1:-}" ;;

--- a/scripts/gitcord-handover
+++ b/scripts/gitcord-handover
@@ -110,13 +110,30 @@ volume_nonempty() {
 }
 
 stop_stacks() {
+  # Usage: stop_stacks [strict]
+  # strict=1 → missing SN compose or compose-down failure aborts (pack/restore).
+  local strict="${1:-0}"
   info "Stopping AOSSIE + Stability Nexus (safe DB snapshot / cutover)…"
-  docker compose -p gitcord-githubdiscordbot --profile scheduler down || true
-  if [[ -f docker-compose.stability-nexus.yml ]]; then
-    docker compose -p gitcord-stability \
-      -f docker-compose.stability-nexus.yml \
-      --env-file .env.stability-nexus \
-      --profile scheduler down || true
+  if ! docker compose -p gitcord-githubdiscordbot --profile scheduler down; then
+    if [[ "$strict" == "1" ]]; then
+      die "Failed to stop AOSSIE stack (gitcord-githubdiscordbot)."
+    fi
+    info "AOSSIE stop returned non-zero (continuing)."
+  fi
+  if [[ ! -f docker-compose.stability-nexus.yml ]]; then
+    if [[ "$strict" == "1" ]]; then
+      die "Missing docker-compose.stability-nexus.yml (required for both stacks)."
+    fi
+    return 0
+  fi
+  if ! docker compose -p gitcord-stability \
+    -f docker-compose.stability-nexus.yml \
+    --env-file .env.stability-nexus \
+    --profile scheduler down; then
+    if [[ "$strict" == "1" ]]; then
+      die "Failed to stop Stability Nexus stack (gitcord-stability)."
+    fi
+    info "Stability Nexus stop returned non-zero (continuing)."
   fi
 }
 
@@ -154,6 +171,8 @@ cmd_pack() {
   [[ -f .env.stability-nexus ]] || die "Missing .env.stability-nexus"
   [[ -f config/config.yaml ]] || die "Missing config/config.yaml"
   [[ -f config/stability-nexus.yaml ]] || die "Missing config/stability-nexus.yaml"
+  [[ -f docker-compose.stability-nexus.yml ]] \
+    || die "Missing docker-compose.stability-nexus.yml (required so the pack can restore SN)."
 
   local pem
   pem="$(detect_pem)"
@@ -162,16 +181,27 @@ cmd_pack() {
   confirm "Pack will briefly STOP both bots so the database copy is consistent. Continue?" \
     || die "Pack cancelled."
 
-  local out_dir stamp work archive
+  local out_dir stamp work archive pack_need_restart=0
   out_dir="${1:-$(pick_out_dir)}"
   stamp="$(date -u +%Y%m%dT%H%M%SZ)"
   umask 077
   work="$(mktemp -d "${TMPDIR:-/tmp}/gitcord-handover.XXXXXX")"
-  trap 'rm -rf "$work"' EXIT INT TERM
   archive="${out_dir}/gitcord-handover-${stamp}.tar.gz"
   mkdir -p "$out_dir" "$work/bundle/volumes"
 
-  stop_stacks
+  pack_cleanup() {
+    rm -rf "$work"
+    if [[ "${pack_need_restart:-0}" -eq 1 ]]; then
+      info "Pack did not finish — restarting bots on this PC…"
+      ensure_pem_host_in_env "$pem" .env || true
+      ensure_pem_host_in_env "$pem" .env.stability-nexus || true
+      start_stacks "$pem" || info "Could not auto-restart bots — start them manually."
+    fi
+  }
+  trap pack_cleanup EXIT INT TERM
+
+  stop_stacks 1
+  pack_need_restart=1
 
   info "Packing secrets + databases (this is the whole live bot state)…"
   cp .env "$work/bundle/aossie.env"
@@ -179,9 +209,7 @@ cmd_pack() {
   cp config/config.yaml "$work/bundle/config.yaml"
   cp config/stability-nexus.yaml "$work/bundle/stability-nexus.yaml"
   cp "$pem" "$work/bundle/gitcordapp.pem"
-  if [[ -f docker-compose.stability-nexus.yml ]]; then
-    cp docker-compose.stability-nexus.yml "$work/bundle/docker-compose.stability-nexus.yml"
-  fi
+  cp docker-compose.stability-nexus.yml "$work/bundle/docker-compose.stability-nexus.yml"
 
   docker volume inspect "$AOSSIE_VOL" >/dev/null 2>&1 || die "AOSSIE volume missing ($AOSSIE_VOL). Are the bots on this PC?"
   docker volume inspect "$SN_VOL" >/dev/null 2>&1 || die "Stability Nexus volume missing ($SN_VOL)."
@@ -209,10 +237,11 @@ EOF
 
   tar -czf "$archive" -C "$work/bundle" .
   chmod 600 "$archive" 2>/dev/null || true
-  rm -rf "$work"
-  trap - EXIT INT TERM
 
-  # Bring bots back so the old PC keeps serving until cutover.
+  pack_need_restart=0
+  trap - EXIT INT TERM
+  rm -rf "$work"
+
   ensure_pem_host_in_env "$pem" .env
   ensure_pem_host_in_env "$pem" .env.stability-nexus
   start_stacks "$pem" || info "Could not auto-restart bots — start them manually if needed."
@@ -251,9 +280,11 @@ cmd_restore() {
   [[ -f "$work/volumes/aossie-data.tgz" ]] || die "Bad handover file (missing volumes/aossie-data.tgz)."
   [[ -f "$work/volumes/stability-data.tgz" ]] || die "Bad handover file (missing volumes/stability-data.tgz)."
 
-  if volume_nonempty "$AOSSIE_VOL" || volume_nonempty "$SN_VOL"; then
-    confirm "Existing Gitcord data found on this PC. Restore will REPLACE it. Continue?" \
-      || die "Restore cancelled (existing volumes left untouched)."
+  if volume_nonempty "$AOSSIE_VOL" || volume_nonempty "$SN_VOL" \
+    || [[ -f .env ]] || [[ -f .env.stability-nexus ]] \
+    || [[ -f config/config.yaml ]] || [[ -f config/stability-nexus.yaml ]]; then
+    confirm "Existing Gitcord config and/or data found on this PC. Restore will REPLACE it. Continue?" \
+      || die "Restore cancelled (existing files/volumes left untouched)."
   fi
 
   pem_host="${GITCORD_PEM_HOST:-$DEFAULT_PEM}"
@@ -280,10 +311,12 @@ cmd_restore() {
   info "IMPORTANT: Only one PC should run the bots."
   echo "  If the old PC is still running Gitcord, stop it first."
   if [[ -t 0 ]]; then
-    read -r -p "Press Enter to wipe local volumes (if any) and start both bots… " _ || true
+    read -r -p "Press Enter to stop any local bots, wipe volumes, and start both stacks… " _ || true
   else
     info "Non-interactive shell: continuing without confirmation."
   fi
+
+  stop_stacks 1
 
   info "Restoring bot databases (verified users + sync progress)…"
   docker volume create "$AOSSIE_VOL" >/dev/null

--- a/scripts/handover-pack.sh
+++ b/scripts/handover-pack.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# Back-compat wrapper — use ./scripts/gitcord-handover pack
+exec "$(cd "$(dirname "$0")" && pwd)/gitcord-handover" pack "$@"

--- a/scripts/handover-restore.sh
+++ b/scripts/handover-restore.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Back-compat wrapper — use ./scripts/gitcord-handover restore FILE.tar.gz
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")" && pwd)"
+BUNDLE="${1:-}"
+if [[ -z "$BUNDLE" ]]; then
+  echo "Usage: $0 /path/to/gitcord-handover-*.tar.gz   (or a extracted bundle dir)" >&2
+  exit 1
+fi
+if [[ -d "$BUNDLE" ]]; then
+  # Old folder-style bundle → wrap to tar then restore
+  TMP="$(mktemp -d)"
+  TAR="$TMP/gitcord-handover-compat.tar.gz"
+  tar -czf "$TAR" -C "$BUNDLE" .
+  exec "$ROOT/gitcord-handover" restore "$TAR"
+fi
+exec "$ROOT/gitcord-handover" restore "$BUNDLE"

--- a/scripts/handover-restore.sh
+++ b/scripts/handover-restore.sh
@@ -6,7 +6,10 @@ FORCE_ARGS=()
 BUNDLE=""
 for arg in "$@"; do
   case "$arg" in
-    --force|--start) FORCE_ARGS+=(--force) ;;
+    --force) FORCE_ARGS+=(--force) ;;
+    --start)
+      # Legacy flag: restore always starts stacks; do NOT treat as --force.
+      ;;
     *) BUNDLE="$arg" ;;
   esac
 done

--- a/scripts/handover-restore.sh
+++ b/scripts/handover-restore.sh
@@ -2,16 +2,24 @@
 # Back-compat wrapper — use ./scripts/gitcord-handover restore FILE.tar.gz
 set -euo pipefail
 ROOT="$(cd "$(dirname "$0")" && pwd)"
-BUNDLE="${1:-}"
+FORCE_ARGS=()
+BUNDLE=""
+for arg in "$@"; do
+  case "$arg" in
+    --force|--start) FORCE_ARGS+=(--force) ;;
+    *) BUNDLE="$arg" ;;
+  esac
+done
 if [[ -z "$BUNDLE" ]]; then
-  echo "Usage: $0 /path/to/gitcord-handover-*.tar.gz   (or a extracted bundle dir)" >&2
+  echo "Usage: $0 [--force] /path/to/gitcord-handover-*.tar.gz" >&2
   exit 1
 fi
 if [[ -d "$BUNDLE" ]]; then
-  # Old folder-style bundle → wrap to tar then restore
-  TMP="$(mktemp -d)"
+  TMP="$(mktemp -d "${TMPDIR:-/tmp}/gitcord-handover-compat.XXXXXX")"
+  trap 'rm -rf "$TMP"' EXIT INT TERM
   TAR="$TMP/gitcord-handover-compat.tar.gz"
   tar -czf "$TAR" -C "$BUNDLE" .
-  exec "$ROOT/gitcord-handover" restore "$TAR"
+  "$ROOT/gitcord-handover" restore "${FORCE_ARGS[@]+"${FORCE_ARGS[@]}"}" "$TAR"
+  exit $?
 fi
-exec "$ROOT/gitcord-handover" restore "$BUNDLE"
+exec "$ROOT/gitcord-handover" restore "${FORCE_ARGS[@]+"${FORCE_ARGS[@]}"}" "$BUNDLE"


### PR DESCRIPTION
## Summary
- Add `./scripts/gitcord-handover` (`pack` → one Desktop `.tar.gz`, `restore`, `check`, `stop-old`) so live AOSSIE + Stability Nexus stacks move PC → PC without cloud
- Add plain-language `HANDOVER-EASY.txt`, short `docs/HANDOVER.md`, and paste-ready `docs/HANDOVER_AI_PROMPT.md` for the next person’s AI
- Mount GitHub App PEM via `GITCORD_PEM_HOST` in `docker-compose.yml` (no hardcoded maintainer path)
- Wire links into README / AGENTS.md / MAINTAINERS.md; ignore local handover pack folders

## Test plan
- [ ] `./scripts/gitcord-handover help` prints pack/restore/check/stop-old
- [ ] On a machine with live stacks: `pack` writes `gitcord-handover-*.tar.gz` (do not commit it)
- [ ] On a clean clone: `restore` that file starts both bots; Discord `/profile` + `/who-is` work
- [ ] After cutover: `stop-old` on the previous PC
- [ ] Confirm `.env` / `.pem` / tarball are not staged in this PR


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a handover utility for migrating running Gitcord bots between local computers.
  - Supports packaging, restoring, validating, starting, checking, and stopping bot installations.
  - Added compatibility wrappers for existing handover commands.
  - Made the GitHub App private-key location configurable.

- **Documentation**
  - Added user and maintainer guides for handover workflows, security precautions, verification, and AI-assisted restoration.
  - Linked handover resources from the README.
  - Documented the required environment configuration.

- **Chores**
  - Added ignore rules to prevent local handover archives and secrets from being committed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->