### PR TITLE
/pr-status 

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ Contributor-facing cheat sheet: [`QUICK_START_GUIDE.txt`](QUICK_START_GUIDE.txt)
 - `/summary` - Show contribution metrics (7 and 30 days); optional Discord member for another verified contributor
 - `/open-prs` - List a contributor's currently open PRs in configured repos
 - `/pr` - List a contributor's recent PRs grouped by closed / merged / open (`count` N, optional `skip` M)
-- `/pr-status` - Show PR health (CI, CodeRabbit review threads, merge conflicts, approval state) for a single PR or multi-PR org dashboard (`show_all:True`, optional `skip` M). Accessible to all server members by default (with command cooldown); optionally gateable via `discord.command_permissions.pr-status`. Dashboard requests are capped at 25 PRs per page. Each PR uses a small number of REST calls (pull request, reviews, check runs) plus paginated GraphQL queries for review threads, so a full dashboard page costs roughly 100 or more API requests.
+- `/pr-status` - Show PR health (CI, CodeRabbit review threads, merge conflicts, approval state) for a single PR or multi-PR org dashboard (`show_all:True`, optional `skip` M). Accessible to all server members by default (with command cooldown); optionally gateable via `discord.command_permissions.pr-status`. Dashboard requests are capped at 25 PRs per page. Each PR uses a small number of REST calls (pull request, reviews, check runs) plus paginated GraphQL queries for review threads, so a full dashboard page costs roughly 100 or more API requests. When querying a single PR, omitting `repo:` probes each configured repository with one additional REST call to auto-detect the repository (capped at 25 candidate repositories, resulting in a maximum of 25 probe calls).
 
 ### Sync (mentor-only)
 

--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ Contributor-facing cheat sheet: [`QUICK_START_GUIDE.txt`](QUICK_START_GUIDE.txt)
 - `/summary` - Show contribution metrics (7 and 30 days); optional Discord member for another verified contributor
 - `/open-prs` - List a contributor's currently open PRs in configured repos
 - `/pr` - List a contributor's recent PRs grouped by closed / merged / open (`count` N, optional `skip` M)
+- `/pr-status` - Show PR health (CI, CodeRabbit review threads, merge conflicts, approval state) for a single PR or multi-PR org dashboard (`show_all:True`, optional `skip` M). Accessible to all server members by default (with command cooldown); optionally gateable via `discord.command_permissions.pr-status`. Dashboard requests are capped at 25 PRs per page and use efficient single-roundtrip GraphQL review thread queries to stay well within GitHub API rate limits.
 
 ### Sync (mentor-only)
 

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ Contributor-facing cheat sheet: [`QUICK_START_GUIDE.txt`](QUICK_START_GUIDE.txt)
 - `/summary` - Show contribution metrics (7 and 30 days); optional Discord member for another verified contributor
 - `/open-prs` - List a contributor's currently open PRs in configured repos
 - `/pr` - List a contributor's recent PRs grouped by closed / merged / open (`count` N, optional `skip` M)
-- `/pr-status` - Show PR health (CI, CodeRabbit review threads, merge conflicts, approval state) for a single PR or multi-PR org dashboard (`show_all:True`, optional `skip` M). Accessible to all server members by default (with command cooldown); optionally gateable via `discord.command_permissions.pr-status`. Dashboard requests are capped at 25 PRs per page and use efficient single-roundtrip GraphQL review thread queries to stay well within GitHub API rate limits.
+- `/pr-status` - Show PR health (CI, CodeRabbit review threads, merge conflicts, approval state) for a single PR or multi-PR org dashboard (`show_all:True`, optional `skip` M). Accessible to all server members by default (with command cooldown); optionally gateable via `discord.command_permissions.pr-status`. Dashboard requests are capped at 25 PRs per page. Each PR uses a small number of REST calls (pull request, reviews, check runs) plus paginated GraphQL queries for review threads, so a full dashboard page costs roughly 100 or more API requests.
 
 ### Sync (mentor-only)
 

--- a/checklist-status.json
+++ b/checklist-status.json
@@ -3,7 +3,7 @@
   "label": "Best Practices",
   "message": "94%",
   "schema": "aossie-best-practices-v1",
-  "updated": "2026-08-10",
+  "updated": "2026-08-22",
   "met": 46,
   "total": 49,
   "percent": 94,

--- a/src/ghdcbot/adapters/github/rest.py
+++ b/src/ghdcbot/adapters/github/rest.py
@@ -775,10 +775,10 @@ class GitHubRestAdapter:
                             timeout=15.0,
                         )
                         if comm_resp.status_code != 200:
-                            break
+                            return None
                         comm_data = comm_resp.json()
                         if not isinstance(comm_data, dict) or "data" not in comm_data or not comm_data["data"]:
-                            break
+                            return None
                         node_data = comm_data["data"].get("node") or {}
                         more_comments_data = node_data.get("comments") or {}
                         more_nodes = more_comments_data.get("nodes") or []

--- a/src/ghdcbot/adapters/github/rest.py
+++ b/src/ghdcbot/adapters/github/rest.py
@@ -27,6 +27,8 @@ _GITHUB_RETRY_BACKOFF_SECONDS = (1.0, 2.0, 4.0)
 _GITHUB_TRANSIENT_STATUS_CODES = frozenset({502, 503, 504})
 _GITHUB_MAX_RATE_LIMIT_RECOVERIES = 10
 _GITHUB_MIN_RATE_LIMIT_SLEEP_SECONDS = 1.0
+_GRAPHQL_MAX_REVIEW_THREADS_PAGES = 10
+_GRAPHQL_MAX_THREAD_COMMENTS_PAGES = 5
 
 
 def _github_retry_sleep_seconds(failed_attempt: int) -> float:
@@ -701,8 +703,10 @@ class GitHubRestAdapter:
             results: list[dict] = []
             threads_cursor = None
             has_next_threads = True
+            threads_pages = 0
 
-            while has_next_threads:
+            while has_next_threads and threads_pages < _GRAPHQL_MAX_REVIEW_THREADS_PAGES:
+                threads_pages += 1
                 response = self._client.post(
                     graphql_url,
                     json={
@@ -761,8 +765,15 @@ class GitHubRestAdapter:
                     comments_page_info = comments_data.get("pageInfo") or {}
                     has_next_comments = bool(comments_page_info.get("hasNextPage"))
                     comments_cursor = comments_page_info.get("endCursor")
+                    comments_pages = 1
 
-                    while has_next_comments and thread_id and comments_cursor:
+                    while (
+                        has_next_comments
+                        and thread_id
+                        and comments_cursor
+                        and comments_pages < _GRAPHQL_MAX_THREAD_COMMENTS_PAGES
+                    ):
+                        comments_pages += 1
                         comm_resp = self._client.post(
                             graphql_url,
                             json={
@@ -789,7 +800,10 @@ class GitHubRestAdapter:
                                 )
                         more_page_info = more_comments_data.get("pageInfo") or {}
                         has_next_comments = bool(more_page_info.get("hasNextPage"))
-                        comments_cursor = more_page_info.get("endCursor")
+                        next_comm_cursor = more_page_info.get("endCursor")
+                        if not next_comm_cursor or next_comm_cursor == comments_cursor:
+                            break
+                        comments_cursor = next_comm_cursor
 
                     results.append(
                         {
@@ -801,9 +815,10 @@ class GitHubRestAdapter:
 
                 page_info = review_threads_data.get("pageInfo") or {}
                 has_next_threads = bool(page_info.get("hasNextPage"))
-                threads_cursor = page_info.get("endCursor")
-                if not threads_cursor:
+                next_threads_cursor = page_info.get("endCursor")
+                if not next_threads_cursor or next_threads_cursor == threads_cursor:
                     break
+                threads_cursor = next_threads_cursor
 
             return results
         except Exception as exc:

--- a/src/ghdcbot/adapters/github/rest.py
+++ b/src/ghdcbot/adapters/github/rest.py
@@ -106,6 +106,7 @@ class GitHubRestAdapter:
         self._logger = logging.getLogger(self.__class__.__name__)
         self._org = org
         self._token = token
+        self._api_base = api_base
         self._last_repo_count: int | None = None
         self._sync_cached_repos: list[dict] | None = None
         self._sync_request_count = 0
@@ -639,16 +640,24 @@ class GitHubRestAdapter:
         Returns list of thread dicts: [{'is_resolved': bool, 'is_outdated': bool, 'authors': list[str]}]
         Returns empty list on error or if GraphQL is unsupported.
         """
-        query = """
-        query($owner: String!, $name: String!, $number: Int!) {
+        threads_query = """
+        query($owner: String!, $name: String!, $number: Int!, $cursor: String) {
           repository(owner: $owner, name: $name) {
             pullRequest(number: $number) {
-              reviewThreads(first: 100) {
+              reviewThreads(first: 100, after: $cursor) {
+                pageInfo {
+                  hasNextPage
+                  endCursor
+                }
                 nodes {
                   id
                   isResolved
                   isOutdated
-                  comments(first: 1) {
+                  comments(first: 100) {
+                    pageInfo {
+                      hasNextPage
+                      endCursor
+                    }
                     nodes {
                       author {
                         login
@@ -661,38 +670,124 @@ class GitHubRestAdapter:
           }
         }
         """
+        comments_query = """
+        query($threadId: ID!, $cursor: String) {
+          node(id: $threadId) {
+            ... on PullRequestReviewThread {
+              comments(first: 100, after: $cursor) {
+                pageInfo {
+                  hasNextPage
+                  endCursor
+                }
+                nodes {
+                  author {
+                    login
+                  }
+                }
+              }
+            }
+          }
+        }
+        """
         try:
-            graphql_url = "https://api.github.com/graphql"
-            if hasattr(self, "_api_base") and str(self._api_base).rstrip("/") != "https://api.github.com":
-                graphql_url = f"{str(self._api_base).rstrip('/')}/graphql"
+            base = (getattr(self, "_api_base", None) or "https://api.github.com").rstrip("/")
+            if base == "https://api.github.com":
+                graphql_url = "https://api.github.com/graphql"
+            elif base.endswith("/api/v3"):
+                graphql_url = f"{base[:-7]}/api/graphql"
+            else:
+                graphql_url = f"{base}/graphql"
 
-            response = self._client.post(
-                graphql_url,
-                json={"query": query, "variables": {"owner": owner, "name": repo, "number": pr_number}},
-                timeout=15.0,
-            )
-            if response.status_code == 200:
+            results: list[dict] = []
+            threads_cursor = None
+            has_next_threads = True
+
+            while has_next_threads:
+                response = self._client.post(
+                    graphql_url,
+                    json={
+                        "query": threads_query,
+                        "variables": {
+                            "owner": owner,
+                            "name": repo,
+                            "number": pr_number,
+                            "cursor": threads_cursor,
+                        },
+                    },
+                    timeout=15.0,
+                )
+                if response.status_code != 200:
+                    break
+
                 data = response.json()
-                if isinstance(data, dict) and "data" in data and data["data"]:
-                    repo_data = data["data"].get("repository") or {}
-                    pr_data = repo_data.get("pullRequest") or {}
-                    raw_threads = (pr_data.get("reviewThreads") or {}).get("nodes") or []
-                    results = []
-                    for t in raw_threads:
-                        c_nodes = (t.get("comments") or {}).get("nodes") or []
-                        authors = [
-                            ((c.get("author") or {}).get("login") or "").strip().lower()
-                            for c in c_nodes
-                            if isinstance(c, dict)
-                        ]
-                        results.append(
-                            {
-                                "is_resolved": bool(t.get("isResolved")),
-                                "is_outdated": bool(t.get("isOutdated")),
-                                "authors": authors,
-                            }
+                if not isinstance(data, dict) or "data" not in data or not data["data"]:
+                    break
+
+                repo_data = data["data"].get("repository") or {}
+                pr_data = repo_data.get("pullRequest") or {}
+                review_threads_data = pr_data.get("reviewThreads") or {}
+                raw_threads = review_threads_data.get("nodes") or []
+
+                for t in raw_threads:
+                    if not isinstance(t, dict):
+                        continue
+                    comments_data = t.get("comments") or {}
+                    c_nodes = comments_data.get("nodes") or []
+                    authors = [
+                        ((c.get("author") or {}).get("login") or "").strip().lower()
+                        for c in c_nodes
+                        if isinstance(c, dict)
+                    ]
+
+                    thread_id = t.get("id")
+                    comments_page_info = comments_data.get("pageInfo") or {}
+                    has_next_comments = bool(comments_page_info.get("hasNextPage"))
+                    comments_cursor = comments_page_info.get("endCursor")
+
+                    while has_next_comments and thread_id and comments_cursor:
+                        comm_resp = self._client.post(
+                            graphql_url,
+                            json={
+                                "query": comments_query,
+                                "variables": {
+                                    "threadId": thread_id,
+                                    "cursor": comments_cursor,
+                                },
+                            },
+                            timeout=15.0,
                         )
-                    return results
+                        if comm_resp.status_code != 200:
+                            break
+                        comm_data = comm_resp.json()
+                        if not isinstance(comm_data, dict) or "data" not in comm_data or not comm_data["data"]:
+                            break
+                        node_data = comm_data["data"].get("node") or {}
+                        more_comments_data = node_data.get("comments") or {}
+                        more_nodes = more_comments_data.get("nodes") or []
+                        for c in more_nodes:
+                            if isinstance(c, dict):
+                                authors.append(
+                                    ((c.get("author") or {}).get("login") or "").strip().lower()
+                                )
+                        more_page_info = more_comments_data.get("pageInfo") or {}
+                        has_next_comments = bool(more_page_info.get("hasNextPage"))
+                        comments_cursor = more_page_info.get("endCursor")
+
+                    results.append(
+                        {
+                            "is_resolved": bool(t.get("isResolved")),
+                            "is_outdated": bool(t.get("isOutdated")),
+                            "authors": authors,
+                        }
+                    )
+
+                page_info = review_threads_data.get("pageInfo") or {}
+                has_next_threads = bool(page_info.get("hasNextPage"))
+                threads_cursor = page_info.get("endCursor")
+                if not threads_cursor:
+                    break
+
+            return results
         except Exception as exc:
             self._logger.debug(
                 "GraphQL reviewThreads query failed, falling back to REST comments",

--- a/src/ghdcbot/adapters/github/rest.py
+++ b/src/ghdcbot/adapters/github/rest.py
@@ -634,11 +634,11 @@ class GitHubRestAdapter:
 
     def get_pull_request_review_threads(
         self, owner: str, repo: str, pr_number: int
-    ) -> list[dict]:
+    ) -> list[dict] | None:
         """Fetch review threads via GraphQL to check resolved/unresolved status.
 
         Returns list of thread dicts: [{'is_resolved': bool, 'is_outdated': bool, 'authors': list[str]}]
-        Returns empty list on error or if GraphQL is unsupported.
+        Returns None on error or if GraphQL is unsupported, signaling callers to fall back to REST.
         """
         threads_query = """
         query($owner: String!, $name: String!, $number: Int!, $cursor: String) {
@@ -717,11 +717,29 @@ class GitHubRestAdapter:
                     timeout=15.0,
                 )
                 if response.status_code != 200:
-                    break
+                    self._logger.debug(
+                        "GraphQL reviewThreads request failed with non-200 status",
+                        extra={
+                            "owner": owner,
+                            "repo": repo,
+                            "pr_number": pr_number,
+                            "status_code": response.status_code,
+                        },
+                    )
+                    return None
 
                 data = response.json()
                 if not isinstance(data, dict) or "data" not in data or not data["data"]:
-                    break
+                    self._logger.debug(
+                        "GraphQL reviewThreads response missing data",
+                        extra={
+                            "owner": owner,
+                            "repo": repo,
+                            "pr_number": pr_number,
+                            "errors": data.get("errors") if isinstance(data, dict) else None,
+                        },
+                    )
+                    return None
 
                 repo_data = data["data"].get("repository") or {}
                 pr_data = repo_data.get("pullRequest") or {}
@@ -736,7 +754,7 @@ class GitHubRestAdapter:
                     authors = [
                         ((c.get("author") or {}).get("login") or "").strip().lower()
                         for c in c_nodes
-                        if isinstance(c, dict)
+                        if isinstance(c, dict) and c.get("author")
                     ]
 
                     thread_id = t.get("id")
@@ -765,7 +783,7 @@ class GitHubRestAdapter:
                         more_comments_data = node_data.get("comments") or {}
                         more_nodes = more_comments_data.get("nodes") or []
                         for c in more_nodes:
-                            if isinstance(c, dict):
+                            if isinstance(c, dict) and c.get("author"):
                                 authors.append(
                                     ((c.get("author") or {}).get("login") or "").strip().lower()
                                 )
@@ -793,7 +811,7 @@ class GitHubRestAdapter:
                 "GraphQL reviewThreads query failed, falling back to REST comments",
                 extra={"owner": owner, "repo": repo, "pr_number": pr_number, "error": str(exc)},
             )
-        return []
+        return None
 
     def get_pull_request_check_runs(self, owner: str, repo: str, head_sha: str) -> list[dict]:
         """Fetch check runs for a commit (used for CI status).

--- a/src/ghdcbot/adapters/github/rest.py
+++ b/src/ghdcbot/adapters/github/rest.py
@@ -631,6 +631,75 @@ class GitHubRestAdapter:
             comments.extend(page)
         return comments
 
+    def get_pull_request_review_threads(
+        self, owner: str, repo: str, pr_number: int
+    ) -> list[dict]:
+        """Fetch review threads via GraphQL to check resolved/unresolved status.
+
+        Returns list of thread dicts: [{'is_resolved': bool, 'is_outdated': bool, 'authors': list[str]}]
+        Returns empty list on error or if GraphQL is unsupported.
+        """
+        query = """
+        query($owner: String!, $name: String!, $number: Int!) {
+          repository(owner: $owner, name: $name) {
+            pullRequest(number: $number) {
+              reviewThreads(first: 100) {
+                nodes {
+                  id
+                  isResolved
+                  isOutdated
+                  comments(first: 1) {
+                    nodes {
+                      author {
+                        login
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+        """
+        try:
+            graphql_url = "https://api.github.com/graphql"
+            if hasattr(self, "_api_base") and str(self._api_base).rstrip("/") != "https://api.github.com":
+                graphql_url = f"{str(self._api_base).rstrip('/')}/graphql"
+
+            response = self._client.post(
+                graphql_url,
+                json={"query": query, "variables": {"owner": owner, "name": repo, "number": pr_number}},
+                timeout=15.0,
+            )
+            if response.status_code == 200:
+                data = response.json()
+                if isinstance(data, dict) and "data" in data and data["data"]:
+                    repo_data = data["data"].get("repository") or {}
+                    pr_data = repo_data.get("pullRequest") or {}
+                    raw_threads = (pr_data.get("reviewThreads") or {}).get("nodes") or []
+                    results = []
+                    for t in raw_threads:
+                        c_nodes = (t.get("comments") or {}).get("nodes") or []
+                        authors = [
+                            ((c.get("author") or {}).get("login") or "").strip().lower()
+                            for c in c_nodes
+                            if isinstance(c, dict)
+                        ]
+                        results.append(
+                            {
+                                "is_resolved": bool(t.get("isResolved")),
+                                "is_outdated": bool(t.get("isOutdated")),
+                                "authors": authors,
+                            }
+                        )
+                    return results
+        except Exception as exc:
+            self._logger.debug(
+                "GraphQL reviewThreads query failed, falling back to REST comments",
+                extra={"owner": owner, "repo": repo, "pr_number": pr_number, "error": str(exc)},
+            )
+        return []
+
     def get_pull_request_check_runs(self, owner: str, repo: str, head_sha: str) -> list[dict]:
         """Fetch check runs for a commit (used for CI status).
 

--- a/src/ghdcbot/bot.py
+++ b/src/ghdcbot/bot.py
@@ -69,11 +69,18 @@ from ghdcbot.help_link import (
     HELP_LINK_COMMAND_NAME,
     HelpLinkSessionStore,
     HelpLinkStartView,
+from ghdcbot.help_link import (
+    HELP_LINK_COMMAND_NAME,
+    HelpLinkSessionStore,
+    HelpLinkStartView,
     deliver_help_link_prompt,
 )
+from ghdcbot.logging.setup import configure_logging
+from ghdcbot.plugins.registry import build_adapter
 
 # Slash command names used for permission checks (must match @tree.command name=...)
 SLASH_CMD_SYNC = "sync"
+SLASH_CMD_PR_STATUS = "pr-status"
 SLASH_CMD_HELP_LINK = HELP_LINK_COMMAND_NAME
 
 

--- a/src/ghdcbot/bot.py
+++ b/src/ghdcbot/bot.py
@@ -1131,7 +1131,7 @@ def run_bot(config_path: str) -> None:
                     f"ℹ️ **{repo_name}#{pr_number}** is a GitHub **Issue**, not a Pull Request.\n\n"
                     f"**Title:** {issue_title}\n"
                     f"**State:** {state_label}\n\n"
-                    f"💡 `/pr-status` is designed for Pull Requests. Try `/pr-status pr_number:<PR#>`.",
+                    "💡 `/pr-status` is designed for Pull Requests. Try `/pr-status pr_number:<PR#>`.",
                     ephemeral=True,
                 )
                 return

--- a/src/ghdcbot/bot.py
+++ b/src/ghdcbot/bot.py
@@ -41,6 +41,13 @@ from ghdcbot.engine.pr_context import (
     fetch_pr_context,
     parse_pr_url,
 )
+from ghdcbot.engine.pr_status import (
+    fetch_all_open_pr_health,
+    fetch_pr_health,
+    format_all_pr_status,
+    format_single_pr_status,
+    PR_STATUS_MAX_PRS,
+)
 from ghdcbot.logging.setup import configure_logging
 from ghdcbot.plugins.registry import build_adapter
 from ghdcbot.discord_command_permissions import (
@@ -927,6 +934,68 @@ def run_bot(config_path: str) -> None:
         
         embed = discord.Embed.from_dict(embed_dict)
         await message.channel.send(embed=embed)
+
+    @tree.command(
+        name="pr-status",
+        description="Show PR health: CI, CodeRabbit, conflicts, reviews for a repository PR",
+        guild=discord.Object(id=guild_id),
+    )
+    @app_commands.describe(
+        repo="Repository name (e.g. Gitcord-GithubDiscordBot)",
+        pr_number="Pull request number (e.g. 7)",
+    )
+    @app_commands.checks.cooldown(1, 3.0)
+    async def pr_status_cmd(
+        interaction: discord.Interaction,
+        repo: str,
+        pr_number: app_commands.Range[int, 1],
+    ) -> None:
+        """Show health status of a pull request."""
+        await interaction.response.defer(ephemeral=True)
+
+        repo_name = repo.strip()
+        if not repo_name:
+            await interaction.followup.send(
+                "❌ Please specify a valid repository name.",
+                ephemeral=True,
+            )
+            return
+
+        # Resolve CodeRabbit bot logins from notification config
+        notification_config = getattr(config.discord, "notifications", None)
+        coderabbit_logins = None
+        if notification_config:
+            coderabbit_logins = getattr(notification_config, "coderabbit_bot_logins", None)
+
+        try:
+            health = await asyncio.to_thread(
+                fetch_pr_health,
+                github_adapter,
+                config.github.org,
+                repo_name,
+                int(pr_number),
+                coderabbit_logins,
+            )
+        except Exception:
+            logger.exception(
+                "Failed to fetch PR health",
+                extra={"repo": repo_name, "pr_number": pr_number},
+            )
+            await interaction.followup.send(
+                "❌ Error fetching PR status. Please try again later.",
+                ephemeral=True,
+            )
+            return
+
+        if health is None:
+            await interaction.followup.send(
+                f"❌ PR **{repo_name}#{pr_number}** not found or inaccessible.",
+                ephemeral=True,
+            )
+            return
+
+        message = format_single_pr_status(health, config.github.org)
+        await interaction.followup.send(message, ephemeral=True)
 
     @tree.command(
         name="sync",

--- a/src/ghdcbot/bot.py
+++ b/src/ghdcbot/bot.py
@@ -4,59 +4,56 @@ from __future__ import annotations
 
 import asyncio
 import logging
-
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from typing import Any
-
-from datetime import datetime
-from typing import Any, Optional
-
 
 import discord
 from discord import app_commands
 
+from ghdcbot.adapters.discord.social_commands import register_social_commands
 from ghdcbot.adapters.github.app_auth import resolve_github_token
 from ghdcbot.adapters.github.identity import GitHubIdentityReader
 from ghdcbot.config.loader import load_config
 from ghdcbot.core.errors import ConfigError
-from ghdcbot.engine.identity_linking import IdentityLinkService, LinkClaim
-from ghdcbot.engine.metrics import (
-    build_contribution_summary_message,
-    get_contribution_metrics,
-    rank_by_activity,
-    get_rank_for_user,
+from ghdcbot.discord_command_permissions import (
+    format_slash_command_permission_denied,
+    slash_command_allowed,
 )
+from ghdcbot.engine.identity_linking import IdentityLinkService, LinkClaim
 from ghdcbot.engine.issue_assignment import (
     resolve_discord_to_github,
     resolve_github_to_discord,
 )
-from ghdcbot.engine.open_prs import format_open_prs_report, list_open_prs_for_author
-from ghdcbot.engine.pr_list import (
-    clamp_pr_list_args,
-    format_pr_list_messages,
-    select_recent_prs,
+from ghdcbot.engine.metrics import (
+    build_contribution_summary_message,
+    get_contribution_metrics,
+    get_rank_for_user,
+    rank_by_activity,
 )
+from ghdcbot.engine.open_prs import format_open_prs_report, list_open_prs_for_author
 from ghdcbot.engine.pr_context import (
     build_pr_embed,
     fetch_pr_context,
     parse_pr_url,
 )
+from ghdcbot.engine.pr_list import (
+    clamp_pr_list_args,
+    format_pr_list_messages,
+    select_recent_prs,
+)
 from ghdcbot.engine.pr_status import (
+    PR_STATUS_MAX_PRS,
     fetch_all_open_pr_health,
     fetch_pr_health,
+    filter_repo_suggestions,
     format_all_pr_status,
     format_single_pr_status,
-    is_repo_allowed,
-    PR_STATUS_MAX_PRS,
+    get_configured_repo_names,
+    resolve_repo_for_pr,
 )
+from ghdcbot.engine.social_profiles import SocialProfileService
 from ghdcbot.logging.setup import configure_logging
 from ghdcbot.plugins.registry import build_adapter
-from ghdcbot.discord_command_permissions import (
-    format_slash_command_permission_denied,
-    slash_command_allowed,
-)
-from ghdcbot.adapters.discord.social_commands import register_social_commands
-from ghdcbot.engine.social_profiles import SocialProfileService
 
 # Slash command names used for permission checks (must match @tree.command name=...)
 SLASH_CMD_SYNC = "sync"
@@ -485,7 +482,7 @@ def run_bot(config_path: str) -> None:
         # 3. Create the Embed
         embed = discord.Embed(
             color=color,
-            timestamp=datetime.now(timezone.utc)
+            timestamp=datetime.now(UTC)
         )
 
         # Show github user link and avatar if linked, and set author details
@@ -534,7 +531,7 @@ def run_bot(config_path: str) -> None:
         if github_user:
             metrics_available = True
             try:
-                now_utc = datetime.now(timezone.utc)
+                now_utc = datetime.now(UTC)
                 start_30 = now_utc - timedelta(days=30)
 
                 def _fetch_metrics():
@@ -765,7 +762,7 @@ def run_bot(config_path: str) -> None:
     async def pr_list_cmd(
         interaction: discord.Interaction,
         contributor: discord.Member,
-        count: Optional[app_commands.Range[int, 1, 100]] = None,
+        count: app_commands.Range[int, 1, 100] | None = None,
         skip: app_commands.Range[int, 0, 500] = 0,
     ) -> None:
         await interaction.response.defer(ephemeral=True)
@@ -945,7 +942,7 @@ def run_bot(config_path: str) -> None:
         guild=discord.Object(id=guild_id),
     )
     @app_commands.describe(
-        repo="Repository name (optional if show_all is True)",
+        repo="Repository name (optional; auto-detected from config if omitted)",
         pr_number="Pull request number (optional if show_all is True)",
         show_all="Show health dashboard for all open PRs in the organization",
         skip="How many open PRs to skip for pagination (when show_all is True)",
@@ -993,22 +990,21 @@ def run_bot(config_path: str) -> None:
                 await interaction.followup.send(msg, ephemeral=True, suppress_embeds=True)
             return
 
-        repo_name = (repo or "").strip()
-        if not repo_name or pr_number is None:
+        if pr_number is None:
             await interaction.followup.send(
-                "❌ Please specify both `repo` and `pr_number`, or use `show_all:True` for the dashboard.",
+                "❌ Please specify `pr_number` to check PR health (or use `show_all:True` for the organization dashboard).",
                 ephemeral=True,
             )
             return
 
-        # Validate repo_name against config.github.repos filter if configured
-        repo_filter = getattr(config.github, "repos", None)
-        if not is_repo_allowed(repo_filter, repo_name):
-            await interaction.followup.send(
-                f"❌ PR **{repo_name}#{pr_number}** not found or inaccessible.",
-                ephemeral=True,
-            )
+        repo_name, err = await resolve_repo_for_pr(
+            config, github_adapter, int(pr_number), repo=repo
+        )
+        if err:
+            await interaction.followup.send(err, ephemeral=True)
             return
+
+        assert repo_name is not None
 
         try:
             health = await asyncio.to_thread(
@@ -1031,6 +1027,30 @@ def run_bot(config_path: str) -> None:
             return
 
         if health is None:
+            # Check if this number is an Issue rather than a PR to provide an informative response
+            issue_info = None
+            try:
+                get_issue = getattr(github_adapter, "get_issue", None)
+                if callable(get_issue):
+                    issue_info = await asyncio.to_thread(
+                        get_issue, config.github.org, repo_name, int(pr_number)
+                    )
+            except Exception as exc:
+                logger.debug("Failed to fetch issue details for fallback check: %s", exc)
+
+            if issue_info and "pull_request" not in issue_info:
+                issue_title = (issue_info.get("title") or "").strip()
+                issue_state = issue_info.get("state") or "unknown"
+                state_label = "Closed 🔴" if issue_state == "closed" else "Open 🟢"
+                await interaction.followup.send(
+                    f"ℹ️ **{repo_name}#{pr_number}** is a GitHub **Issue**, not a Pull Request.\n\n"
+                    f"**Title:** {issue_title}\n"
+                    f"**State:** {state_label}\n\n"
+                    f"💡 `/pr-status` is designed for Pull Requests. Try `/pr-status pr_number:<PR#>`.",
+                    ephemeral=True,
+                )
+                return
+
             await interaction.followup.send(
                 f"❌ PR **{repo_name}#{pr_number}** not found or inaccessible.",
                 ephemeral=True,
@@ -1038,7 +1058,21 @@ def run_bot(config_path: str) -> None:
             return
 
         message = format_single_pr_status(health, config.github.org)
-        await interaction.followup.send(message, ephemeral=True)
+        await interaction.followup.send(message, ephemeral=True, suppress_embeds=True)
+
+    @pr_status_cmd.autocomplete("repo")
+    async def pr_status_repo_autocomplete(
+        interaction: discord.Interaction,
+        current: str,
+    ) -> list[app_commands.Choice[str]]:
+        configured_repos = get_configured_repo_names(config)
+        suggestions = filter_repo_suggestions(configured_repos, current)
+        logger.debug(
+            "Autocomplete for pr-status repo: current=%r, suggestions=%s",
+            current,
+            suggestions,
+        )
+        return [app_commands.Choice(name=r, value=r) for r in suggestions]
 
     @tree.command(
         name="sync",

--- a/src/ghdcbot/bot.py
+++ b/src/ghdcbot/bot.py
@@ -937,35 +937,81 @@ def run_bot(config_path: str) -> None:
 
     @tree.command(
         name="pr-status",
-        description="Show PR health: CI, CodeRabbit, conflicts, reviews for a repository PR",
+        description="Show PR health: CI, CodeRabbit, conflicts, reviews for PRs or full repo dashboard",
         guild=discord.Object(id=guild_id),
     )
     @app_commands.describe(
-        repo="Repository name (e.g. Gitcord-GithubDiscordBot)",
-        pr_number="Pull request number (e.g. 7)",
+        repo="Repository name (optional if show_all is True)",
+        pr_number="Pull request number (optional if show_all is True)",
+        show_all="Show health dashboard for all open PRs in the organization",
+        skip="How many open PRs to skip for pagination (when show_all is True)",
     )
     @app_commands.checks.cooldown(1, 3.0)
     async def pr_status_cmd(
         interaction: discord.Interaction,
-        repo: str,
-        pr_number: app_commands.Range[int, 1],
+        repo: str | None = None,
+        pr_number: app_commands.Range[int, 1] | None = None,
+        show_all: bool = False,
+        skip: app_commands.Range[int, 0] = 0,
     ) -> None:
-        """Show health status of a pull request."""
+        """Show health status of a pull request or all open PRs."""
         await interaction.response.defer(ephemeral=True)
-
-        repo_name = repo.strip()
-        if not repo_name:
-            await interaction.followup.send(
-                "❌ Please specify a valid repository name.",
-                ephemeral=True,
-            )
-            return
 
         # Resolve CodeRabbit bot logins from notification config
         notification_config = getattr(config.discord, "notifications", None)
         coderabbit_logins = None
         if notification_config:
             coderabbit_logins = getattr(notification_config, "coderabbit_bot_logins", None)
+
+        if show_all:
+            try:
+                statuses, total = await asyncio.to_thread(
+                    fetch_all_open_pr_health,
+                    github_adapter,
+                    config.github.org,
+                    coderabbit_logins,
+                    PR_STATUS_MAX_PRS,
+                    int(skip),
+                )
+            except Exception:
+                logger.exception("Failed to fetch all open PR health")
+                await interaction.followup.send(
+                    "❌ Error fetching PR dashboard. Please try again later.",
+                    ephemeral=True,
+                )
+                return
+
+            messages = format_all_pr_status(
+                statuses, config.github.org, skip=int(skip), total=total
+            )
+            for msg in messages:
+                await interaction.followup.send(msg, ephemeral=True, suppress_embeds=True)
+            return
+
+        repo_name = (repo or "").strip()
+        if not repo_name or pr_number is None:
+            await interaction.followup.send(
+                "❌ Please specify both `repo` and `pr_number`, or use `show_all:True` for the dashboard.",
+                ephemeral=True,
+            )
+            return
+
+        # Validate repo_name against config.github.repos filter if configured
+        repo_filter = getattr(config.github, "repos", None)
+        if repo_filter:
+            filter_names = {name.strip() for name in repo_filter.names}
+            is_excluded = False
+            if repo_filter.mode == "allow" and repo_name not in filter_names:
+                is_excluded = True
+            elif repo_filter.mode == "deny" and repo_name in filter_names:
+                is_excluded = True
+
+            if is_excluded:
+                await interaction.followup.send(
+                    f"❌ PR **{repo_name}#{pr_number}** not found or inaccessible.",
+                    ephemeral=True,
+                )
+                return
 
         try:
             health = await asyncio.to_thread(

--- a/src/ghdcbot/bot.py
+++ b/src/ghdcbot/bot.py
@@ -52,24 +52,12 @@ from ghdcbot.engine.pr_status import (
     get_configured_repo_names,
     resolve_repo_for_pr,
 )
-from ghdcbot.engine.social_profiles import SocialProfileService
-from ghdcbot.logging.setup import configure_logging
-from ghdcbot.plugins.registry import build_adapter
-
-# Slash command names used for permission checks (must match @tree.command name=...)
-SLASH_CMD_SYNC = "sync"
-SLASH_CMD_PR_STATUS = "pr-status"
-
+from ghdcbot.adapters.discord.social_commands import register_social_commands
 from ghdcbot.discord_command_permissions import (
     format_slash_command_permission_denied,
     slash_command_allowed,
 )
-from ghdcbot.adapters.discord.social_commands import register_social_commands
 from ghdcbot.engine.social_profiles import SocialProfileService
-from ghdcbot.help_link import (
-    HELP_LINK_COMMAND_NAME,
-    HelpLinkSessionStore,
-    HelpLinkStartView,
 from ghdcbot.help_link import (
     HELP_LINK_COMMAND_NAME,
     HelpLinkSessionStore,

--- a/src/ghdcbot/bot.py
+++ b/src/ghdcbot/bot.py
@@ -46,6 +46,7 @@ from ghdcbot.engine.pr_status import (
     fetch_pr_health,
     format_all_pr_status,
     format_single_pr_status,
+    is_repo_allowed,
     PR_STATUS_MAX_PRS,
 )
 from ghdcbot.logging.setup import configure_logging
@@ -863,20 +864,12 @@ def run_bot(config_path: str) -> None:
             )
         
     def command_permission_check(command_name: str, *, allow_all_by_default: bool = False):
-        """Restrict slash commands via discord.command_permissions or legacy issue_assignees.
-
-        When allow_all_by_default is True (e.g. for informational commands like /pr-status),
-        the command is open to all guild members unless explicitly configured in
-        discord.command_permissions.
-        """
+        """Restrict slash commands via discord.command_permissions or legacy issue_assignees."""
 
         def check(interaction: discord.Interaction) -> bool:
-            if allow_all_by_default:
-                perms = getattr(config.discord, "command_permissions", None)
-                if perms and command_name in perms:
-                    return slash_command_allowed(interaction, config, command_name)
-                return hasattr(interaction.user, "roles") and hasattr(interaction.user, "guild_permissions")
-            return slash_command_allowed(interaction, config, command_name)
+            return slash_command_allowed(
+                interaction, config, command_name, allow_all_by_default=allow_all_by_default
+            )
 
         return check
 
@@ -1010,20 +1003,12 @@ def run_bot(config_path: str) -> None:
 
         # Validate repo_name against config.github.repos filter if configured
         repo_filter = getattr(config.github, "repos", None)
-        if repo_filter:
-            filter_names = {name.strip() for name in repo_filter.names}
-            is_excluded = False
-            if repo_filter.mode == "allow" and repo_name not in filter_names:
-                is_excluded = True
-            elif repo_filter.mode == "deny" and repo_name in filter_names:
-                is_excluded = True
-
-            if is_excluded:
-                await interaction.followup.send(
-                    f"❌ PR **{repo_name}#{pr_number}** not found or inaccessible.",
-                    ephemeral=True,
-                )
-                return
+        if not is_repo_allowed(repo_filter, repo_name):
+            await interaction.followup.send(
+                f"❌ PR **{repo_name}#{pr_number}** not found or inaccessible.",
+                ephemeral=True,
+            )
+            return
 
         try:
             health = await asyncio.to_thread(

--- a/src/ghdcbot/bot.py
+++ b/src/ghdcbot/bot.py
@@ -59,6 +59,7 @@ from ghdcbot.engine.social_profiles import SocialProfileService
 
 # Slash command names used for permission checks (must match @tree.command name=...)
 SLASH_CMD_SYNC = "sync"
+SLASH_CMD_PR_STATUS = "pr-status"
 
 VERIFICATION_CODE_REMOVAL_NOTE = (
     "You may now safely remove the verification code from your GitHub bio. "
@@ -861,10 +862,20 @@ def run_bot(config_path: str) -> None:
                 ephemeral=True
             )
         
-    def command_permission_check(command_name: str):
-        """Restrict slash commands via discord.command_permissions or legacy issue_assignees."""
+    def command_permission_check(command_name: str, *, allow_all_by_default: bool = False):
+        """Restrict slash commands via discord.command_permissions or legacy issue_assignees.
+
+        When allow_all_by_default is True (e.g. for informational commands like /pr-status),
+        the command is open to all guild members unless explicitly configured in
+        discord.command_permissions.
+        """
 
         def check(interaction: discord.Interaction) -> bool:
+            if allow_all_by_default:
+                perms = getattr(config.discord, "command_permissions", None)
+                if perms and command_name in perms:
+                    return slash_command_allowed(interaction, config, command_name)
+                return hasattr(interaction.user, "roles") and hasattr(interaction.user, "guild_permissions")
             return slash_command_allowed(interaction, config, command_name)
 
         return check
@@ -946,7 +957,8 @@ def run_bot(config_path: str) -> None:
         show_all="Show health dashboard for all open PRs in the organization",
         skip="How many open PRs to skip for pagination (when show_all is True)",
     )
-    @app_commands.checks.cooldown(1, 3.0)
+    @app_commands.checks.cooldown(1, 5.0)
+    @app_commands.check(command_permission_check(SLASH_CMD_PR_STATUS, allow_all_by_default=True))
     async def pr_status_cmd(
         interaction: discord.Interaction,
         repo: str | None = None,

--- a/src/ghdcbot/discord_command_permissions.py
+++ b/src/ghdcbot/discord_command_permissions.py
@@ -28,6 +28,8 @@ def slash_command_allowed(
     interaction: discord.Interaction,
     config: BotConfig,
     command_name: str,
+    *,
+    allow_all_by_default: bool = False,
 ) -> bool:
     """Return True if the member may run this slash command."""
     member = interaction.user
@@ -43,6 +45,8 @@ def slash_command_allowed(
         rule = perms[command_name]
 
     if rule is None:
+        if allow_all_by_default:
+            return True
         return _legacy_issue_assignee_allowed(member, config)
 
     if rule.allow_discord_administrators and member.guild_permissions.administrator:

--- a/src/ghdcbot/engine/pr_status.py
+++ b/src/ghdcbot/engine/pr_status.py
@@ -19,6 +19,19 @@ _DEFAULT_CODERABBIT_BOT_LOGINS = ["coderabbitai", "coderabbitai[bot]"]
 PR_STATUS_MAX_PRS = 25
 
 
+def is_repo_allowed(repo_filter: Any, repo_name: str) -> bool:
+    """Check whether a repository is permitted by the configured RepoFilterConfig."""
+    if not repo_filter:
+        return True
+    filter_names = {name.strip() for name in getattr(repo_filter, "names", [])}
+    mode = getattr(repo_filter, "mode", "allow")
+    if mode == "allow":
+        return repo_name in filter_names
+    if mode == "deny":
+        return repo_name not in filter_names
+    return True
+
+
 @dataclass(frozen=True)
 class PRHealthStatus:
     """Health assessment for a single pull request."""

--- a/src/ghdcbot/engine/pr_status.py
+++ b/src/ghdcbot/engine/pr_status.py
@@ -1,0 +1,541 @@
+"""PR health dashboard: fetch and format PR status for maintainer triage.
+
+Provides at-a-glance health assessment of open PRs including CI status,
+CodeRabbit review comments, merge conflicts, and review state.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Sequence
+
+logger = logging.getLogger(__name__)
+
+# Default CodeRabbit bot logins (matches notifications.py pattern).
+_DEFAULT_CODERABBIT_BOT_LOGINS = ["coderabbitai", "coderabbitai[bot]"]
+
+# Maximum PRs per invocation to stay within Discord interaction timeout.
+PR_STATUS_MAX_PRS = 25
+
+
+@dataclass(frozen=True)
+class PRHealthStatus:
+    """Health assessment for a single pull request."""
+
+    repo: str
+    number: int
+    title: str
+    author: str
+    html_url: str
+    ci_status: str  # "passing" | "failing" | "pending" | "unknown"
+    mergeable: bool | None  # True | False | None (unknown)
+    review_state: str  # "approved" | "changes_requested" | "review_comment" | "awaiting_review"
+    approved_count: int
+    changes_requested_count: int
+    has_coderabbit_comments: bool
+    coderabbit_comment_count: int
+    is_draft: bool
+
+    @property
+    def health_indicator(self) -> str:
+        """Compute overall health: safe_to_merge | needs_attention | blocked | draft."""
+        if self.is_draft:
+            return "draft"
+        # Blocked conditions: CI failing or merge conflicts
+        if self.ci_status == "failing":
+            return "blocked"
+        if self.mergeable is False:
+            return "blocked"
+        if self.review_state == "changes_requested":
+            return "blocked"
+        # Safe to merge: CI passing/unknown, approved, mergeable, no CodeRabbit
+        if (
+            self.review_state == "approved"
+            and self.ci_status in ("passing", "unknown")
+            and self.mergeable is not False
+            and not self.has_coderabbit_comments
+        ):
+            return "safe_to_merge"
+        # Everything else needs attention
+        return "needs_attention"
+
+
+def fetch_pr_health(
+    github_adapter: Any,
+    owner: str,
+    repo: str,
+    pr_number: int,
+    coderabbit_bot_logins: list[str] | None = None,
+) -> PRHealthStatus | None:
+    """Fetch and compute health status for a single PR.
+
+    Returns None if the PR does not exist or is inaccessible.
+    """
+    pr = github_adapter.get_pull_request(owner, repo, pr_number)
+    if not pr:
+        return None
+
+    # Reviews (separate human reviews and bot reviews)
+    bot_logins = coderabbit_bot_logins or _DEFAULT_CODERABBIT_BOT_LOGINS
+    bot_logins_lower = [x.strip().lower() for x in bot_logins if x]
+
+    reviews = github_adapter.get_pull_request_reviews(owner, repo, pr_number)
+    human_reviews = [
+        r for r in reviews
+        if ((r.get("user") or {}).get("login") or "").strip().lower() not in bot_logins_lower
+    ]
+    coderabbit_reviews = [
+        r for r in reviews
+        if ((r.get("user") or {}).get("login") or "").strip().lower() in bot_logins_lower
+    ]
+
+    approved_count = sum(
+        1 for r in human_reviews if (r.get("state") or "").upper() == "APPROVED"
+    )
+    changes_requested_count = sum(
+        1 for r in human_reviews if (r.get("state") or "").upper() == "CHANGES_REQUESTED"
+    )
+    comment_review_count = sum(
+        1
+        for r in human_reviews
+        if (r.get("state") or "").upper() in ("COMMENT", "COMMENTED")
+    )
+
+    if changes_requested_count > 0:
+        review_state = "changes_requested"
+    elif approved_count > 0:
+        review_state = "approved"
+    elif comment_review_count > 0:
+        review_state = "review_comment"
+    else:
+        review_state = "awaiting_review"
+
+    # CI status from check runs
+    head_sha = pr.get("head", {}).get("sha")
+    ci_status = "unknown"
+    if head_sha:
+        check_runs = github_adapter.get_pull_request_check_runs(
+            owner, repo, head_sha
+        )
+        ci_status = _compute_ci_status(check_runs)
+
+    # Check if latest CodeRabbit review is APPROVED
+    coderabbit_approved = False
+    if coderabbit_reviews:
+        # Latest review from CodeRabbit
+        latest_cr_review = coderabbit_reviews[-1]
+        if (latest_cr_review.get("state") or "").upper() == "APPROVED":
+            coderabbit_approved = True
+
+    # CodeRabbit inline review comments & unresolved review threads
+    coderabbit_count = 0
+    if not coderabbit_approved:
+        # First check GraphQL review threads (if supported and returns a non-empty list of dicts)
+        get_threads = getattr(github_adapter, "get_pull_request_review_threads", None)
+        raw_threads = get_threads(owner, repo, pr_number) if callable(get_threads) else None
+        if isinstance(raw_threads, list) and raw_threads:
+            for t in raw_threads:
+                if isinstance(t, dict):
+                    authors = t.get("authors") or []
+                    if any(a in bot_logins_lower for a in authors):
+                        if not t.get("is_resolved") and not t.get("is_outdated"):
+                            coderabbit_count += 1
+        else:
+            # Fallback to REST review comments
+            get_comments = getattr(github_adapter, "get_pull_request_review_comments", None)
+            if callable(get_comments):
+                try:
+                    comments = get_comments(owner, repo, pr_number)
+                    if isinstance(comments, list):
+                        coderabbit_count = sum(
+                            1
+                            for c in comments
+                            if isinstance(c, dict)
+                            and _is_active_coderabbit_comment(c, bot_logins_lower, head_sha)
+                        )
+                except Exception as exc:
+                    logger.debug(
+                        "Failed to fetch review comments for PR health",
+                        extra={"repo": repo, "pr_number": pr_number, "error": str(exc)},
+                    )
+
+    user = pr.get("user") or {}
+    return PRHealthStatus(
+        repo=repo,
+        number=pr_number,
+        title=(pr.get("title") or "Untitled").strip(),
+        author=user.get("login") or "unknown",
+        html_url=pr.get("html_url") or f"https://github.com/{owner}/{repo}/pull/{pr_number}",
+        ci_status=ci_status,
+        mergeable=pr.get("mergeable"),
+        review_state=review_state,
+        approved_count=approved_count,
+        changes_requested_count=changes_requested_count,
+        has_coderabbit_comments=coderabbit_count > 0,
+        coderabbit_comment_count=coderabbit_count,
+        is_draft=bool(pr.get("draft", False)),
+    )
+
+
+def fetch_all_open_pr_health(
+    github_adapter: Any,
+    org: str,
+    coderabbit_bot_logins: list[str] | None = None,
+    max_prs: int = PR_STATUS_MAX_PRS,
+    skip: int = 0,
+) -> tuple[list[PRHealthStatus], int]:
+    """Fetch health for all open PRs in the configured org.
+
+    Returns (health_list, total_open_count).
+    """
+    all_open_prs = list(github_adapter.list_open_pull_requests())
+    total = len(all_open_prs)
+
+    # Apply pagination
+    page_prs = all_open_prs[skip : skip + max_prs]
+
+    results: list[PRHealthStatus] = []
+    for pr in page_prs:
+        repo = pr.get("repo")
+        number = pr.get("number")
+        if not repo or number is None:
+            continue
+        try:
+            health = fetch_pr_health(
+                github_adapter, org, repo, number, coderabbit_bot_logins
+            )
+            if health is not None:
+                results.append(health)
+        except Exception as exc:
+            logger.warning(
+                "Failed to fetch health for PR",
+                extra={"repo": repo, "number": number, "error": str(exc)},
+            )
+    return results, total
+
+
+# ---------------------------------------------------------------------------
+# Formatting helpers
+# ---------------------------------------------------------------------------
+
+_HEALTH_EMOJI = {
+    "safe_to_merge": "🟢",
+    "needs_attention": "🟡",
+    "blocked": "🔴",
+    "draft": "⬜",
+}
+
+_CI_EMOJI = {
+    "passing": "✅",
+    "failing": "❌",
+    "pending": "⏳",
+    "unknown": "❓",
+}
+
+_CI_LABEL = {
+    "passing": "Passing",
+    "failing": "Failing",
+    "pending": "In Progress",
+    "unknown": "Unknown",
+}
+
+_REVIEW_EMOJI = {
+    "approved": "✅",
+    "changes_requested": "🔄",
+    "review_comment": "💬",
+    "awaiting_review": "⏳",
+}
+
+_REVIEW_LABEL = {
+    "approved": "Approved",
+    "changes_requested": "Changes Requested",
+    "review_comment": "Comment Review",
+    "awaiting_review": "Awaiting Review",
+}
+
+_HEALTH_LABEL = {
+    "safe_to_merge": "🟢 Safe to Merge",
+    "needs_attention": "🟡 Needs Attention",
+    "blocked": "🔴 Blocked",
+    "draft": "⬜ Draft",
+}
+
+# Sort priority: blocked first (maintainer needs to know what's stuck), then
+# needs_attention, then safe_to_merge, then drafts last.
+_HEALTH_SORT_ORDER = {
+    "blocked": 0,
+    "needs_attention": 1,
+    "safe_to_merge": 2,
+    "draft": 3,
+}
+
+
+def format_single_pr_status(status: PRHealthStatus, org: str) -> str:
+    """Format a detailed health report for a single PR."""
+    lines: list[str] = []
+
+    # Header
+    lines.append(f"**{status.repo}#{status.number}** — {_truncate(status.title, 80)}")
+    lines.append(f"👤 **Author:** {status.author}")
+    lines.append("")
+
+    # CI
+    ci_emoji = _CI_EMOJI.get(status.ci_status, "❓")
+    ci_label = _CI_LABEL.get(status.ci_status, "Unknown")
+    lines.append(f"{ci_emoji} **CI:** {ci_label}")
+
+    # CodeRabbit
+    if status.has_coderabbit_comments:
+        lines.append(
+            f"🟡 **CodeRabbit:** {status.coderabbit_comment_count} suggestion"
+            f"{'s' if status.coderabbit_comment_count != 1 else ''} pending"
+        )
+    else:
+        lines.append("✅ **CodeRabbit:** No pending suggestions")
+
+    # Merge conflicts
+    if status.mergeable is False:
+        lines.append("⚠️ **Merge Conflicts:** Yes")
+    elif status.mergeable is True:
+        lines.append("✅ **Mergeable:** Yes")
+    else:
+        lines.append("❓ **Mergeable:** Unknown")
+
+    # Reviews
+    review_emoji = _REVIEW_EMOJI.get(status.review_state, "❓")
+    review_label = _REVIEW_LABEL.get(status.review_state, "Unknown")
+    review_detail = review_label
+    if status.approved_count > 0:
+        review_detail += f" ({status.approved_count} approval{'s' if status.approved_count != 1 else ''})"
+    if status.changes_requested_count > 0:
+        review_detail += f" ({status.changes_requested_count} change request{'s' if status.changes_requested_count != 1 else ''})"
+    lines.append(f"{review_emoji} **Review:** {review_detail}")
+
+    # Draft
+    if status.is_draft:
+        lines.append("📝 **Draft:** Yes")
+
+    lines.append("")
+    lines.append("──────────")
+    health_label = _HEALTH_LABEL.get(status.health_indicator, "Unknown")
+    lines.append(f"📊 **Health:** {health_label}")
+    lines.append(f"🔗 {status.html_url}")
+
+    return "\n".join(lines)
+
+
+def format_all_pr_status(
+    statuses: list[PRHealthStatus],
+    org: str,
+    skip: int = 0,
+    total: int = 0,
+) -> list[str]:
+    """Format a triage-priority sorted summary for multiple PRs.
+
+    Returns a list of message strings, each ≤2000 chars (Discord limit).
+    """
+    if not statuses:
+        if total == 0:
+            return ["📋 **PR Status Dashboard**\n\nNo open PRs found in configured repos."]
+        return [
+            f"📋 **PR Status Dashboard**\n\n"
+            f"No PRs in range (skip={skip}, total={total}). "
+            f"Try `/pr-status show_all:True` without skip."
+        ]
+
+    # Sort by triage priority
+    sorted_statuses = sorted(
+        statuses,
+        key=lambda s: (_HEALTH_SORT_ORDER.get(s.health_indicator, 99), s.repo, s.number),
+    )
+
+    # Count by health
+    counts = {"safe_to_merge": 0, "needs_attention": 0, "blocked": 0, "draft": 0}
+    for s in sorted_statuses:
+        counts[s.health_indicator] = counts.get(s.health_indicator, 0) + 1
+
+    # Build header
+    header_lines = [
+        "📋 **PR Status Dashboard**",
+        "",
+        f"Showing {len(statuses)} of {total} open PR{'s' if total != 1 else ''}",
+    ]
+    summary_parts = []
+    if counts["blocked"] > 0:
+        summary_parts.append(f"🔴 {counts['blocked']} blocked")
+    if counts["needs_attention"] > 0:
+        summary_parts.append(f"🟡 {counts['needs_attention']} need attention")
+    if counts["safe_to_merge"] > 0:
+        summary_parts.append(f"🟢 {counts['safe_to_merge']} safe to merge")
+    if counts["draft"] > 0:
+        summary_parts.append(f"⬜ {counts['draft']} draft")
+    if summary_parts:
+        header_lines.append(" · ".join(summary_parts))
+    header_lines.append("")
+
+    header = "\n".join(header_lines)
+
+    # Build PR lines
+    pr_lines: list[str] = []
+    for s in sorted_statuses:
+        health_emoji = _HEALTH_EMOJI.get(s.health_indicator, "❓")
+        detail_parts = []
+
+        # CI
+        ci_emoji = _CI_EMOJI.get(s.ci_status, "❓")
+        detail_parts.append(f"CI {ci_emoji}")
+
+        # Reviews
+        if s.review_state == "approved":
+            detail_parts.append(f"Reviews ✅")
+        elif s.review_state == "changes_requested":
+            detail_parts.append("Reviews: changes requested")
+        elif s.review_state == "awaiting_review":
+            detail_parts.append("Reviews: awaiting")
+        else:
+            detail_parts.append("Reviews: comment")
+
+        # Mergeable
+        if s.mergeable is False:
+            detail_parts.append("Conflicts ⚠️")
+        elif s.mergeable is True:
+            detail_parts.append("Mergeable ✅")
+
+        # CodeRabbit
+        if s.has_coderabbit_comments:
+            detail_parts.append(f"CodeRabbit: {s.coderabbit_comment_count} pending")
+
+        # Draft
+        if s.is_draft:
+            detail_parts.append("Draft")
+
+        detail = " · ".join(detail_parts)
+        title = _truncate(s.title, 50)
+        pr_lines.append(
+            f"{health_emoji} **{s.repo}#{s.number}** — \"{title}\" ({detail})"
+        )
+
+    # Pagination footer
+    footer_lines: list[str] = []
+    shown_end = skip + len(statuses)
+    if shown_end < total:
+        footer_lines.append("")
+        footer_lines.append(
+            f"*…and {total - shown_end} more. "
+            f"Use `/pr-status show_all:True skip:{shown_end}` to see next page.*"
+        )
+
+    # Split into ≤2000 char messages
+    return _split_messages(header, pr_lines, footer_lines, max_length=2000)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _compute_ci_status(check_runs: list[dict]) -> str:
+    """Determine CI status from GitHub check runs (same logic as pr_context.py)."""
+    if not check_runs:
+        return "unknown"
+
+    conclusions = [(cr.get("conclusion") or "").lower() for cr in check_runs]
+    statuses = [(cr.get("status") or "").lower() for cr in check_runs]
+
+    if any(c == "failure" for c in conclusions):
+        return "failing"
+    if any(c == "success" for c in conclusions) and not any(
+        c == "failure" for c in conclusions
+    ):
+        return "passing"
+    if any(s in ("in_progress", "queued") for s in statuses):
+        return "pending"
+    return "unknown"
+
+
+def _is_coderabbit_bot(comment: dict, bot_logins_lower: list[str]) -> bool:
+    """True if comment is from a configured CodeRabbit bot login."""
+    user = comment.get("user") or {}
+    login = (user.get("login") or "").strip().lower()
+    return bool(login and login in bot_logins_lower)
+
+
+def _is_active_coderabbit_comment(
+    comment: dict,
+    bot_logins_lower: list[str],
+    head_sha: str | None = None,
+) -> bool:
+    """True if comment is from CodeRabbit and is still active/unresolved on the current PR HEAD.
+
+    A CodeRabbit comment is considered resolved/inactive if:
+    - It is not from CodeRabbit
+    - It is marked outdated by GitHub (position is None while original_position was set)
+    - It was on an older commit that has been superseded by a new HEAD commit
+    - Its content indicates it was resolved (checked checkbox [x] or struck-through suggestion ~~)
+    """
+    if not _is_coderabbit_bot(comment, bot_logins_lower):
+        return False
+
+    # Outdated diff check: GitHub sets position to null when code changes supersede it
+    if comment.get("position") is None and comment.get("original_position") is not None:
+        return False
+
+    # Superseded commit check: if head_sha is known and comment was made on an earlier commit
+    comment_commit = comment.get("commit_id")
+    if head_sha and comment_commit and comment_commit != head_sha:
+        return False
+
+    # Check if comment has explicit resolved flag or status
+    if comment.get("resolved") is True or comment.get("is_resolved") is True:
+        return False
+
+    # Body check: if CodeRabbit marked the item resolved
+    body = (comment.get("body") or "").strip()
+    if "[x]" in body and "[ ]" not in body:
+        # All checklist items were resolved
+        return False
+
+    return True
+
+
+def _truncate(text: str, max_len: int) -> str:
+    """Truncate text with ellipsis if too long."""
+    if len(text) <= max_len:
+        return text
+    return f"{text[: max_len - 3]}..."
+
+
+def _split_messages(
+    header: str,
+    lines: list[str],
+    footer_lines: list[str],
+    max_length: int = 2000,
+) -> list[str]:
+    """Split content into messages each ≤max_length chars."""
+    messages: list[str] = []
+    current = header
+
+    for line in lines:
+        candidate = current + "\n" + line if current else line
+        if len(candidate) > max_length and current:
+            messages.append(current)
+            current = line
+        else:
+            current = candidate
+
+    # Append footer to last chunk
+    footer = "\n".join(footer_lines) if footer_lines else ""
+    if footer:
+        candidate = current + "\n" + footer if current else footer
+        if len(candidate) > max_length and current:
+            messages.append(current)
+            current = footer
+        else:
+            current = candidate
+
+    if current:
+        messages.append(current)
+
+    return messages if messages else [header]

--- a/src/ghdcbot/engine/pr_status.py
+++ b/src/ghdcbot/engine/pr_status.py
@@ -19,6 +19,12 @@ _DEFAULT_CODERABBIT_BOT_LOGINS = ["coderabbitai", "coderabbitai[bot]"]
 # Maximum PRs per invocation to stay within Discord interaction timeout.
 PR_STATUS_MAX_PRS = 25
 
+# Maximum candidate repositories to probe when auto-detecting repo for a PR.
+RESOLVE_REPO_MAX_CANDIDATES = 25
+
+# Maximum concurrent repository probe requests.
+RESOLVE_REPO_MAX_CONCURRENCY = 5
+
 
 def is_repo_allowed(repo_filter: Any, repo_name: str) -> bool:
     """Check whether a repository is permitted by the configured RepoFilterConfig."""
@@ -34,6 +40,17 @@ def is_repo_allowed(repo_filter: Any, repo_name: str) -> bool:
     if mode == "deny":
         return repo_name not in filter_names
     return True
+
+
+def _cfg_get(target: Any, key: str, default: Any = None) -> Any:
+    """Retrieve an attribute or dict key from target, returning default if absent or None."""
+    if target is None:
+        return default
+    if isinstance(target, dict):
+        val = target.get(key)
+    else:
+        val = getattr(target, key, None)
+    return default if val is None else val
 
 
 def get_configured_repo_names(config: Any) -> list[str]:
@@ -60,52 +77,31 @@ def get_configured_repo_names(config: Any) -> list[str]:
         return repo_names
 
     # 1. github.repos.names (allow mode)
-    github_cfg = getattr(config, "github", None)
-    if isinstance(config, dict) and github_cfg is None:
-        github_cfg = config.get("github")
-
+    github_cfg = _cfg_get(config, "github")
     if github_cfg:
-        repos_cfg = getattr(github_cfg, "repos", None)
-        if isinstance(github_cfg, dict) and repos_cfg is None:
-            repos_cfg = github_cfg.get("repos")
-
+        repos_cfg = _cfg_get(github_cfg, "repos")
         if repos_cfg:
             if isinstance(repos_cfg, (list, tuple)):
                 for r in repos_cfg:
                     _add(r)
             else:
-                mode = getattr(repos_cfg, "mode", None)
-                if isinstance(repos_cfg, dict) and mode is None:
-                    mode = repos_cfg.get("mode")
-                mode = mode or "allow"
-
-                names = getattr(repos_cfg, "names", None)
-                if isinstance(repos_cfg, dict) and names is None:
-                    names = repos_cfg.get("names")
+                mode = _cfg_get(repos_cfg, "mode", "allow") or "allow"
+                names = _cfg_get(repos_cfg, "names")
 
                 if mode == "allow" and isinstance(names, (list, tuple)):
                     for r in names:
                         _add(r)
 
     # 2. discord.pr_open_channels
-    discord_cfg = getattr(config, "discord", None)
-    if isinstance(config, dict) and discord_cfg is None:
-        discord_cfg = config.get("discord")
-
+    discord_cfg = _cfg_get(config, "discord")
     if discord_cfg:
-        pr_open_channels = getattr(discord_cfg, "pr_open_channels", None)
-        if isinstance(discord_cfg, dict) and pr_open_channels is None:
-            pr_open_channels = discord_cfg.get("pr_open_channels")
-
+        pr_open_channels = _cfg_get(discord_cfg, "pr_open_channels")
         if isinstance(pr_open_channels, dict):
             for r in pr_open_channels:
                 _add(r)
 
     # 3. repo_contributor_roles
-    contributor_roles = getattr(config, "repo_contributor_roles", None)
-    if isinstance(config, dict) and contributor_roles is None:
-        contributor_roles = config.get("repo_contributor_roles")
-
+    contributor_roles = _cfg_get(config, "repo_contributor_roles")
     if isinstance(contributor_roles, dict):
         for r in contributor_roles:
             _add(r)
@@ -151,13 +147,9 @@ async def resolve_repo_for_pr(
     """
     repo_filter = None
     if config:
-        github_cfg = getattr(config, "github", None)
-        if isinstance(config, dict) and github_cfg is None:
-            github_cfg = config.get("github")
+        github_cfg = _cfg_get(config, "github")
         if github_cfg:
-            repo_filter = getattr(github_cfg, "repos", None)
-            if isinstance(github_cfg, dict) and repo_filter is None:
-                repo_filter = github_cfg.get("repos")
+            repo_filter = _cfg_get(github_cfg, "repos")
 
     # Case 1: User explicitly provided repo
     if repo and repo.strip():
@@ -180,26 +172,26 @@ async def resolve_repo_for_pr(
     # Multiple repos configured: check which one contains this PR number
     org = ""
     if config:
-        github_cfg = getattr(config, "github", None)
-        if isinstance(config, dict) and github_cfg is None:
-            github_cfg = config.get("github")
+        github_cfg = _cfg_get(config, "github")
         if github_cfg:
-            org = getattr(github_cfg, "org", "")
-            if isinstance(github_cfg, dict) and not org:
-                org = github_cfg.get("org", "")
+            org = _cfg_get(github_cfg, "org", "") or ""
+
+    candidates = configured_repos[:RESOLVE_REPO_MAX_CANDIDATES]
+    semaphore = asyncio.Semaphore(RESOLVE_REPO_MAX_CONCURRENCY)
 
     async def _check_repo(candidate: str) -> bool:
-        try:
-            get_pr = getattr(github_adapter, "get_pull_request", None)
-            if not callable(get_pr):
+        async with semaphore:
+            try:
+                get_pr = getattr(github_adapter, "get_pull_request", None)
+                if not callable(get_pr):
+                    return False
+                pr = await asyncio.to_thread(get_pr, org, candidate, int(pr_number))
+                return bool(pr)
+            except Exception:
                 return False
-            pr = await asyncio.to_thread(get_pr, org, candidate, int(pr_number))
-            return bool(pr)
-        except Exception:
-            return False
 
-    results = await asyncio.gather(*[_check_repo(r) for r in configured_repos])
-    matching = [r for r, ok in zip(configured_repos, results) if ok]
+    results = await asyncio.gather(*[_check_repo(r) for r in candidates])
+    matching = [r for r, ok in zip(candidates, results) if ok]
 
     if len(matching) == 1:
         return matching[0], None
@@ -214,7 +206,7 @@ async def resolve_repo_for_pr(
             ),
         )
 
-    repo_list = ", ".join(f"`{r}`" for r in configured_repos)
+    repo_list = ", ".join(f"`{r}`" for r in candidates)
     return (
         None,
         (

--- a/src/ghdcbot/engine/pr_status.py
+++ b/src/ghdcbot/engine/pr_status.py
@@ -30,8 +30,13 @@ def is_repo_allowed(repo_filter: Any, repo_name: str) -> bool:
     """Check whether a repository is permitted by the configured RepoFilterConfig."""
     if not repo_filter:
         return True
-    filter_names = {name.strip().lower() for name in getattr(repo_filter, "names", [])}
-    mode = getattr(repo_filter, "mode", "allow")
+    if isinstance(repo_filter, dict):
+        names = repo_filter.get("names", [])
+        mode = repo_filter.get("mode", "allow")
+    else:
+        names = getattr(repo_filter, "names", [])
+        mode = getattr(repo_filter, "mode", "allow")
+    filter_names = {name.strip().lower() for name in names}
     candidate = (repo_name or "").strip().lower()
     if mode == "allow":
         return candidate in filter_names

--- a/src/ghdcbot/engine/pr_status.py
+++ b/src/ghdcbot/engine/pr_status.py
@@ -389,7 +389,7 @@ def format_all_pr_status(
 
         # Reviews
         if s.review_state == "approved":
-            detail_parts.append(f"Reviews ✅")
+            detail_parts.append("Reviews ✅")
         elif s.review_state == "changes_requested":
             detail_parts.append("Reviews: changes requested")
         elif s.review_state == "awaiting_review":

--- a/src/ghdcbot/engine/pr_status.py
+++ b/src/ghdcbot/engine/pr_status.py
@@ -24,10 +24,13 @@ def is_repo_allowed(repo_filter: Any, repo_name: str) -> bool:
     """Check whether a repository is permitted by the configured RepoFilterConfig."""
     if not repo_filter:
         return True
-    filter_names = {name.strip() for name in getattr(repo_filter, "names", [])}
+    filter_names = {name.strip().lower() for name in getattr(repo_filter, "names", [])}
     mode = getattr(repo_filter, "mode", "allow")
+    candidate = (repo_name or "").strip().lower()
     if mode == "allow":
-        return repo_name in filter_names
+        return candidate in filter_names
+    if mode == "deny":
+        return candidate not in filter_names
     if mode == "deny":
         return repo_name not in filter_names
     return True

--- a/src/ghdcbot/engine/pr_status.py
+++ b/src/ghdcbot/engine/pr_status.py
@@ -8,8 +8,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from datetime import datetime, timezone
-from typing import Any, Sequence
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -132,7 +131,7 @@ def fetch_pr_health(
     # CodeRabbit inline review comments & unresolved review threads
     coderabbit_count = 0
     if not coderabbit_approved:
-        # First check GraphQL review threads (if supported and returns a non-empty list of dicts)
+        # First check GraphQL review threads (returns list of threads if supported/available, None on error)
         get_threads = getattr(github_adapter, "get_pull_request_review_threads", None)
         raw_threads = None
         if callable(get_threads):
@@ -143,7 +142,8 @@ def fetch_pr_health(
                     "Failed to fetch review threads for PR health",
                     extra={"repo": repo, "pr_number": pr_number, "error": str(exc)},
                 )
-        if isinstance(raw_threads, list) and raw_threads:
+                raw_threads = None
+        if isinstance(raw_threads, list):
             for t in raw_threads:
                 if isinstance(t, dict):
                     authors = t.get("authors") or []
@@ -151,7 +151,7 @@ def fetch_pr_health(
                         if not t.get("is_resolved") and not t.get("is_outdated"):
                             coderabbit_count += 1
         else:
-            # Fallback to REST review comments
+            # Fallback to REST review comments if GraphQL is unavailable or encountered an error
             get_comments = getattr(github_adapter, "get_pull_request_review_comments", None)
             if callable(get_comments):
                 try:

--- a/src/ghdcbot/engine/pr_status.py
+++ b/src/ghdcbot/engine/pr_status.py
@@ -113,7 +113,7 @@ def fetch_pr_health(
         review_state = "awaiting_review"
 
     # CI status from check runs
-    head_sha = pr.get("head", {}).get("sha")
+    head_sha = (pr.get("head") or {}).get("sha")
     ci_status = "unknown"
     if head_sha:
         check_runs = github_adapter.get_pull_request_check_runs(

--- a/src/ghdcbot/engine/pr_status.py
+++ b/src/ghdcbot/engine/pr_status.py
@@ -134,7 +134,15 @@ def fetch_pr_health(
     if not coderabbit_approved:
         # First check GraphQL review threads (if supported and returns a non-empty list of dicts)
         get_threads = getattr(github_adapter, "get_pull_request_review_threads", None)
-        raw_threads = get_threads(owner, repo, pr_number) if callable(get_threads) else None
+        raw_threads = None
+        if callable(get_threads):
+            try:
+                raw_threads = get_threads(owner, repo, pr_number)
+            except Exception as exc:
+                logger.debug(
+                    "Failed to fetch review threads for PR health",
+                    extra={"repo": repo, "pr_number": pr_number, "error": str(exc)},
+                )
         if isinstance(raw_threads, list) and raw_threads:
             for t in raw_threads:
                 if isinstance(t, dict):

--- a/src/ghdcbot/engine/pr_status.py
+++ b/src/ghdcbot/engine/pr_status.py
@@ -6,6 +6,7 @@ CodeRabbit review comments, merge conflicts, and review state.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from dataclasses import dataclass
 from typing import Any
@@ -32,6 +33,194 @@ def is_repo_allowed(repo_filter: Any, repo_name: str) -> bool:
     return True
 
 
+def get_configured_repo_names(config: Any) -> list[str]:
+    """Extract repository names configured in Gitcord configuration.
+
+    Collects repository names from:
+    1. config.github.repos.names (when mode is 'allow')
+    2. config.discord.pr_open_channels (keys)
+    3. config.repo_contributor_roles (keys)
+
+    Returns a deduplicated list of repository names preserving configuration order.
+    """
+    repo_names: list[str] = []
+    seen: set[str] = set()
+
+    def _add(name: Any) -> None:
+        if isinstance(name, str):
+            cleaned = name.strip()
+            if cleaned and cleaned.lower() not in seen:
+                seen.add(cleaned.lower())
+                repo_names.append(cleaned)
+
+    if not config:
+        return repo_names
+
+    # 1. github.repos.names (allow mode)
+    github_cfg = getattr(config, "github", None)
+    if isinstance(config, dict) and github_cfg is None:
+        github_cfg = config.get("github")
+
+    if github_cfg:
+        repos_cfg = getattr(github_cfg, "repos", None)
+        if isinstance(github_cfg, dict) and repos_cfg is None:
+            repos_cfg = github_cfg.get("repos")
+
+        if repos_cfg:
+            if isinstance(repos_cfg, (list, tuple)):
+                for r in repos_cfg:
+                    _add(r)
+            else:
+                mode = getattr(repos_cfg, "mode", None)
+                if isinstance(repos_cfg, dict) and mode is None:
+                    mode = repos_cfg.get("mode")
+                mode = mode or "allow"
+
+                names = getattr(repos_cfg, "names", None)
+                if isinstance(repos_cfg, dict) and names is None:
+                    names = repos_cfg.get("names")
+
+                if mode == "allow" and isinstance(names, (list, tuple)):
+                    for r in names:
+                        _add(r)
+
+    # 2. discord.pr_open_channels
+    discord_cfg = getattr(config, "discord", None)
+    if isinstance(config, dict) and discord_cfg is None:
+        discord_cfg = config.get("discord")
+
+    if discord_cfg:
+        pr_open_channels = getattr(discord_cfg, "pr_open_channels", None)
+        if isinstance(discord_cfg, dict) and pr_open_channels is None:
+            pr_open_channels = discord_cfg.get("pr_open_channels")
+
+        if isinstance(pr_open_channels, dict):
+            for r in pr_open_channels:
+                _add(r)
+
+    # 3. repo_contributor_roles
+    contributor_roles = getattr(config, "repo_contributor_roles", None)
+    if isinstance(config, dict) and contributor_roles is None:
+        contributor_roles = config.get("repo_contributor_roles")
+
+    if isinstance(contributor_roles, dict):
+        for r in contributor_roles:
+            _add(r)
+
+    return repo_names
+
+
+def filter_repo_suggestions(configured_repos: list[str], current: str) -> list[str]:
+    """Filter configured repositories by prefix/substring match, up to 25 items."""
+    curr = (current or "").strip().lower()
+    if not curr:
+        return configured_repos[:25]
+    prefix_matches = [r for r in configured_repos if r.lower().startswith(curr)]
+    substring_matches = [
+        r for r in configured_repos if curr in r.lower() and not r.lower().startswith(curr)
+    ]
+    return (prefix_matches + substring_matches)[:25]
+
+
+async def resolve_repo_for_pr(
+    config: Any,
+    github_adapter: Any,
+    pr_number: int,
+    repo: str | None = None,
+) -> tuple[str | None, str | None]:
+    """Resolve repository name for a PR status query.
+
+    If ``repo`` is specified:
+      - Validates against configured repo filters.
+      - Returns (repo_name, None) or (None, error_message).
+
+    If ``repo`` is omitted:
+      - Reads configured repositories from Gitcord config.
+      - If exactly one repo is configured, uses it directly (zero overhead).
+      - If multiple repos are configured, scans them concurrently for ``pr_number``.
+        - Exactly one match: uses that repo.
+        - Multiple matches: asks user to disambiguate.
+        - No matches: informs user which configured repos were checked.
+      - If no repos are configured, prompts user to provide ``repo``.
+
+    Returns:
+      (repo_name, error_message)
+    """
+    repo_filter = None
+    if config:
+        github_cfg = getattr(config, "github", None)
+        if isinstance(config, dict) and github_cfg is None:
+            github_cfg = config.get("github")
+        if github_cfg:
+            repo_filter = getattr(github_cfg, "repos", None)
+            if isinstance(github_cfg, dict) and repo_filter is None:
+                repo_filter = github_cfg.get("repos")
+
+    # Case 1: User explicitly provided repo
+    if repo and repo.strip():
+        cleaned = repo.strip()
+        if not is_repo_allowed(repo_filter, cleaned):
+            return None, f"❌ Repository **{cleaned}** is not allowed by Gitcord configuration."
+        return cleaned, None
+
+    # Case 2: Auto-detect from Gitcord config
+    configured_repos = get_configured_repo_names(config)
+    if not configured_repos:
+        return (
+            None,
+            "❌ Please specify `repo` (no allowed repositories found in Gitcord configuration).",
+        )
+
+    if len(configured_repos) == 1:
+        return configured_repos[0], None
+
+    # Multiple repos configured: check which one contains this PR number
+    org = ""
+    if config:
+        github_cfg = getattr(config, "github", None)
+        if isinstance(config, dict) and github_cfg is None:
+            github_cfg = config.get("github")
+        if github_cfg:
+            org = getattr(github_cfg, "org", "")
+            if isinstance(github_cfg, dict) and not org:
+                org = github_cfg.get("org", "")
+
+    async def _check_repo(candidate: str) -> bool:
+        try:
+            get_pr = getattr(github_adapter, "get_pull_request", None)
+            if not callable(get_pr):
+                return False
+            pr = await asyncio.to_thread(get_pr, org, candidate, int(pr_number))
+            return bool(pr)
+        except Exception:
+            return False
+
+    results = await asyncio.gather(*[_check_repo(r) for r in configured_repos])
+    matching = [r for r, ok in zip(configured_repos, results) if ok]
+
+    if len(matching) == 1:
+        return matching[0], None
+
+    if len(matching) > 1:
+        repo_list = ", ".join(f"`{r}`" for r in matching)
+        return (
+            None,
+            (
+                f"❌ Found PR **#{pr_number}** in multiple configured repositories: {repo_list}. "
+                "Please specify which repository using `repo:<name>`."
+            ),
+        )
+
+    repo_list = ", ".join(f"`{r}`" for r in configured_repos)
+    return (
+        None,
+        (
+            f"❌ PR **#{pr_number}** not found in configured repositories ({repo_list}). "
+            "Please check the PR number or specify the repository with `repo:<name>`."
+        ),
+    )
+
+
 @dataclass(frozen=True)
 class PRHealthStatus:
     """Health assessment for a single pull request."""
@@ -49,10 +238,15 @@ class PRHealthStatus:
     has_coderabbit_comments: bool
     coderabbit_comment_count: int
     is_draft: bool
+    state: str = "open"  # "open" | "merged" | "closed"
 
     @property
     def health_indicator(self) -> str:
-        """Compute overall health: safe_to_merge | needs_attention | blocked | draft."""
+        """Compute overall health: safe_to_merge | needs_attention | blocked | draft | merged | closed."""
+        if self.state == "merged":
+            return "merged"
+        if self.state == "closed":
+            return "closed"
         if self.is_draft:
             return "draft"
         # Blocked conditions: CI failing or merge conflicts
@@ -88,6 +282,36 @@ def fetch_pr_health(
     pr = github_adapter.get_pull_request(owner, repo, pr_number)
     if not pr:
         return None
+
+    pr_state = (pr.get("state") or "open").strip().lower()
+    is_merged = bool(pr.get("merged") or pr.get("merged_at"))
+    if is_merged or pr_state == "merged":
+        state = "merged"
+    elif pr_state == "closed":
+        state = "closed"
+    else:
+        state = "open"
+
+    user = pr.get("user") or {}
+
+    # If merged or closed, return immediately without querying check runs, threads, reviews
+    if state in ("merged", "closed"):
+        return PRHealthStatus(
+            repo=repo,
+            number=pr_number,
+            title=(pr.get("title") or "Untitled").strip(),
+            author=user.get("login") or "unknown",
+            html_url=pr.get("html_url") or f"https://github.com/{owner}/{repo}/pull/{pr_number}",
+            ci_status="unknown",
+            mergeable=None,
+            review_state="unknown",
+            approved_count=0,
+            changes_requested_count=0,
+            has_coderabbit_comments=False,
+            coderabbit_comment_count=0,
+            is_draft=False,
+            state=state,
+        )
 
     # Reviews (separate human reviews and bot reviews)
     bot_logins = coderabbit_bot_logins or _DEFAULT_CODERABBIT_BOT_LOGINS
@@ -197,6 +421,7 @@ def fetch_pr_health(
         has_coderabbit_comments=coderabbit_count > 0,
         coderabbit_comment_count=coderabbit_count,
         is_draft=bool(pr.get("draft", False)),
+        state="open",
     )
 
 
@@ -281,6 +506,8 @@ _HEALTH_LABEL = {
     "needs_attention": "🟡 Needs Attention",
     "blocked": "🔴 Blocked",
     "draft": "⬜ Draft",
+    "merged": "🟣 Merged",
+    "closed": "🔴 Closed",
 }
 
 # Sort priority: blocked first (maintainer needs to know what's stuck), then
@@ -301,6 +528,15 @@ def format_single_pr_status(status: PRHealthStatus, org: str) -> str:
     lines.append(f"**{status.repo}#{status.number}** — {_truncate(status.title, 80)}")
     lines.append(f"👤 **Author:** {status.author}")
     lines.append("")
+
+    # If merged or closed, just show that it's Merged or Closed and nothing on it
+    if status.state == "merged":
+        lines.append("🟣 **Status:** Merged")
+        return "\n".join(lines)
+
+    if status.state == "closed":
+        lines.append("🔴 **Status:** Closed")
+        return "\n".join(lines)
 
     # CI
     ci_emoji = _CI_EMOJI.get(status.ci_status, "❓")
@@ -342,7 +578,6 @@ def format_single_pr_status(status: PRHealthStatus, org: str) -> str:
     lines.append("──────────")
     health_label = _HEALTH_LABEL.get(status.health_indicator, "Unknown")
     lines.append(f"📊 **Health:** {health_label}")
-    lines.append(f"🔗 {status.html_url}")
 
     return "\n".join(lines)
 

--- a/tests/test_pr_status.py
+++ b/tests/test_pr_status.py
@@ -2,13 +2,11 @@
 
 from __future__ import annotations
 
-from dataclasses import replace
 from unittest.mock import MagicMock
 
 import pytest
 
 from ghdcbot.engine.pr_status import (
-    PR_STATUS_MAX_PRS,
     PRHealthStatus,
     _compute_ci_status,
     _is_coderabbit_bot,
@@ -455,8 +453,8 @@ class TestFetchPRHealth:
         adapter.get_pull_request_review_threads.assert_called_once_with("org", "my-repo", 7)
         adapter.get_pull_request_review_comments.assert_not_called()
 
-    def test_review_threads_graphql_fallback_when_threads_empty(self) -> None:
-        """When get_pull_request_review_threads returns empty, falls back to REST comments."""
+    def test_review_threads_graphql_empty_list_no_fallback_to_rest(self) -> None:
+        """When get_pull_request_review_threads returns an empty list, GraphQL succeeded with 0 threads and does NOT call REST fallback."""
         adapter = MagicMock()
         adapter.get_pull_request.return_value = _make_pr_data()
         adapter.get_pull_request_reviews.return_value = [{"state": "APPROVED"}]
@@ -464,6 +462,26 @@ class TestFetchPRHealth:
             {"status": "completed", "conclusion": "success"}
         ]
         adapter.get_pull_request_review_threads.return_value = []
+        adapter.get_pull_request_review_comments.return_value = [
+            {"user": {"login": "coderabbitai"}, "created_at": "2025-01-01T00:00:00Z"},
+        ]
+
+        health = fetch_pr_health(adapter, "org", "my-repo", 7)
+        assert health is not None
+        assert health.has_coderabbit_comments is False
+        assert health.coderabbit_comment_count == 0
+        adapter.get_pull_request_review_threads.assert_called_once_with("org", "my-repo", 7)
+        adapter.get_pull_request_review_comments.assert_not_called()
+
+    def test_review_threads_graphql_returns_none_falls_back_to_rest(self) -> None:
+        """When get_pull_request_review_threads returns None (error/unsupported), falls back to REST comments."""
+        adapter = MagicMock()
+        adapter.get_pull_request.return_value = _make_pr_data()
+        adapter.get_pull_request_reviews.return_value = [{"state": "APPROVED"}]
+        adapter.get_pull_request_check_runs.return_value = [
+            {"status": "completed", "conclusion": "success"}
+        ]
+        adapter.get_pull_request_review_threads.return_value = None
         adapter.get_pull_request_review_comments.return_value = [
             {"user": {"login": "coderabbitai"}, "created_at": "2025-01-01T00:00:00Z"},
         ]
@@ -600,7 +618,7 @@ class TestReviewThreadsGraphQLAdapter:
         adapter._client = mock_client
 
         threads = adapter.get_pull_request_review_threads("org", "repo", 42)
-        assert threads == []
+        assert threads is None
 
     def test_review_threads_non_200_response(self) -> None:
         from ghdcbot.adapters.github.rest import GitHubRestAdapter
@@ -613,7 +631,7 @@ class TestReviewThreadsGraphQLAdapter:
         adapter._client = mock_client
 
         threads = adapter.get_pull_request_review_threads("org", "repo", 42)
-        assert threads == []
+        assert threads is None
 
     def test_review_threads_empty_or_malformed_data(self) -> None:
         from ghdcbot.adapters.github.rest import GitHubRestAdapter
@@ -627,7 +645,65 @@ class TestReviewThreadsGraphQLAdapter:
         adapter._client = mock_client
 
         threads = adapter.get_pull_request_review_threads("org", "repo", 42)
-        assert threads == []
+        assert threads is None
+
+    def test_review_threads_graphql_errors_payload_returns_none(self) -> None:
+        from ghdcbot.adapters.github.rest import GitHubRestAdapter
+
+        adapter = GitHubRestAdapter(token="token", org="org", api_base="https://api.github.com")
+        mock_client = MagicMock()
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"errors": [{"message": "Field 'reviewThreads' doesn't exist"}]}
+        mock_client.post.return_value = mock_resp
+        adapter._client = mock_client
+
+        threads = adapter.get_pull_request_review_threads("org", "repo", 42)
+        assert threads is None
+
+    def test_review_threads_null_author_safely_ignored(self) -> None:
+        from ghdcbot.adapters.github.rest import GitHubRestAdapter
+
+        adapter = GitHubRestAdapter(token="token", org="org", api_base="https://api.github.com")
+        mock_client = MagicMock()
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "reviewThreads": {
+                            "pageInfo": {"hasNextPage": False, "endCursor": None},
+                            "nodes": [
+                                {
+                                    "id": "thread_1",
+                                    "isResolved": False,
+                                    "isOutdated": False,
+                                    "comments": {
+                                        "pageInfo": {"hasNextPage": False, "endCursor": None},
+                                        "nodes": [
+                                            {"author": None},
+                                            {"author": {"login": "coderabbitai[bot]"}},
+                                        ],
+                                    },
+                                },
+                            ],
+                        }
+                    }
+                }
+            }
+        }
+        mock_client.post.return_value = mock_resp
+        adapter._client = mock_client
+
+        threads = adapter.get_pull_request_review_threads("org", "repo", 42)
+        assert threads == [
+            {
+                "is_resolved": False,
+                "is_outdated": False,
+                "authors": ["coderabbitai[bot]"],
+            }
+        ]
 
     def test_graphql_endpoint_enterprise_and_public(self) -> None:
         from ghdcbot.adapters.github.rest import GitHubRestAdapter
@@ -959,4 +1035,107 @@ class TestPRStatusCommandRepoFilter:
             is_excluded = True
 
         assert is_excluded is False
+
+
+# ===================================================================
+# pr_status_cmd permissions gating tests
+# ===================================================================
+
+
+class TestPRStatusCommandPermissions:
+    def test_pr_status_allowed_by_default_without_explicit_rule(self) -> None:
+        """When discord.command_permissions has no pr-status rule, any guild member with roles is allowed."""
+        from ghdcbot.config.models import BotConfig, DiscordConfig, GitHubConfig, RuntimeConfig
+        from ghdcbot.discord_command_permissions import slash_command_allowed
+
+        config = BotConfig(
+            runtime=RuntimeConfig(
+                data_dir="/tmp/test",
+                github_adapter="rest",
+                discord_adapter="rest",
+                storage_adapter="sqlite",
+            ),
+            github=GitHubConfig(org="test-org"),
+            discord=DiscordConfig(guild_id="123", token="xyz"),
+        )
+
+        member = MagicMock()
+        member.roles = [MagicMock(name="Contributor", id="999")]
+        member.guild_permissions = MagicMock(administrator=False)
+        interaction = MagicMock()
+        interaction.user = member
+
+        # Simulating command_permission_check(SLASH_CMD_PR_STATUS, allow_all_by_default=True)
+        perms = getattr(config.discord, "command_permissions", None)
+        assert perms is None
+        allowed = (
+            slash_command_allowed(interaction, config, "pr-status")
+            if perms and "pr-status" in perms
+            else (hasattr(interaction.user, "roles") and hasattr(interaction.user, "guild_permissions"))
+        )
+        assert allowed is True
+
+    def test_pr_status_gated_when_configured_in_command_permissions(self) -> None:
+        """When discord.command_permissions specifies pr-status, unauthorized members are blocked and authorized members pass."""
+        from ghdcbot.config.models import (
+            BotConfig,
+            DiscordConfig,
+            GitHubConfig,
+            RuntimeConfig,
+            SlashCommandPermissionRule,
+        )
+        from ghdcbot.discord_command_permissions import slash_command_allowed
+
+        config = BotConfig(
+            runtime=RuntimeConfig(
+                data_dir="/tmp/test",
+                github_adapter="rest",
+                discord_adapter="rest",
+                storage_adapter="sqlite",
+            ),
+            github=GitHubConfig(org="test-org"),
+            discord=DiscordConfig(
+                guild_id="123",
+                token="xyz",
+                command_permissions={
+                    "pr-status": SlashCommandPermissionRule(role_names=["Mentor", "Maintainer"])
+                },
+            ),
+        )
+
+        # 1. Contributor without Mentor role
+        member_contributor = MagicMock()
+        role_contrib = MagicMock()
+        role_contrib.name = "Contributor"
+        role_contrib.id = 111
+        member_contributor.roles = [role_contrib]
+        member_contributor.guild_permissions = MagicMock(administrator=False)
+        interaction_contrib = MagicMock()
+        interaction_contrib.user = member_contributor
+
+        perms = getattr(config.discord, "command_permissions", None)
+        allowed_contrib = (
+            slash_command_allowed(interaction_contrib, config, "pr-status")
+            if perms and "pr-status" in perms
+            else hasattr(interaction_contrib.user, "roles")
+        )
+        assert allowed_contrib is False
+
+        # 2. Mentor with Mentor role
+        member_mentor = MagicMock()
+        role_mentor = MagicMock()
+        role_mentor.name = "Mentor"
+        role_mentor.id = 222
+        member_mentor.roles = [role_mentor]
+        member_mentor.guild_permissions = MagicMock(administrator=False)
+        interaction_mentor = MagicMock()
+        interaction_mentor.user = member_mentor
+
+        allowed_mentor = (
+            slash_command_allowed(interaction_mentor, config, "pr-status")
+            if perms and "pr-status" in perms
+            else hasattr(interaction_mentor.user, "roles")
+        )
+        assert allowed_mentor is True
+
 

--- a/tests/test_pr_status.py
+++ b/tests/test_pr_status.py
@@ -981,60 +981,31 @@ class TestSplitMessages:
 
 
 class TestPRStatusCommandRepoFilter:
-    @pytest.mark.asyncio
-    async def test_repo_filter_allow_mode_blocks_unlisted_repo(self) -> None:
+    def test_repo_filter_allow_mode_blocks_unlisted_repo(self) -> None:
         from ghdcbot.config.models import RepoFilterConfig
+        from ghdcbot.engine.pr_status import is_repo_allowed
 
         repo_filter = RepoFilterConfig(mode="allow", names=["allowed-repo"])
-        repo_name = "secret-repo"
-        pr_number = 42
+        assert is_repo_allowed(repo_filter, "secret-repo") is False
 
-        # Simulate the filter validation logic from pr_status_cmd
-        filter_names = {name.strip() for name in repo_filter.names}
-        is_excluded = False
-        if repo_filter.mode == "allow" and repo_name not in filter_names:
-            is_excluded = True
-        elif repo_filter.mode == "deny" and repo_name in filter_names:
-            is_excluded = True
-
-        assert is_excluded is True
-        error_msg = f"❌ PR **{repo_name}#{pr_number}** not found or inaccessible."
-        assert error_msg == "❌ PR **secret-repo#42** not found or inaccessible."
-
-    @pytest.mark.asyncio
-    async def test_repo_filter_deny_mode_blocks_denied_repo(self) -> None:
+    def test_repo_filter_deny_mode_blocks_denied_repo(self) -> None:
         from ghdcbot.config.models import RepoFilterConfig
+        from ghdcbot.engine.pr_status import is_repo_allowed
 
         repo_filter = RepoFilterConfig(mode="deny", names=["denied-repo"])
-        repo_name = "denied-repo"
-        pr_number = 7
+        assert is_repo_allowed(repo_filter, "denied-repo") is False
 
-        filter_names = {name.strip() for name in repo_filter.names}
-        is_excluded = False
-        if repo_filter.mode == "allow" and repo_name not in filter_names:
-            is_excluded = True
-        elif repo_filter.mode == "deny" and repo_name in filter_names:
-            is_excluded = True
-
-        assert is_excluded is True
-        error_msg = f"❌ PR **{repo_name}#{pr_number}** not found or inaccessible."
-        assert error_msg == "❌ PR **denied-repo#7** not found or inaccessible."
-
-    @pytest.mark.asyncio
-    async def test_repo_filter_allows_valid_repo(self) -> None:
+    def test_repo_filter_allows_valid_repo(self) -> None:
         from ghdcbot.config.models import RepoFilterConfig
+        from ghdcbot.engine.pr_status import is_repo_allowed
 
         repo_filter = RepoFilterConfig(mode="allow", names=["allowed-repo"])
-        repo_name = "allowed-repo"
+        assert is_repo_allowed(repo_filter, "allowed-repo") is True
 
-        filter_names = {name.strip() for name in repo_filter.names}
-        is_excluded = False
-        if repo_filter.mode == "allow" and repo_name not in filter_names:
-            is_excluded = True
-        elif repo_filter.mode == "deny" and repo_name in filter_names:
-            is_excluded = True
+    def test_repo_filter_none_allows_all_repos(self) -> None:
+        from ghdcbot.engine.pr_status import is_repo_allowed
 
-        assert is_excluded is False
+        assert is_repo_allowed(None, "any-repo") is True
 
 
 # ===================================================================
@@ -1065,15 +1036,7 @@ class TestPRStatusCommandPermissions:
         interaction = MagicMock()
         interaction.user = member
 
-        # Simulating command_permission_check(SLASH_CMD_PR_STATUS, allow_all_by_default=True)
-        perms = getattr(config.discord, "command_permissions", None)
-        assert perms is None
-        allowed = (
-            slash_command_allowed(interaction, config, "pr-status")
-            if perms and "pr-status" in perms
-            else (hasattr(interaction.user, "roles") and hasattr(interaction.user, "guild_permissions"))
-        )
-        assert allowed is True
+        assert slash_command_allowed(interaction, config, "pr-status", allow_all_by_default=True) is True
 
     def test_pr_status_gated_when_configured_in_command_permissions(self) -> None:
         """When discord.command_permissions specifies pr-status, unauthorized members are blocked and authorized members pass."""
@@ -1113,13 +1076,12 @@ class TestPRStatusCommandPermissions:
         interaction_contrib = MagicMock()
         interaction_contrib.user = member_contributor
 
-        perms = getattr(config.discord, "command_permissions", None)
-        allowed_contrib = (
-            slash_command_allowed(interaction_contrib, config, "pr-status")
-            if perms and "pr-status" in perms
-            else hasattr(interaction_contrib.user, "roles")
+        assert (
+            slash_command_allowed(
+                interaction_contrib, config, "pr-status", allow_all_by_default=True
+            )
+            is False
         )
-        assert allowed_contrib is False
 
         # 2. Mentor with Mentor role
         member_mentor = MagicMock()
@@ -1131,11 +1093,11 @@ class TestPRStatusCommandPermissions:
         interaction_mentor = MagicMock()
         interaction_mentor.user = member_mentor
 
-        allowed_mentor = (
-            slash_command_allowed(interaction_mentor, config, "pr-status")
-            if perms and "pr-status" in perms
-            else hasattr(interaction_mentor.user, "roles")
+        assert (
+            slash_command_allowed(
+                interaction_mentor, config, "pr-status", allow_all_by_default=True
+            )
+            is True
         )
-        assert allowed_mentor is True
 
 

--- a/tests/test_pr_status.py
+++ b/tests/test_pr_status.py
@@ -534,7 +534,8 @@ class TestFormatSinglePRStatus:
     def test_draft_format(self) -> None:
         h = _make_health(is_draft=True)
         result = format_single_pr_status(h, "org")
-        assert "Draft" in result
+        assert "**Draft:** Yes" in result
+        assert "⬜ Draft" in result
 
     def test_coderabbit_singular(self) -> None:
         """Single CodeRabbit comment uses singular form."""

--- a/tests/test_pr_status.py
+++ b/tests/test_pr_status.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -17,7 +18,6 @@ from ghdcbot.engine.pr_status import (
     format_all_pr_status,
     format_single_pr_status,
 )
-
 
 # ---------------------------------------------------------------------------
 # Fixtures / helpers
@@ -62,13 +62,14 @@ def _make_health(
     number: int = 7,
     title: str = "Test PR",
     author: str = "contributor",
+    html_url: str | None = None,
 ) -> PRHealthStatus:
     return PRHealthStatus(
         repo=repo,
         number=number,
         title=title,
         author=author,
-        html_url=f"https://github.com/org/{repo}/pull/{number}",
+        html_url=html_url or f"https://github.com/org/{repo}/pull/{number}",
         ci_status=ci_status,
         mergeable=mergeable,
         review_state=review_state,
@@ -960,6 +961,13 @@ class TestFormatSinglePRStatus:
         assert "1 suggestion pending" in result
         assert "suggestions" not in result
 
+    def test_no_github_link_embedded_box(self) -> None:
+        """Single PR status report does not contain naked html_url link or link embed box."""
+        h = _make_health(html_url="https://github.com/org/my-repo/pull/7")
+        result = format_single_pr_status(h, "org")
+        assert "https://github.com" not in result
+        assert "🔗" not in result
+
 
 # ===================================================================
 # Format: all PRs
@@ -1190,5 +1198,813 @@ class TestPRStatusCommandPermissions:
             )
             is True
         )
+
+
+# ===================================================================
+# repo box recommendation and autocomplete tests
+# ===================================================================
+
+
+class TestRepoRecommendationAndAutocomplete:
+    def test_get_configured_repo_names_allow_mode(self) -> None:
+        """Configured repos with mode='allow' are returned in order."""
+        from ghdcbot.config.models import (
+            BotConfig,
+            DiscordConfig,
+            GitHubConfig,
+            RepoFilterConfig,
+            RuntimeConfig,
+        )
+        from ghdcbot.engine.pr_status import get_configured_repo_names
+
+        config = BotConfig(
+            runtime=RuntimeConfig(
+                data_dir="/tmp/test",
+                github_adapter="ghdcbot.adapters.github.rest:GitHubRestAdapter",
+                discord_adapter="ghdcbot.adapters.discord.api:DiscordApiAdapter",
+                storage_adapter="ghdcbot.adapters.storage.sqlite:SqliteStorage",
+            ),
+            github=GitHubConfig(
+                org="test-org",
+                repos=RepoFilterConfig(mode="allow", names=["Knowledge-Agent", "Devr.AI"]),
+            ),
+            discord=DiscordConfig(guild_id="123", token="xyz"),
+        )
+        assert get_configured_repo_names(config) == ["Knowledge-Agent", "Devr.AI"]
+
+    def test_get_configured_repo_names_deny_mode_excludes_denied(self) -> None:
+        """When repos.mode='deny', denied repos are not suggested."""
+        from ghdcbot.config.models import (
+            BotConfig,
+            DiscordConfig,
+            GitHubConfig,
+            RepoFilterConfig,
+            RuntimeConfig,
+        )
+        from ghdcbot.engine.pr_status import get_configured_repo_names
+
+        config = BotConfig(
+            runtime=RuntimeConfig(
+                data_dir="/tmp/test",
+                github_adapter="ghdcbot.adapters.github.rest:GitHubRestAdapter",
+                discord_adapter="ghdcbot.adapters.discord.api:DiscordApiAdapter",
+                storage_adapter="ghdcbot.adapters.storage.sqlite:SqliteStorage",
+            ),
+            github=GitHubConfig(
+                org="test-org",
+                repos=RepoFilterConfig(mode="deny", names=["denied-repo"]),
+            ),
+            discord=DiscordConfig(guild_id="123", token="xyz"),
+        )
+        assert get_configured_repo_names(config) == []
+
+    def test_get_configured_repo_names_from_channels_and_roles(self) -> None:
+        """Repos configured in discord.pr_open_channels and repo_contributor_roles are included."""
+        from ghdcbot.config.models import (
+            BotConfig,
+            DiscordConfig,
+            GitHubConfig,
+            RepoFilterConfig,
+            RuntimeConfig,
+        )
+        from ghdcbot.engine.pr_status import get_configured_repo_names
+
+        config = BotConfig(
+            runtime=RuntimeConfig(
+                data_dir="/tmp/test",
+                github_adapter="ghdcbot.adapters.github.rest:GitHubRestAdapter",
+                discord_adapter="ghdcbot.adapters.discord.api:DiscordApiAdapter",
+                storage_adapter="ghdcbot.adapters.storage.sqlite:SqliteStorage",
+            ),
+            github=GitHubConfig(
+                org="test-org",
+                repos=RepoFilterConfig(mode="allow", names=["Repo-A"]),
+            ),
+            discord=DiscordConfig(
+                guild_id="123",
+                token="xyz",
+                pr_open_channels={"Repo-B": "111", "repo-a": "222"},
+            ),
+            repo_contributor_roles={"Repo-C": "Contributor-Role"},
+        )
+        repos = get_configured_repo_names(config)
+        assert repos == ["Repo-A", "Repo-B", "Repo-C"]
+
+    def test_get_configured_repo_names_case_insensitive_dedup(self) -> None:
+        """Duplicate repo names across sources are deduplicated case-insensitively."""
+        from ghdcbot.config.models import (
+            BotConfig,
+            DiscordConfig,
+            GitHubConfig,
+            RepoFilterConfig,
+            RuntimeConfig,
+        )
+        from ghdcbot.engine.pr_status import get_configured_repo_names
+
+        config = BotConfig(
+            runtime=RuntimeConfig(
+                data_dir="/tmp/test",
+                github_adapter="ghdcbot.adapters.github.rest:GitHubRestAdapter",
+                discord_adapter="ghdcbot.adapters.discord.api:DiscordApiAdapter",
+                storage_adapter="ghdcbot.adapters.storage.sqlite:SqliteStorage",
+            ),
+            github=GitHubConfig(
+                org="test-org",
+                repos=RepoFilterConfig(mode="allow", names=["Knowledge-Agent", "knowledge-agent"]),
+            ),
+            discord=DiscordConfig(
+                guild_id="123",
+                token="xyz",
+                pr_open_channels={"KNOWLEDGE-AGENT": "999"},
+            ),
+        )
+        assert get_configured_repo_names(config) == ["Knowledge-Agent"]
+
+    def test_get_configured_repo_names_none_or_empty(self) -> None:
+        """Returns empty list when config is None or empty dict."""
+        from ghdcbot.engine.pr_status import get_configured_repo_names
+
+        assert get_configured_repo_names(None) == []
+        assert get_configured_repo_names({}) == []
+
+    def test_filter_repo_suggestions_prefix_then_substring(self) -> None:
+        """Filter prioritizes prefix matches over substring matches."""
+        from ghdcbot.engine.pr_status import filter_repo_suggestions
+
+        repos = ["Knowledge-Agent", "Agent-Smith", "Devr.AI", "PictoPy", "Gitcord"]
+        # Empty string returns all
+        assert filter_repo_suggestions(repos, "") == repos
+
+        # "Agent" matches Agent-Smith (prefix) first, then Knowledge-Agent (substring)
+        matches = filter_repo_suggestions(repos, "agent")
+        assert matches == ["Agent-Smith", "Knowledge-Agent"]
+
+    def test_filter_repo_suggestions_capped_at_25(self) -> None:
+        """Filter returns at most 25 choices (Discord interaction limit)."""
+        from ghdcbot.engine.pr_status import filter_repo_suggestions
+
+        long_list = [f"repo-{i:02d}" for i in range(35)]
+        capped = filter_repo_suggestions(long_list, "")
+        assert len(capped) == 25
+        assert capped[0] == "repo-00"
+        assert capped[24] == "repo-24"
+
+    @pytest.mark.asyncio
+    async def test_repo_autocomplete_choice_creation(self) -> None:
+        """Filtered suggestions map cleanly to discord app_commands Choice objects."""
+        from discord import app_commands
+
+        from ghdcbot.engine.pr_status import filter_repo_suggestions
+
+        repos = ["Knowledge-Agent", "Gitcord-Bot"]
+        suggestions = filter_repo_suggestions(repos, "know")
+        choices = [app_commands.Choice(name=r, value=r) for r in suggestions]
+        assert len(choices) == 1
+        assert choices[0].name == "Knowledge-Agent"
+        assert choices[0].value == "Knowledge-Agent"
+
+    @pytest.mark.asyncio
+    async def test_pr_status_repo_autocomplete_integration(self) -> None:
+        """In run_bot, pr-status repo param has autocomplete connected to config."""
+        from unittest.mock import MagicMock, patch
+
+        import discord
+
+        from ghdcbot.bot import run_bot
+        from ghdcbot.config.models import (
+            BotConfig,
+            DiscordConfig,
+            GitHubConfig,
+            RepoFilterConfig,
+            RuntimeConfig,
+        )
+
+        cfg = BotConfig(
+            runtime=RuntimeConfig(
+                data_dir="./data",
+                github_adapter="ghdcbot.adapters.github.rest:GitHubRestAdapter",
+                discord_adapter="ghdcbot.adapters.discord.api:DiscordApiAdapter",
+                storage_adapter="ghdcbot.adapters.storage.sqlite:SqliteStorage",
+            ),
+            github=GitHubConfig(
+                org="test-org",
+                repos=RepoFilterConfig(mode="allow", names=["Knowledge-Agent", "Devr.AI"]),
+            ),
+            discord=DiscordConfig(guild_id="123", token="fake"),
+        )
+
+        captured = []
+        orig_tree_init = discord.app_commands.CommandTree.__init__
+
+        def mock_tree_init(tree_self: Any, client: Any) -> None:
+            captured.append(tree_self)
+            orig_tree_init(tree_self, client)
+
+        with (
+            patch("ghdcbot.bot.load_config", return_value=cfg),
+            patch("ghdcbot.bot.resolve_github_token", return_value="fake"),
+            patch("ghdcbot.bot.build_adapter"),
+            patch("ghdcbot.bot.GitHubIdentityReader"),
+            patch("ghdcbot.bot.IdentityLinkService"),
+            patch("ghdcbot.bot.SocialProfileService"),
+            patch("discord.app_commands.CommandTree.__init__", mock_tree_init),
+            patch("discord.Client.run", side_effect=SystemExit(0)),
+        ):
+            try:
+                run_bot("dummy.yaml")
+            except SystemExit:
+                pass
+
+        assert len(captured) == 1
+        tree = captured[0]
+        pr_status_cmds = [
+            cmd
+            for cmd in tree.get_commands(guild=discord.Object(id=123))
+            if cmd.name == "pr-status"
+        ]
+        assert len(pr_status_cmds) == 1
+        pr_status = pr_status_cmds[0]
+
+        # Verify repo parameter has autocomplete registered
+        repo_params = [p for p in pr_status.parameters if p.name == "repo"]
+        assert len(repo_params) == 1
+        assert repo_params[0].autocomplete is True
+
+        # Call the autocomplete callback and verify it returns configured repos from config
+        callback = pr_status._params["repo"].autocomplete
+        mock_interaction = MagicMock()
+        choices = await callback(mock_interaction, "know")
+        assert len(choices) == 1
+        assert choices[0].name == "Knowledge-Agent"
+        assert choices[0].value == "Knowledge-Agent"
+
+    @pytest.mark.asyncio
+    async def test_pr_status_single_pr_suppress_embeds(self) -> None:
+        """pr_status_cmd sends single PR status message with suppress_embeds=True."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        import discord
+
+        from ghdcbot.bot import run_bot
+        from ghdcbot.config.models import (
+            BotConfig,
+            DiscordConfig,
+            GitHubConfig,
+            RepoFilterConfig,
+            RuntimeConfig,
+        )
+        from ghdcbot.engine.pr_status import PRHealthStatus
+
+        cfg = BotConfig(
+            runtime=RuntimeConfig(
+                data_dir="./data",
+                github_adapter="ghdcbot.adapters.github.rest:GitHubRestAdapter",
+                discord_adapter="ghdcbot.adapters.discord.api:DiscordApiAdapter",
+                storage_adapter="ghdcbot.adapters.storage.sqlite:SqliteStorage",
+            ),
+            github=GitHubConfig(
+                org="test-org",
+                repos=RepoFilterConfig(mode="allow", names=["Knowledge-Agent"]),
+            ),
+            discord=DiscordConfig(guild_id="123", token="fake"),
+        )
+
+        captured = []
+        orig_tree_init = discord.app_commands.CommandTree.__init__
+
+        def mock_tree_init(tree_self: Any, client: Any) -> None:
+            captured.append(tree_self)
+            orig_tree_init(tree_self, client)
+
+        with (
+            patch("ghdcbot.bot.load_config", return_value=cfg),
+            patch("ghdcbot.bot.resolve_github_token", return_value="fake"),
+            patch("ghdcbot.bot.build_adapter"),
+            patch("ghdcbot.bot.GitHubIdentityReader"),
+            patch("ghdcbot.bot.IdentityLinkService"),
+            patch("ghdcbot.bot.SocialProfileService"),
+            patch("discord.app_commands.CommandTree.__init__", mock_tree_init),
+            patch("discord.Client.run", side_effect=SystemExit(0)),
+        ):
+            try:
+                run_bot("dummy.yaml")
+            except SystemExit:
+                pass
+
+        pr_status = next(
+            cmd
+            for cmd in captured[0].get_commands(guild=discord.Object(id=123))
+            if cmd.name == "pr-status"
+        )
+
+        mock_interaction = MagicMock()
+        mock_interaction.response.defer = AsyncMock()
+        mock_interaction.followup.send = AsyncMock()
+
+        sample_health = PRHealthStatus(
+            repo="Knowledge-Agent",
+            number=1,
+            title="Test PR",
+            author="contributor",
+            html_url="https://github.com/org/Knowledge-Agent/pull/1",
+            ci_status="passing",
+            mergeable=True,
+            review_state="approved",
+            approved_count=1,
+            changes_requested_count=0,
+            has_coderabbit_comments=False,
+            coderabbit_comment_count=0,
+            is_draft=False,
+        )
+
+        with patch("ghdcbot.bot.fetch_pr_health", return_value=sample_health):
+            await pr_status.callback(mock_interaction, repo="Knowledge-Agent", pr_number=1)
+
+        mock_interaction.followup.send.assert_awaited_once()
+        kwargs = mock_interaction.followup.send.call_args.kwargs
+        assert kwargs.get("ephemeral") is True
+        assert kwargs.get("suppress_embeds") is True
+
+    @pytest.mark.asyncio
+    async def test_resolve_repo_for_pr_single_configured_repo(self) -> None:
+        """When 1 repo is configured, resolve_repo_for_pr returns it without extra queries."""
+        from unittest.mock import MagicMock
+
+        from ghdcbot.config.models import (
+            BotConfig,
+            DiscordConfig,
+            GitHubConfig,
+            RepoFilterConfig,
+            RuntimeConfig,
+        )
+        from ghdcbot.engine.pr_status import resolve_repo_for_pr
+
+        cfg = BotConfig(
+            runtime=RuntimeConfig(
+                data_dir="./data",
+                github_adapter="fake",
+                discord_adapter="fake",
+                storage_adapter="fake",
+            ),
+            github=GitHubConfig(
+                org="test-org",
+                repos=RepoFilterConfig(mode="allow", names=["Knowledge-Agent"]),
+            ),
+            discord=DiscordConfig(guild_id="123", token="fake"),
+        )
+        mock_adapter = MagicMock()
+        repo, err = await resolve_repo_for_pr(cfg, mock_adapter, 42, repo=None)
+        assert err is None
+        assert repo == "Knowledge-Agent"
+        mock_adapter.get_pull_request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_resolve_repo_for_pr_multiple_repos_single_match(self) -> None:
+        """When multiple repos are configured, scans candidates and resolves the matching repo."""
+        from unittest.mock import MagicMock
+
+        from ghdcbot.config.models import (
+            BotConfig,
+            DiscordConfig,
+            GitHubConfig,
+            RepoFilterConfig,
+            RuntimeConfig,
+        )
+        from ghdcbot.engine.pr_status import resolve_repo_for_pr
+
+        cfg = BotConfig(
+            runtime=RuntimeConfig(
+                data_dir="./data",
+                github_adapter="fake",
+                discord_adapter="fake",
+                storage_adapter="fake",
+            ),
+            github=GitHubConfig(
+                org="test-org",
+                repos=RepoFilterConfig(mode="allow", names=["Repo-A", "Repo-B"]),
+            ),
+            discord=DiscordConfig(guild_id="123", token="fake"),
+        )
+        mock_adapter = MagicMock()
+        # Repo-A returns None, Repo-B returns PR dict
+        def fake_get_pr(org: str, repo: str, num: int):
+            if repo == "Repo-B":
+                return {"number": num}
+            return None
+
+        mock_adapter.get_pull_request.side_effect = fake_get_pr
+        repo, err = await resolve_repo_for_pr(cfg, mock_adapter, 7, repo=None)
+        assert err is None
+        assert repo == "Repo-B"
+
+    @pytest.mark.asyncio
+    async def test_resolve_repo_for_pr_multiple_repos_ambiguous(self) -> None:
+        """When PR exists in multiple repos, returns informative disambiguation error."""
+        from unittest.mock import MagicMock
+
+        from ghdcbot.config.models import (
+            BotConfig,
+            DiscordConfig,
+            GitHubConfig,
+            RepoFilterConfig,
+            RuntimeConfig,
+        )
+        from ghdcbot.engine.pr_status import resolve_repo_for_pr
+
+        cfg = BotConfig(
+            runtime=RuntimeConfig(
+                data_dir="./data",
+                github_adapter="fake",
+                discord_adapter="fake",
+                storage_adapter="fake",
+            ),
+            github=GitHubConfig(
+                org="test-org",
+                repos=RepoFilterConfig(mode="allow", names=["Repo-A", "Repo-B"]),
+            ),
+            discord=DiscordConfig(guild_id="123", token="fake"),
+        )
+        mock_adapter = MagicMock()
+        mock_adapter.get_pull_request.return_value = {"number": 10}
+
+        repo, err = await resolve_repo_for_pr(cfg, mock_adapter, 10, repo=None)
+        assert repo is None
+        assert err is not None
+        assert "Found PR **#10** in multiple configured repositories" in err
+        assert "`Repo-A`" in err
+        assert "`Repo-B`" in err
+
+    @pytest.mark.asyncio
+    async def test_resolve_repo_for_pr_multiple_repos_not_found(self) -> None:
+        """When PR is not found in any configured repo, returns not found message."""
+        from unittest.mock import MagicMock
+
+        from ghdcbot.config.models import (
+            BotConfig,
+            DiscordConfig,
+            GitHubConfig,
+            RepoFilterConfig,
+            RuntimeConfig,
+        )
+        from ghdcbot.engine.pr_status import resolve_repo_for_pr
+
+        cfg = BotConfig(
+            runtime=RuntimeConfig(
+                data_dir="./data",
+                github_adapter="fake",
+                discord_adapter="fake",
+                storage_adapter="fake",
+            ),
+            github=GitHubConfig(
+                org="test-org",
+                repos=RepoFilterConfig(mode="allow", names=["Repo-A", "Repo-B"]),
+            ),
+            discord=DiscordConfig(guild_id="123", token="fake"),
+        )
+        mock_adapter = MagicMock()
+        mock_adapter.get_pull_request.return_value = None
+
+        repo, err = await resolve_repo_for_pr(cfg, mock_adapter, 999, repo=None)
+        assert repo is None
+        assert err is not None
+        assert "PR **#999** not found in configured repositories" in err
+
+    @pytest.mark.asyncio
+    async def test_resolve_repo_for_pr_empty_configured_repos(self) -> None:
+        """When no repos are configured, asks user to specify repo."""
+        from unittest.mock import MagicMock
+
+        from ghdcbot.config.models import BotConfig, DiscordConfig, GitHubConfig, RuntimeConfig
+        from ghdcbot.engine.pr_status import resolve_repo_for_pr
+
+        cfg = BotConfig(
+            runtime=RuntimeConfig(
+                data_dir="./data",
+                github_adapter="fake",
+                discord_adapter="fake",
+                storage_adapter="fake",
+            ),
+            github=GitHubConfig(org="test-org"),
+            discord=DiscordConfig(guild_id="123", token="fake"),
+        )
+        mock_adapter = MagicMock()
+        repo, err = await resolve_repo_for_pr(cfg, mock_adapter, 1, repo=None)
+        assert repo is None
+        assert "Please specify `repo`" in (err or "")
+
+    @pytest.mark.asyncio
+    async def test_resolve_repo_for_pr_explicit_disallowed_repo(self) -> None:
+        """Explicit repo not matching allowlist is rejected."""
+        from unittest.mock import MagicMock
+
+        from ghdcbot.config.models import (
+            BotConfig,
+            DiscordConfig,
+            GitHubConfig,
+            RepoFilterConfig,
+            RuntimeConfig,
+        )
+        from ghdcbot.engine.pr_status import resolve_repo_for_pr
+
+        cfg = BotConfig(
+            runtime=RuntimeConfig(
+                data_dir="./data",
+                github_adapter="fake",
+                discord_adapter="fake",
+                storage_adapter="fake",
+            ),
+            github=GitHubConfig(
+                org="test-org",
+                repos=RepoFilterConfig(mode="allow", names=["Knowledge-Agent"]),
+            ),
+            discord=DiscordConfig(guild_id="123", token="fake"),
+        )
+        mock_adapter = MagicMock()
+        repo, err = await resolve_repo_for_pr(cfg, mock_adapter, 1, repo="Secret-Repo")
+        assert repo is None
+        assert "not allowed by Gitcord configuration" in (err or "")
+
+    @pytest.mark.asyncio
+    async def test_pr_status_cmd_auto_detects_repo_when_omitted(self) -> None:
+        """pr_status_cmd works end-to-end without repo argument (auto-resolves from config)."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        import discord
+
+        from ghdcbot.bot import run_bot
+        from ghdcbot.config.models import (
+            BotConfig,
+            DiscordConfig,
+            GitHubConfig,
+            RepoFilterConfig,
+            RuntimeConfig,
+        )
+        from ghdcbot.engine.pr_status import PRHealthStatus
+
+        cfg = BotConfig(
+            runtime=RuntimeConfig(
+                data_dir="./data",
+                github_adapter="ghdcbot.adapters.github.rest:GitHubRestAdapter",
+                discord_adapter="ghdcbot.adapters.discord.api:DiscordApiAdapter",
+                storage_adapter="ghdcbot.adapters.storage.sqlite:SqliteStorage",
+            ),
+            github=GitHubConfig(
+                org="test-org",
+                repos=RepoFilterConfig(mode="allow", names=["Knowledge-Agent"]),
+            ),
+            discord=DiscordConfig(guild_id="123", token="fake"),
+        )
+
+        captured = []
+        orig_tree_init = discord.app_commands.CommandTree.__init__
+
+        def mock_tree_init(tree_self: Any, client: Any) -> None:
+            captured.append(tree_self)
+            orig_tree_init(tree_self, client)
+
+        with (
+            patch("ghdcbot.bot.load_config", return_value=cfg),
+            patch("ghdcbot.bot.resolve_github_token", return_value="fake"),
+            patch("ghdcbot.bot.build_adapter"),
+            patch("ghdcbot.bot.GitHubIdentityReader"),
+            patch("ghdcbot.bot.IdentityLinkService"),
+            patch("ghdcbot.bot.SocialProfileService"),
+            patch("discord.app_commands.CommandTree.__init__", mock_tree_init),
+            patch("discord.Client.run", side_effect=SystemExit(0)),
+        ):
+            try:
+                run_bot("dummy.yaml")
+            except SystemExit:
+                pass
+
+        pr_status = next(
+            cmd
+            for cmd in captured[0].get_commands(guild=discord.Object(id=123))
+            if cmd.name == "pr-status"
+        )
+
+        mock_interaction = MagicMock()
+        mock_interaction.response.defer = AsyncMock()
+        mock_interaction.followup.send = AsyncMock()
+
+        sample_health = PRHealthStatus(
+            repo="Knowledge-Agent",
+            number=2,
+            title="Auto detected PR",
+            author="contributor",
+            html_url="https://github.com/org/Knowledge-Agent/pull/2",
+            ci_status="passing",
+            mergeable=True,
+            review_state="approved",
+            approved_count=1,
+            changes_requested_count=0,
+            has_coderabbit_comments=False,
+            coderabbit_comment_count=0,
+            is_draft=False,
+        )
+
+        # Call WITHOUT repo parameter
+        with patch("ghdcbot.bot.fetch_pr_health", return_value=sample_health) as mock_fetch:
+            await pr_status.callback(mock_interaction, repo=None, pr_number=2)
+
+        # Verify fetch_pr_health was called with auto-detected "Knowledge-Agent"
+        mock_fetch.assert_called_once()
+        assert mock_fetch.call_args[0][2] == "Knowledge-Agent"
+
+        mock_interaction.followup.send.assert_awaited_once()
+        kwargs = mock_interaction.followup.send.call_args.kwargs
+        assert kwargs.get("ephemeral") is True
+        assert kwargs.get("suppress_embeds") is True
+        msg = mock_interaction.followup.send.call_args[0][0]
+        assert "Knowledge-Agent#2" in msg
+        assert "Safe to Merge" in msg
+
+    def test_format_single_pr_status_merged_shows_only_merged(self) -> None:
+        """When PR is merged, format_single_pr_status only shows Merged and no CI/CodeRabbit."""
+        from ghdcbot.engine.pr_status import PRHealthStatus, format_single_pr_status
+
+        status = PRHealthStatus(
+            repo="Knowledge-Agent",
+            number=42,
+            title="Feature X",
+            author="prith",
+            html_url="https://github.com/org/Knowledge-Agent/pull/42",
+            ci_status="passing",
+            mergeable=True,
+            review_state="approved",
+            approved_count=1,
+            changes_requested_count=0,
+            has_coderabbit_comments=False,
+            coderabbit_comment_count=0,
+            is_draft=False,
+            state="merged",
+        )
+        msg = format_single_pr_status(status, "org")
+        assert "**Knowledge-Agent#42** — Feature X" in msg
+        assert "👤 **Author:** prith" in msg
+        assert "🟣 **Status:** Merged" in msg
+        # Ensure CI, CodeRabbit, Mergeable, Review, and Health are omitted
+        assert "CI:" not in msg
+        assert "CodeRabbit:" not in msg
+        assert "Mergeable:" not in msg
+        assert "Review:" not in msg
+        assert "Health:" not in msg
+
+    def test_format_single_pr_status_closed_shows_only_closed(self) -> None:
+        """When PR is closed, format_single_pr_status only shows Closed and no CI/CodeRabbit."""
+        from ghdcbot.engine.pr_status import PRHealthStatus, format_single_pr_status
+
+        status = PRHealthStatus(
+            repo="Knowledge-Agent",
+            number=43,
+            title="Abandoned Fix",
+            author="contributor",
+            html_url="https://github.com/org/Knowledge-Agent/pull/43",
+            ci_status="failing",
+            mergeable=False,
+            review_state="changes_requested",
+            approved_count=0,
+            changes_requested_count=1,
+            has_coderabbit_comments=True,
+            coderabbit_comment_count=3,
+            is_draft=False,
+            state="closed",
+        )
+        msg = format_single_pr_status(status, "org")
+        assert "**Knowledge-Agent#43** — Abandoned Fix" in msg
+        assert "👤 **Author:** contributor" in msg
+        assert "🔴 **Status:** Closed" in msg
+        # Ensure CI, CodeRabbit, Mergeable, Review, and Health are omitted
+        assert "CI:" not in msg
+        assert "CodeRabbit:" not in msg
+        assert "Mergeable:" not in msg
+        assert "Review:" not in msg
+        assert "Health:" not in msg
+
+    def test_fetch_pr_health_merged_skips_reviews_and_ci(self) -> None:
+        """fetch_pr_health detects merged PR and skips check-runs / reviews / threads."""
+        from unittest.mock import MagicMock
+
+        from ghdcbot.engine.pr_status import fetch_pr_health
+
+        mock_adapter = MagicMock()
+        mock_adapter.get_pull_request.return_value = {
+            "number": 15,
+            "title": "Merged PR",
+            "state": "closed",
+            "merged": True,
+            "user": {"login": "dev1"},
+            "html_url": "https://github.com/org/repo/pull/15",
+        }
+
+        health = fetch_pr_health(mock_adapter, "org", "repo", 15)
+        assert health is not None
+        assert health.state == "merged"
+        assert health.health_indicator == "merged"
+        mock_adapter.get_pull_request_check_runs.assert_not_called()
+        mock_adapter.get_pull_request_reviews.assert_not_called()
+
+    def test_fetch_pr_health_closed_skips_reviews_and_ci(self) -> None:
+        """fetch_pr_health detects closed PR and skips check-runs / reviews / threads."""
+        from unittest.mock import MagicMock
+
+        from ghdcbot.engine.pr_status import fetch_pr_health
+
+        mock_adapter = MagicMock()
+        mock_adapter.get_pull_request.return_value = {
+            "number": 16,
+            "title": "Closed PR",
+            "state": "closed",
+            "merged": False,
+            "user": {"login": "dev2"},
+            "html_url": "https://github.com/org/repo/pull/16",
+        }
+
+        health = fetch_pr_health(mock_adapter, "org", "repo", 16)
+        assert health is not None
+        assert health.state == "closed"
+        assert health.health_indicator == "closed"
+        mock_adapter.get_pull_request_check_runs.assert_not_called()
+        mock_adapter.get_pull_request_reviews.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_pr_status_cmd_informs_when_target_is_issue(self) -> None:
+        """When number points to an Issue rather than a PR, pr_status_cmd explains it clearly."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        import discord
+
+        from ghdcbot.bot import run_bot
+        from ghdcbot.config.models import (
+            BotConfig,
+            DiscordConfig,
+            GitHubConfig,
+            RepoFilterConfig,
+            RuntimeConfig,
+        )
+
+        cfg = BotConfig(
+            runtime=RuntimeConfig(
+                data_dir="./data",
+                github_adapter="ghdcbot.adapters.github.rest:GitHubRestAdapter",
+                discord_adapter="ghdcbot.adapters.discord.api:DiscordApiAdapter",
+                storage_adapter="ghdcbot.adapters.storage.sqlite:SqliteStorage",
+            ),
+            github=GitHubConfig(
+                org="test-org",
+                repos=RepoFilterConfig(mode="allow", names=["Knowledge-Agent"]),
+            ),
+            discord=DiscordConfig(guild_id="123", token="fake"),
+        )
+
+        captured = []
+        orig_tree_init = discord.app_commands.CommandTree.__init__
+
+        def mock_tree_init(tree_self: Any, client: Any) -> None:
+            captured.append(tree_self)
+            orig_tree_init(tree_self, client)
+
+        mock_github = MagicMock()
+        # get_pull_request returns None, get_issue returns an issue without 'pull_request'
+        mock_github.get_pull_request.return_value = None
+        mock_github.get_issue.return_value = {
+            "title": "Bug in context engine",
+            "state": "closed",
+        }
+
+        with (
+            patch("ghdcbot.bot.load_config", return_value=cfg),
+            patch("ghdcbot.bot.resolve_github_token", return_value="fake"),
+            patch("ghdcbot.bot.build_adapter", return_value=mock_github),
+            patch("ghdcbot.bot.GitHubIdentityReader"),
+            patch("ghdcbot.bot.IdentityLinkService"),
+            patch("ghdcbot.bot.SocialProfileService"),
+            patch("discord.app_commands.CommandTree.__init__", mock_tree_init),
+            patch("discord.Client.run", side_effect=SystemExit(0)),
+        ):
+            try:
+                run_bot("dummy.yaml")
+            except SystemExit:
+                pass
+
+        pr_status = next(
+            cmd
+            for cmd in captured[0].get_commands(guild=discord.Object(id=123))
+            if cmd.name == "pr-status"
+        )
+
+        mock_interaction = MagicMock()
+        mock_interaction.response.defer = AsyncMock()
+        mock_interaction.followup.send = AsyncMock()
+
+        await pr_status.callback(mock_interaction, repo=None, pr_number=1)
+
+        mock_interaction.followup.send.assert_awaited_once()
+        msg = mock_interaction.followup.send.call_args[0][0]
+        assert "is a GitHub **Issue**, not a Pull Request" in msg
+        assert "Bug in context engine" in msg
+        assert "Closed 🔴" in msg
+
+
 
 

--- a/tests/test_pr_status.py
+++ b/tests/test_pr_status.py
@@ -737,6 +737,97 @@ class TestReviewThreadsGraphQLAdapter:
         mock_client_slash.post.assert_called_once()
         assert mock_client_slash.post.call_args[0][0] == "https://ghe.example.com/api/graphql"
 
+    def test_review_threads_repeated_cursor_stops_pagination(self) -> None:
+        from ghdcbot.adapters.github.rest import GitHubRestAdapter
+
+        adapter = GitHubRestAdapter(token="t", org="o", api_base="https://api.github.com")
+        mock_client = MagicMock()
+
+        # Returns hasNextPage=True, but endCursor stays identical
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "reviewThreads": {
+                            "pageInfo": {"hasNextPage": True, "endCursor": "same_cursor"},
+                            "nodes": [
+                                {
+                                    "id": "t1",
+                                    "isResolved": True,
+                                    "isOutdated": False,
+                                    "comments": {"pageInfo": {"hasNextPage": False}, "nodes": []},
+                                }
+                            ],
+                        }
+                    }
+                }
+            }
+        }
+        mock_client.post.return_value = mock_resp
+        adapter._client = mock_client
+
+        threads = adapter.get_pull_request_review_threads("o", "r", 1)
+        assert threads is not None
+        assert len(threads) == 2
+        # Called once for initial request (cursor=None -> "same_cursor"), and once for second request ("same_cursor" -> "same_cursor" repeats and halts)
+        assert mock_client.post.call_count == 2
+
+    def test_thread_comments_repeated_cursor_stops_pagination(self) -> None:
+        from ghdcbot.adapters.github.rest import GitHubRestAdapter
+
+        adapter = GitHubRestAdapter(token="t", org="o", api_base="https://api.github.com")
+        mock_client = MagicMock()
+
+        threads_resp = MagicMock()
+        threads_resp.status_code = 200
+        threads_resp.json.return_value = {
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "reviewThreads": {
+                            "pageInfo": {"hasNextPage": False, "endCursor": None},
+                            "nodes": [
+                                {
+                                    "id": "t1",
+                                    "isResolved": False,
+                                    "isOutdated": False,
+                                    "comments": {
+                                        "pageInfo": {"hasNextPage": True, "endCursor": "comm_cur_1"},
+                                        "nodes": [{"author": {"login": "dev1"}}],
+                                    },
+                                }
+                            ],
+                        }
+                    }
+                }
+            }
+        }
+
+        # Comments query returns same cursor repeatedly
+        comm_resp = MagicMock()
+        comm_resp.status_code = 200
+        comm_resp.json.return_value = {
+            "data": {
+                "node": {
+                    "comments": {
+                        "pageInfo": {"hasNextPage": True, "endCursor": "comm_cur_1"},
+                        "nodes": [{"author": {"login": "dev2"}}],
+                    }
+                }
+            }
+        }
+
+        mock_client.post.side_effect = [threads_resp, comm_resp]
+        adapter._client = mock_client
+
+        threads = adapter.get_pull_request_review_threads("o", "r", 1)
+        assert threads is not None
+        assert len(threads) == 1
+        assert sorted(threads[0]["authors"]) == ["dev1", "dev2"]
+        assert mock_client.post.call_count == 2
+
 
 
 # ===================================================================

--- a/tests/test_pr_status.py
+++ b/tests/test_pr_status.py
@@ -1206,6 +1206,33 @@ class TestPRStatusCommandPermissions:
 
 
 class TestRepoRecommendationAndAutocomplete:
+    def test_cfg_get_helper_behavior(self) -> None:
+        """_cfg_get handles dicts, objects, None, missing keys, and defaults."""
+        from ghdcbot.engine.pr_status import _cfg_get
+
+        # None target returns default
+        assert _cfg_get(None, "key") is None
+        assert _cfg_get(None, "key", "default_val") == "default_val"
+
+        # Dict lookups
+        d = {"existing": "val", "nullable": None, "empty_str": ""}
+        assert _cfg_get(d, "existing") == "val"
+        assert _cfg_get(d, "missing", "fallback") == "fallback"
+        assert _cfg_get(d, "nullable", "fallback") == "fallback"
+        assert _cfg_get(d, "empty_str", "fallback") == ""
+
+        # Object attribute lookups
+        class Dummy:
+            existing = "attr_val"
+            nullable = None
+            empty_str = ""
+
+        obj = Dummy()
+        assert _cfg_get(obj, "existing") == "attr_val"
+        assert _cfg_get(obj, "missing", "fallback") == "fallback"
+        assert _cfg_get(obj, "nullable", "fallback") == "fallback"
+        assert _cfg_get(obj, "empty_str", "fallback") == ""
+
     def test_get_configured_repo_names_allow_mode(self) -> None:
         """Configured repos with mode='allow' are returned in order."""
         from ghdcbot.config.models import (
@@ -1723,6 +1750,65 @@ class TestRepoRecommendationAndAutocomplete:
         repo, err = await resolve_repo_for_pr(cfg, mock_adapter, 1, repo="Secret-Repo")
         assert repo is None
         assert "not allowed by Gitcord configuration" in (err or "")
+
+    @pytest.mark.asyncio
+    async def test_resolve_repo_for_pr_candidate_cap_and_bounded_concurrency(self) -> None:
+        """Probe caps candidates at RESOLVE_REPO_MAX_CANDIDATES and bounds concurrency."""
+        import time
+        from unittest.mock import MagicMock
+
+        from ghdcbot.config.models import (
+            BotConfig,
+            DiscordConfig,
+            GitHubConfig,
+            RepoFilterConfig,
+            RuntimeConfig,
+        )
+        from ghdcbot.engine.pr_status import (
+            RESOLVE_REPO_MAX_CANDIDATES,
+            RESOLVE_REPO_MAX_CONCURRENCY,
+            resolve_repo_for_pr,
+        )
+
+        # 35 repos configured (exceeds cap of 25)
+        repo_names = [f"Repo-{i:02d}" for i in range(35)]
+        cfg = BotConfig(
+            runtime=RuntimeConfig(
+                data_dir="./data",
+                github_adapter="fake",
+                discord_adapter="fake",
+                storage_adapter="fake",
+            ),
+            github=GitHubConfig(
+                org="test-org",
+                repos=RepoFilterConfig(mode="allow", names=repo_names),
+            ),
+            discord=DiscordConfig(guild_id="123", token="fake"),
+        )
+
+        current_concurrency = 0
+        max_seen_concurrency = 0
+
+        def fake_get_pr(org: str, repo: str, num: int):
+            nonlocal current_concurrency, max_seen_concurrency
+            current_concurrency += 1
+            if current_concurrency > max_seen_concurrency:
+                max_seen_concurrency = current_concurrency
+            time.sleep(0.01)
+            current_concurrency -= 1
+            if repo == "Repo-05":
+                return {"number": num}
+            return None
+
+        mock_adapter = MagicMock()
+        mock_adapter.get_pull_request.side_effect = fake_get_pr
+
+        repo, err = await resolve_repo_for_pr(cfg, mock_adapter, 123, repo=None)
+        assert err is None
+        assert repo == "Repo-05"
+        # Only probed candidates up to RESOLVE_REPO_MAX_CANDIDATES (25), not all 35
+        assert mock_adapter.get_pull_request.call_count == RESOLVE_REPO_MAX_CANDIDATES
+        assert max_seen_concurrency <= RESOLVE_REPO_MAX_CONCURRENCY
 
     @pytest.mark.asyncio
     async def test_pr_status_cmd_auto_detects_repo_when_omitted(self) -> None:

--- a/tests/test_pr_status.py
+++ b/tests/test_pr_status.py
@@ -416,6 +416,252 @@ class TestFetchPRHealth:
         assert health.has_coderabbit_comments is False
         assert health.coderabbit_comment_count == 0
 
+    def test_review_threads_graphql_unresolved_coderabbit_counted(self) -> None:
+        """Unresolved CodeRabbit threads are counted, while resolved/outdated/human threads are excluded, and REST fallback is not called."""
+        adapter = MagicMock()
+        adapter.get_pull_request.return_value = _make_pr_data()
+        adapter.get_pull_request_reviews.return_value = [{"state": "APPROVED"}]
+        adapter.get_pull_request_check_runs.return_value = [
+            {"status": "completed", "conclusion": "success"}
+        ]
+        adapter.get_pull_request_review_threads.return_value = [
+            {
+                "is_resolved": False,
+                "is_outdated": False,
+                "authors": ["human-dev", "coderabbitai[bot]"],
+            },
+            {
+                "is_resolved": True,
+                "is_outdated": False,
+                "authors": ["coderabbitai[bot]"],
+            },
+            {
+                "is_resolved": False,
+                "is_outdated": True,
+                "authors": ["coderabbitai[bot]"],
+            },
+            {
+                "is_resolved": False,
+                "is_outdated": False,
+                "authors": ["human-reviewer"],
+            },
+        ]
+
+        health = fetch_pr_health(adapter, "org", "my-repo", 7)
+        assert health is not None
+        assert health.has_coderabbit_comments is True
+        assert health.coderabbit_comment_count == 1
+        assert health.health_indicator == "needs_attention"
+        adapter.get_pull_request_review_threads.assert_called_once_with("org", "my-repo", 7)
+        adapter.get_pull_request_review_comments.assert_not_called()
+
+    def test_review_threads_graphql_fallback_when_threads_empty(self) -> None:
+        """When get_pull_request_review_threads returns empty, falls back to REST comments."""
+        adapter = MagicMock()
+        adapter.get_pull_request.return_value = _make_pr_data()
+        adapter.get_pull_request_reviews.return_value = [{"state": "APPROVED"}]
+        adapter.get_pull_request_check_runs.return_value = [
+            {"status": "completed", "conclusion": "success"}
+        ]
+        adapter.get_pull_request_review_threads.return_value = []
+        adapter.get_pull_request_review_comments.return_value = [
+            {"user": {"login": "coderabbitai"}, "created_at": "2025-01-01T00:00:00Z"},
+        ]
+
+        health = fetch_pr_health(adapter, "org", "my-repo", 7)
+        assert health is not None
+        assert health.has_coderabbit_comments is True
+        assert health.coderabbit_comment_count == 1
+        adapter.get_pull_request_review_threads.assert_called_once_with("org", "my-repo", 7)
+        adapter.get_pull_request_review_comments.assert_called_once_with("org", "my-repo", 7)
+
+    def test_review_threads_graphql_fallback_when_threads_raise(self) -> None:
+        """When get_pull_request_review_threads raises an exception, falls back to REST comments."""
+        adapter = MagicMock()
+        adapter.get_pull_request.return_value = _make_pr_data()
+        adapter.get_pull_request_reviews.return_value = [{"state": "APPROVED"}]
+        adapter.get_pull_request_check_runs.return_value = [
+            {"status": "completed", "conclusion": "success"}
+        ]
+        adapter.get_pull_request_review_threads.side_effect = RuntimeError("GraphQL error")
+        adapter.get_pull_request_review_comments.return_value = [
+            {"user": {"login": "coderabbitai"}, "created_at": "2025-01-01T00:00:00Z"},
+        ]
+
+        health = fetch_pr_health(adapter, "org", "my-repo", 7)
+        assert health is not None
+        assert health.has_coderabbit_comments is True
+        assert health.coderabbit_comment_count == 1
+        adapter.get_pull_request_review_threads.assert_called_once_with("org", "my-repo", 7)
+        adapter.get_pull_request_review_comments.assert_called_once_with("org", "my-repo", 7)
+
+
+# ===================================================================
+# GitHubRestAdapter review threads GraphQL pagination tests
+# ===================================================================
+
+
+class TestReviewThreadsGraphQLAdapter:
+    def test_review_threads_and_comments_pagination(self) -> None:
+        from ghdcbot.adapters.github.rest import GitHubRestAdapter
+
+        adapter = GitHubRestAdapter(token="token", org="org", api_base="https://api.github.com")
+        mock_client = MagicMock()
+
+        # Call 1: Page 1 of threads (Thread 1 has next page of comments, Thread 2 has <= 100 comments)
+        page1_response = MagicMock()
+        page1_response.status_code = 200
+        page1_response.json.return_value = {
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "reviewThreads": {
+                            "pageInfo": {"hasNextPage": True, "endCursor": "thread_cursor_1"},
+                            "nodes": [
+                                {
+                                    "id": "thread_1",
+                                    "isResolved": False,
+                                    "isOutdated": False,
+                                    "comments": {
+                                        "pageInfo": {"hasNextPage": True, "endCursor": "comm_cursor_1"},
+                                        "nodes": [{"author": {"login": "dev1"}}],
+                                    },
+                                },
+                            ],
+                        }
+                    }
+                }
+            }
+        }
+
+        # Call 2: Comments page 2 for thread_1
+        thread1_comm_response = MagicMock()
+        thread1_comm_response.status_code = 200
+        thread1_comm_response.json.return_value = {
+            "data": {
+                "node": {
+                    "comments": {
+                        "pageInfo": {"hasNextPage": False, "endCursor": None},
+                        "nodes": [{"author": {"login": "coderabbitai[bot]"}}],
+                    }
+                }
+            }
+        }
+
+        # Call 3: Page 2 of threads
+        page2_response = MagicMock()
+        page2_response.status_code = 200
+        page2_response.json.return_value = {
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "reviewThreads": {
+                            "pageInfo": {"hasNextPage": False, "endCursor": "thread_cursor_2"},
+                            "nodes": [
+                                {
+                                    "id": "thread_2",
+                                    "isResolved": True,
+                                    "isOutdated": False,
+                                    "comments": {
+                                        "pageInfo": {"hasNextPage": False, "endCursor": None},
+                                        "nodes": [{"author": {"login": "coderabbitai"}}],
+                                    },
+                                },
+                            ],
+                        }
+                    }
+                }
+            }
+        }
+
+        mock_client.post.side_effect = [page1_response, thread1_comm_response, page2_response]
+        adapter._client = mock_client
+
+        threads = adapter.get_pull_request_review_threads("org", "repo", 42)
+        assert len(threads) == 2
+        assert threads[0] == {
+            "is_resolved": False,
+            "is_outdated": False,
+            "authors": ["dev1", "coderabbitai[bot]"],
+        }
+        assert threads[1] == {
+            "is_resolved": True,
+            "is_outdated": False,
+            "authors": ["coderabbitai"],
+        }
+        assert mock_client.post.call_count == 3
+
+    def test_review_threads_error_handling(self) -> None:
+        from ghdcbot.adapters.github.rest import GitHubRestAdapter
+
+        adapter = GitHubRestAdapter(token="token", org="org", api_base="https://api.github.com")
+        mock_client = MagicMock()
+        mock_client.post.side_effect = RuntimeError("Network failure")
+        adapter._client = mock_client
+
+        threads = adapter.get_pull_request_review_threads("org", "repo", 42)
+        assert threads == []
+
+    def test_review_threads_non_200_response(self) -> None:
+        from ghdcbot.adapters.github.rest import GitHubRestAdapter
+
+        adapter = GitHubRestAdapter(token="token", org="org", api_base="https://api.github.com")
+        mock_client = MagicMock()
+        mock_resp = MagicMock()
+        mock_resp.status_code = 403
+        mock_client.post.return_value = mock_resp
+        adapter._client = mock_client
+
+        threads = adapter.get_pull_request_review_threads("org", "repo", 42)
+        assert threads == []
+
+    def test_review_threads_empty_or_malformed_data(self) -> None:
+        from ghdcbot.adapters.github.rest import GitHubRestAdapter
+
+        adapter = GitHubRestAdapter(token="token", org="org", api_base="https://api.github.com")
+        mock_client = MagicMock()
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"data": None}
+        mock_client.post.return_value = mock_resp
+        adapter._client = mock_client
+
+        threads = adapter.get_pull_request_review_threads("org", "repo", 42)
+        assert threads == []
+
+    def test_graphql_endpoint_enterprise_and_public(self) -> None:
+        from ghdcbot.adapters.github.rest import GitHubRestAdapter
+
+        # Public GitHub
+        adapter_public = GitHubRestAdapter(token="t", org="o", api_base="https://api.github.com")
+        assert adapter_public._api_base == "https://api.github.com"
+        mock_client_pub = MagicMock()
+        mock_client_pub.post.return_value.status_code = 500
+        adapter_public._client = mock_client_pub
+        adapter_public.get_pull_request_review_threads("o", "r", 1)
+        mock_client_pub.post.assert_called_once()
+        assert mock_client_pub.post.call_args[0][0] == "https://api.github.com/graphql"
+
+        # Enterprise GitHub with /api/v3
+        adapter_ghe = GitHubRestAdapter(token="t", org="o", api_base="https://ghe.example.com/api/v3")
+        assert adapter_ghe._api_base == "https://ghe.example.com/api/v3"
+        mock_client_ghe = MagicMock()
+        mock_client_ghe.post.return_value.status_code = 500
+        adapter_ghe._client = mock_client_ghe
+        adapter_ghe.get_pull_request_review_threads("o", "r", 1)
+        mock_client_ghe.post.assert_called_once()
+        assert mock_client_ghe.post.call_args[0][0] == "https://ghe.example.com/api/graphql"
+
+        # Enterprise GitHub with trailing slash
+        adapter_ghe_slash = GitHubRestAdapter(token="t", org="o", api_base="https://ghe.example.com/api/v3/")
+        mock_client_slash = MagicMock()
+        mock_client_slash.post.return_value.status_code = 500
+        adapter_ghe_slash._client = mock_client_slash
+        adapter_ghe_slash.get_pull_request_review_threads("o", "r", 1)
+        mock_client_slash.post.assert_called_once()
+        assert mock_client_slash.post.call_args[0][0] == "https://ghe.example.com/api/graphql"
+
+
 
 # ===================================================================
 # fetch_all_open_pr_health
@@ -651,3 +897,66 @@ class TestSplitMessages:
         msgs = _split_messages("Header", ["line1"], ["footer"], max_length=2000)
         assert len(msgs) == 1
         assert "footer" in msgs[0]
+
+
+# ===================================================================
+# pr_status_cmd repo filter validation tests
+# ===================================================================
+
+
+class TestPRStatusCommandRepoFilter:
+    @pytest.mark.asyncio
+    async def test_repo_filter_allow_mode_blocks_unlisted_repo(self) -> None:
+        from ghdcbot.config.models import RepoFilterConfig
+
+        repo_filter = RepoFilterConfig(mode="allow", names=["allowed-repo"])
+        repo_name = "secret-repo"
+        pr_number = 42
+
+        # Simulate the filter validation logic from pr_status_cmd
+        filter_names = {name.strip() for name in repo_filter.names}
+        is_excluded = False
+        if repo_filter.mode == "allow" and repo_name not in filter_names:
+            is_excluded = True
+        elif repo_filter.mode == "deny" and repo_name in filter_names:
+            is_excluded = True
+
+        assert is_excluded is True
+        error_msg = f"❌ PR **{repo_name}#{pr_number}** not found or inaccessible."
+        assert error_msg == "❌ PR **secret-repo#42** not found or inaccessible."
+
+    @pytest.mark.asyncio
+    async def test_repo_filter_deny_mode_blocks_denied_repo(self) -> None:
+        from ghdcbot.config.models import RepoFilterConfig
+
+        repo_filter = RepoFilterConfig(mode="deny", names=["denied-repo"])
+        repo_name = "denied-repo"
+        pr_number = 7
+
+        filter_names = {name.strip() for name in repo_filter.names}
+        is_excluded = False
+        if repo_filter.mode == "allow" and repo_name not in filter_names:
+            is_excluded = True
+        elif repo_filter.mode == "deny" and repo_name in filter_names:
+            is_excluded = True
+
+        assert is_excluded is True
+        error_msg = f"❌ PR **{repo_name}#{pr_number}** not found or inaccessible."
+        assert error_msg == "❌ PR **denied-repo#7** not found or inaccessible."
+
+    @pytest.mark.asyncio
+    async def test_repo_filter_allows_valid_repo(self) -> None:
+        from ghdcbot.config.models import RepoFilterConfig
+
+        repo_filter = RepoFilterConfig(mode="allow", names=["allowed-repo"])
+        repo_name = "allowed-repo"
+
+        filter_names = {name.strip() for name in repo_filter.names}
+        is_excluded = False
+        if repo_filter.mode == "allow" and repo_name not in filter_names:
+            is_excluded = True
+        elif repo_filter.mode == "deny" and repo_name in filter_names:
+            is_excluded = True
+
+        assert is_excluded is False
+

--- a/tests/test_pr_status.py
+++ b/tests/test_pr_status.py
@@ -1,0 +1,652 @@
+"""Tests for PR health status dashboard feature."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from unittest.mock import MagicMock
+
+import pytest
+
+from ghdcbot.engine.pr_status import (
+    PR_STATUS_MAX_PRS,
+    PRHealthStatus,
+    _compute_ci_status,
+    _is_coderabbit_bot,
+    _split_messages,
+    _truncate,
+    fetch_all_open_pr_health,
+    fetch_pr_health,
+    format_all_pr_status,
+    format_single_pr_status,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+def _make_pr_data(
+    *,
+    title: str = "Test PR",
+    state: str = "open",
+    draft: bool = False,
+    mergeable: bool | None = True,
+    author: str = "contributor",
+    number: int = 7,
+    repo: str = "my-repo",
+    head_sha: str = "abc123",
+) -> dict:
+    return {
+        "title": title,
+        "state": state,
+        "draft": draft,
+        "mergeable": mergeable,
+        "user": {"login": author},
+        "assignees": [],
+        "requested_reviewers": [],
+        "created_at": "2025-01-01T00:00:00Z",
+        "html_url": f"https://github.com/org/{repo}/pull/{number}",
+        "head": {"sha": head_sha},
+    }
+
+
+def _make_health(
+    *,
+    ci_status: str = "passing",
+    mergeable: bool | None = True,
+    review_state: str = "approved",
+    approved_count: int = 1,
+    changes_requested_count: int = 0,
+    has_coderabbit_comments: bool = False,
+    coderabbit_comment_count: int = 0,
+    is_draft: bool = False,
+    repo: str = "my-repo",
+    number: int = 7,
+    title: str = "Test PR",
+    author: str = "contributor",
+) -> PRHealthStatus:
+    return PRHealthStatus(
+        repo=repo,
+        number=number,
+        title=title,
+        author=author,
+        html_url=f"https://github.com/org/{repo}/pull/{number}",
+        ci_status=ci_status,
+        mergeable=mergeable,
+        review_state=review_state,
+        approved_count=approved_count,
+        changes_requested_count=changes_requested_count,
+        has_coderabbit_comments=has_coderabbit_comments,
+        coderabbit_comment_count=coderabbit_comment_count,
+        is_draft=is_draft,
+    )
+
+
+# ===================================================================
+# Health indicator logic
+# ===================================================================
+
+
+class TestHealthIndicator:
+    def test_safe_to_merge(self) -> None:
+        """Approved + CI passing + mergeable + no CodeRabbit = safe."""
+        h = _make_health(
+            ci_status="passing",
+            mergeable=True,
+            review_state="approved",
+            has_coderabbit_comments=False,
+        )
+        assert h.health_indicator == "safe_to_merge"
+
+    def test_safe_to_merge_ci_unknown(self) -> None:
+        """Approved + CI unknown + mergeable = still safe."""
+        h = _make_health(ci_status="unknown", mergeable=True, review_state="approved")
+        assert h.health_indicator == "safe_to_merge"
+
+    def test_blocked_ci_failing(self) -> None:
+        """CI failing → blocked."""
+        h = _make_health(ci_status="failing")
+        assert h.health_indicator == "blocked"
+
+    def test_blocked_merge_conflict(self) -> None:
+        """mergeable=False → blocked."""
+        h = _make_health(mergeable=False)
+        assert h.health_indicator == "blocked"
+
+    def test_blocked_changes_requested(self) -> None:
+        """Changes requested → blocked."""
+        h = _make_health(
+            review_state="changes_requested",
+            changes_requested_count=1,
+        )
+        assert h.health_indicator == "blocked"
+
+    def test_needs_attention_coderabbit(self) -> None:
+        """Approved but has CodeRabbit comments → needs attention."""
+        h = _make_health(
+            review_state="approved",
+            has_coderabbit_comments=True,
+            coderabbit_comment_count=3,
+        )
+        assert h.health_indicator == "needs_attention"
+
+    def test_needs_attention_awaiting_review(self) -> None:
+        """No reviews → awaiting review → needs attention."""
+        h = _make_health(
+            review_state="awaiting_review",
+            approved_count=0,
+        )
+        assert h.health_indicator == "needs_attention"
+
+    def test_needs_attention_ci_pending(self) -> None:
+        """CI pending → needs attention (not blocked)."""
+        h = _make_health(ci_status="pending", review_state="approved")
+        assert h.health_indicator == "needs_attention"
+
+    def test_draft(self) -> None:
+        """Draft PR → draft indicator."""
+        h = _make_health(is_draft=True)
+        assert h.health_indicator == "draft"
+
+    def test_draft_overrides_blocking(self) -> None:
+        """Draft takes precedence over CI failure."""
+        h = _make_health(is_draft=True, ci_status="failing")
+        assert h.health_indicator == "draft"
+
+
+# ===================================================================
+# CI status computation
+# ===================================================================
+
+
+class TestComputeCIStatus:
+    def test_empty_check_runs(self) -> None:
+        assert _compute_ci_status([]) == "unknown"
+
+    def test_failure(self) -> None:
+        runs = [{"status": "completed", "conclusion": "failure"}]
+        assert _compute_ci_status(runs) == "failing"
+
+    def test_success(self) -> None:
+        runs = [{"status": "completed", "conclusion": "success"}]
+        assert _compute_ci_status(runs) == "passing"
+
+    def test_pending(self) -> None:
+        runs = [{"status": "in_progress", "conclusion": None}]
+        assert _compute_ci_status(runs) == "pending"
+
+    def test_queued(self) -> None:
+        runs = [{"status": "queued", "conclusion": None}]
+        assert _compute_ci_status(runs) == "pending"
+
+    def test_mixed_failure_wins(self) -> None:
+        runs = [
+            {"status": "completed", "conclusion": "success"},
+            {"status": "completed", "conclusion": "failure"},
+        ]
+        assert _compute_ci_status(runs) == "failing"
+
+
+# ===================================================================
+# CodeRabbit detection
+# ===================================================================
+
+
+class TestCodeRabbitDetection:
+    def test_matches_coderabbitai(self) -> None:
+        comment = {"user": {"login": "coderabbitai"}}
+        assert _is_coderabbit_bot(comment, ["coderabbitai"]) is True
+
+    def test_matches_coderabbitai_bot(self) -> None:
+        comment = {"user": {"login": "coderabbitai[bot]"}}
+        assert _is_coderabbit_bot(comment, ["coderabbitai[bot]"]) is True
+
+    def test_case_insensitive(self) -> None:
+        comment = {"user": {"login": "CodeRabbitAI"}}
+        assert _is_coderabbit_bot(comment, ["coderabbitai"]) is True
+
+    def test_non_matching_user(self) -> None:
+        comment = {"user": {"login": "contributor123"}}
+        assert _is_coderabbit_bot(comment, ["coderabbitai"]) is False
+
+    def test_missing_user(self) -> None:
+        comment = {}
+        assert _is_coderabbit_bot(comment, ["coderabbitai"]) is False
+
+    def test_empty_login(self) -> None:
+        comment = {"user": {"login": ""}}
+        assert _is_coderabbit_bot(comment, ["coderabbitai"]) is False
+
+    def test_active_comment_on_head(self) -> None:
+        from ghdcbot.engine.pr_status import _is_active_coderabbit_comment
+        comment = {
+            "user": {"login": "coderabbitai[bot]"},
+            "position": 5,
+            "original_position": 5,
+            "commit_id": "abc123",
+            "body": "Consider refactoring this.",
+        }
+        assert _is_active_coderabbit_comment(comment, ["coderabbitai[bot]"], head_sha="abc123") is True
+
+    def test_outdated_diff_not_active(self) -> None:
+        from ghdcbot.engine.pr_status import _is_active_coderabbit_comment
+        comment = {
+            "user": {"login": "coderabbitai[bot]"},
+            "position": None,  # Outdated diff on GitHub
+            "original_position": 5,
+            "commit_id": "abc123",
+            "body": "Consider refactoring this.",
+        }
+        assert _is_active_coderabbit_comment(comment, ["coderabbitai[bot]"], head_sha="abc123") is False
+
+    def test_superseded_commit_not_active(self) -> None:
+        from ghdcbot.engine.pr_status import _is_active_coderabbit_comment
+        comment = {
+            "user": {"login": "coderabbitai[bot]"},
+            "position": 5,
+            "commit_id": "old_sha",
+            "body": "Consider refactoring this.",
+        }
+        assert _is_active_coderabbit_comment(comment, ["coderabbitai[bot]"], head_sha="new_head_sha") is False
+
+    def test_resolved_checkbox_not_active(self) -> None:
+        from ghdcbot.engine.pr_status import _is_active_coderabbit_comment
+        comment = {
+            "user": {"login": "coderabbitai[bot]"},
+            "position": 5,
+            "commit_id": "abc123",
+            "body": "- [x] Resolved this change",
+        }
+        assert _is_active_coderabbit_comment(comment, ["coderabbitai[bot]"], head_sha="abc123") is False
+
+
+# ===================================================================
+# fetch_pr_health
+# ===================================================================
+
+
+class TestFetchPRHealth:
+    def test_success(self) -> None:
+        """Happy path: fetch health for an open, mergeable, CI-passing PR."""
+        adapter = MagicMock()
+        adapter.get_pull_request.return_value = _make_pr_data()
+        adapter.get_pull_request_reviews.return_value = [{"state": "APPROVED"}]
+        adapter.get_pull_request_check_runs.return_value = [
+            {"status": "completed", "conclusion": "success"}
+        ]
+        adapter.get_pull_request_review_comments.return_value = []
+
+        health = fetch_pr_health(adapter, "org", "my-repo", 7)
+
+        assert health is not None
+        assert health.repo == "my-repo"
+        assert health.number == 7
+        assert health.ci_status == "passing"
+        assert health.mergeable is True
+        assert health.review_state == "approved"
+        assert health.approved_count == 1
+        assert health.has_coderabbit_comments is False
+        assert health.health_indicator == "safe_to_merge"
+
+    def test_not_found(self) -> None:
+        """PR not found returns None."""
+        adapter = MagicMock()
+        adapter.get_pull_request.return_value = None
+
+        health = fetch_pr_health(adapter, "org", "my-repo", 999)
+        assert health is None
+
+    def test_ci_failing(self) -> None:
+        adapter = MagicMock()
+        adapter.get_pull_request.return_value = _make_pr_data()
+        adapter.get_pull_request_reviews.return_value = []
+        adapter.get_pull_request_check_runs.return_value = [
+            {"status": "completed", "conclusion": "failure"}
+        ]
+        adapter.get_pull_request_review_comments.return_value = []
+
+        health = fetch_pr_health(adapter, "org", "my-repo", 7)
+        assert health is not None
+        assert health.ci_status == "failing"
+        assert health.health_indicator == "blocked"
+
+    def test_coderabbit_comments_detected(self) -> None:
+        adapter = MagicMock()
+        adapter.get_pull_request.return_value = _make_pr_data()
+        adapter.get_pull_request_reviews.return_value = [{"state": "APPROVED"}]
+        adapter.get_pull_request_check_runs.return_value = [
+            {"status": "completed", "conclusion": "success"}
+        ]
+        adapter.get_pull_request_review_comments.return_value = [
+            {"user": {"login": "coderabbitai"}, "created_at": "2025-01-01T00:00:00Z"},
+            {"user": {"login": "coderabbitai[bot]"}, "created_at": "2025-01-01T00:00:00Z"},
+            {"user": {"login": "human-reviewer"}, "created_at": "2025-01-01T00:00:00Z"},
+        ]
+
+        health = fetch_pr_health(adapter, "org", "my-repo", 7)
+        assert health is not None
+        assert health.has_coderabbit_comments is True
+        assert health.coderabbit_comment_count == 2
+        assert health.health_indicator == "needs_attention"
+
+    def test_custom_coderabbit_logins(self) -> None:
+        """Custom bot logins are respected."""
+        adapter = MagicMock()
+        adapter.get_pull_request.return_value = _make_pr_data()
+        adapter.get_pull_request_reviews.return_value = [{"state": "APPROVED"}]
+        adapter.get_pull_request_check_runs.return_value = []
+        adapter.get_pull_request_review_comments.return_value = [
+            {"user": {"login": "mybot"}},
+        ]
+
+        health = fetch_pr_health(
+            adapter, "org", "my-repo", 7, coderabbit_bot_logins=["mybot"]
+        )
+        assert health is not None
+        assert health.coderabbit_comment_count == 1
+
+    def test_merge_conflict(self) -> None:
+        adapter = MagicMock()
+        adapter.get_pull_request.return_value = _make_pr_data(mergeable=False)
+        adapter.get_pull_request_reviews.return_value = [{"state": "APPROVED"}]
+        adapter.get_pull_request_check_runs.return_value = [
+            {"status": "completed", "conclusion": "success"}
+        ]
+        adapter.get_pull_request_review_comments.return_value = []
+
+        health = fetch_pr_health(adapter, "org", "my-repo", 7)
+        assert health is not None
+        assert health.mergeable is False
+        assert health.health_indicator == "blocked"
+
+    def test_draft_pr(self) -> None:
+        adapter = MagicMock()
+        adapter.get_pull_request.return_value = _make_pr_data(draft=True)
+        adapter.get_pull_request_reviews.return_value = []
+        adapter.get_pull_request_check_runs.return_value = []
+        adapter.get_pull_request_review_comments.return_value = []
+
+        health = fetch_pr_health(adapter, "org", "my-repo", 7)
+        assert health is not None
+        assert health.is_draft is True
+        assert health.health_indicator == "draft"
+
+    def test_changes_requested(self) -> None:
+        adapter = MagicMock()
+        adapter.get_pull_request.return_value = _make_pr_data()
+        adapter.get_pull_request_reviews.return_value = [
+            {"state": "CHANGES_REQUESTED"},
+        ]
+        adapter.get_pull_request_check_runs.return_value = []
+        adapter.get_pull_request_review_comments.return_value = []
+
+        health = fetch_pr_health(adapter, "org", "my-repo", 7)
+        assert health is not None
+        assert health.review_state == "changes_requested"
+        assert health.changes_requested_count == 1
+        assert health.health_indicator == "blocked"
+
+    def test_no_head_sha(self) -> None:
+        """PR without head SHA: CI stays unknown."""
+        adapter = MagicMock()
+        pr_data = _make_pr_data()
+        pr_data["head"] = {}
+        adapter.get_pull_request.return_value = pr_data
+        adapter.get_pull_request_reviews.return_value = [{"state": "APPROVED"}]
+        adapter.get_pull_request_review_comments.return_value = []
+
+        health = fetch_pr_health(adapter, "org", "my-repo", 7)
+        assert health is not None
+        assert health.ci_status == "unknown"
+        # Should not call check_runs if no sha
+        adapter.get_pull_request_check_runs.assert_not_called()
+
+    def test_review_comments_fetch_failure_non_fatal(self) -> None:
+        """If fetching review comments fails, CodeRabbit count is 0."""
+        adapter = MagicMock()
+        adapter.get_pull_request.return_value = _make_pr_data()
+        adapter.get_pull_request_reviews.return_value = [{"state": "APPROVED"}]
+        adapter.get_pull_request_check_runs.return_value = [
+            {"status": "completed", "conclusion": "success"}
+        ]
+        adapter.get_pull_request_review_comments.side_effect = RuntimeError("API error")
+
+        health = fetch_pr_health(adapter, "org", "my-repo", 7)
+        assert health is not None
+        assert health.has_coderabbit_comments is False
+        assert health.coderabbit_comment_count == 0
+
+
+# ===================================================================
+# fetch_all_open_pr_health
+# ===================================================================
+
+
+class TestFetchAllOpenPRHealth:
+    def test_pagination_skip(self) -> None:
+        """skip parameter skips the first N PRs."""
+        adapter = MagicMock()
+        adapter.list_open_pull_requests.return_value = [
+            {"repo": "a", "number": 1},
+            {"repo": "b", "number": 2},
+            {"repo": "c", "number": 3},
+        ]
+        adapter.get_pull_request.return_value = _make_pr_data()
+        adapter.get_pull_request_reviews.return_value = []
+        adapter.get_pull_request_check_runs.return_value = []
+        adapter.get_pull_request_review_comments.return_value = []
+
+        results, total = fetch_all_open_pr_health(adapter, "org", max_prs=2, skip=1)
+        assert total == 3
+        assert len(results) == 2  # items at index 1 and 2
+
+    def test_max_prs_cap(self) -> None:
+        """At most max_prs are returned."""
+        adapter = MagicMock()
+        prs = [{"repo": f"repo-{i}", "number": i} for i in range(10)]
+        adapter.list_open_pull_requests.return_value = prs
+        adapter.get_pull_request.return_value = _make_pr_data()
+        adapter.get_pull_request_reviews.return_value = []
+        adapter.get_pull_request_check_runs.return_value = []
+        adapter.get_pull_request_review_comments.return_value = []
+
+        results, total = fetch_all_open_pr_health(adapter, "org", max_prs=3, skip=0)
+        assert total == 10
+        assert len(results) == 3
+
+    def test_empty_org(self) -> None:
+        adapter = MagicMock()
+        adapter.list_open_pull_requests.return_value = []
+
+        results, total = fetch_all_open_pr_health(adapter, "org")
+        assert total == 0
+        assert results == []
+
+    def test_individual_pr_failure_skipped(self) -> None:
+        """If one PR fails, others still succeed."""
+        adapter = MagicMock()
+        adapter.list_open_pull_requests.return_value = [
+            {"repo": "a", "number": 1},
+            {"repo": "b", "number": 2},
+        ]
+
+        call_count = 0
+        def side_effect(owner, repo, pr_number):
+            nonlocal call_count
+            call_count += 1
+            if repo == "a":
+                raise RuntimeError("API error")
+            return _make_pr_data(repo=repo, number=pr_number)
+
+        adapter.get_pull_request.side_effect = side_effect
+        adapter.get_pull_request_reviews.return_value = []
+        adapter.get_pull_request_check_runs.return_value = []
+        adapter.get_pull_request_review_comments.return_value = []
+
+        results, total = fetch_all_open_pr_health(adapter, "org")
+        assert total == 2
+        assert len(results) == 1
+        assert results[0].repo == "b"
+
+
+# ===================================================================
+# Format: single PR
+# ===================================================================
+
+
+class TestFormatSinglePRStatus:
+    def test_safe_to_merge_format(self) -> None:
+        h = _make_health(
+            ci_status="passing",
+            mergeable=True,
+            review_state="approved",
+            approved_count=2,
+            has_coderabbit_comments=False,
+        )
+        result = format_single_pr_status(h, "org")
+
+        assert "my-repo#7" in result
+        assert "Test PR" in result
+        assert "contributor" in result
+        assert "Passing" in result
+        assert "No pending suggestions" in result
+        assert "Mergeable" in result
+        assert "Approved" in result
+        assert "Safe to Merge" in result
+
+    def test_blocked_format(self) -> None:
+        h = _make_health(
+            ci_status="failing",
+            mergeable=False,
+            review_state="changes_requested",
+            changes_requested_count=1,
+            has_coderabbit_comments=True,
+            coderabbit_comment_count=3,
+        )
+        result = format_single_pr_status(h, "org")
+
+        assert "Failing" in result
+        assert "3 suggestions pending" in result
+        assert "Merge Conflicts" in result
+        assert "Changes Requested" in result
+        assert "Blocked" in result
+
+    def test_draft_format(self) -> None:
+        h = _make_health(is_draft=True)
+        result = format_single_pr_status(h, "org")
+        assert "Draft" in result
+
+    def test_coderabbit_singular(self) -> None:
+        """Single CodeRabbit comment uses singular form."""
+        h = _make_health(
+            has_coderabbit_comments=True,
+            coderabbit_comment_count=1,
+        )
+        result = format_single_pr_status(h, "org")
+        assert "1 suggestion pending" in result
+        assert "suggestions" not in result
+
+
+# ===================================================================
+# Format: all PRs
+# ===================================================================
+
+
+class TestFormatAllPRStatus:
+    def test_empty_no_prs(self) -> None:
+        msgs = format_all_pr_status([], "org", skip=0, total=0)
+        assert len(msgs) == 1
+        assert "No open PRs" in msgs[0]
+
+    def test_empty_out_of_range(self) -> None:
+        msgs = format_all_pr_status([], "org", skip=50, total=30)
+        assert len(msgs) == 1
+        assert "No PRs in range" in msgs[0]
+
+    def test_sorting_priority(self) -> None:
+        """Blocked → needs_attention → safe_to_merge → draft."""
+        statuses = [
+            _make_health(repo="draft-repo", number=1, is_draft=True),
+            _make_health(repo="safe-repo", number=2, review_state="approved"),
+            _make_health(repo="blocked-repo", number=3, ci_status="failing"),
+            _make_health(
+                repo="attention-repo",
+                number=4,
+                review_state="awaiting_review",
+                approved_count=0,
+            ),
+        ]
+        msgs = format_all_pr_status(statuses, "org", skip=0, total=4)
+        combined = "\n".join(msgs)
+
+        # Find positions: blocked < attention < safe < draft
+        blocked_pos = combined.index("blocked-repo#3")
+        attention_pos = combined.index("attention-repo#4")
+        safe_pos = combined.index("safe-repo#2")
+        draft_pos = combined.index("draft-repo#1")
+
+        assert blocked_pos < attention_pos < safe_pos < draft_pos
+
+    def test_summary_counts(self) -> None:
+        statuses = [
+            _make_health(repo="a", number=1, ci_status="failing"),
+            _make_health(repo="b", number=2, ci_status="failing"),
+            _make_health(repo="c", number=3, review_state="approved"),
+        ]
+        msgs = format_all_pr_status(statuses, "org", skip=0, total=3)
+        combined = "\n".join(msgs)
+
+        assert "2 blocked" in combined
+        assert "1 safe to merge" in combined
+
+    def test_pagination_footer(self) -> None:
+        statuses = [_make_health(repo="a", number=1)]
+        msgs = format_all_pr_status(statuses, "org", skip=0, total=30)
+        combined = "\n".join(msgs)
+
+        assert "29 more" in combined
+        assert "skip:1" in combined
+
+    def test_no_pagination_footer_when_all_shown(self) -> None:
+        statuses = [_make_health(repo="a", number=1)]
+        msgs = format_all_pr_status(statuses, "org", skip=0, total=1)
+        combined = "\n".join(msgs)
+
+        assert "more" not in combined
+
+
+# ===================================================================
+# Internal helper tests
+# ===================================================================
+
+
+class TestTruncate:
+    def test_short_text(self) -> None:
+        assert _truncate("hello", 10) == "hello"
+
+    def test_long_text(self) -> None:
+        assert _truncate("hello world", 8) == "hello..."
+
+    def test_exact_length(self) -> None:
+        assert _truncate("hello", 5) == "hello"
+
+
+class TestSplitMessages:
+    def test_single_message(self) -> None:
+        msgs = _split_messages("Header", ["line1", "line2"], [], max_length=2000)
+        assert len(msgs) == 1
+        assert "Header" in msgs[0]
+        assert "line1" in msgs[0]
+
+    def test_splits_long_content(self) -> None:
+        header = "H" * 10
+        lines = ["L" * 50 for _ in range(50)]
+        msgs = _split_messages(header, lines, [], max_length=200)
+        assert len(msgs) > 1
+        for msg in msgs:
+            assert len(msg) <= 200
+
+    def test_footer_included(self) -> None:
+        msgs = _split_messages("Header", ["line1"], ["footer"], max_length=2000)
+        assert len(msgs) == 1
+        assert "footer" in msgs[0]


### PR DESCRIPTION


###  Screenshots/Recordings:


https://github.com/user-attachments/assets/90a155b1-426e-4091-9b7b-aa8ec10e4679


###  Additional Notes:
- **`/pr-status` Discord Slash Command** ([`src/ghdcbot/bot.py`](file:///c:/Users/prith/OneDrive/Desktop/gitcord/Gitcord-GithubDiscordBot/src/ghdcbot/bot.py)):
  - Added ephemeral `/pr-status repo:<repo> pr_number:<number>` command with rate limiting (1 request per 3s).
  - Fetches and formats real-time PR health indicators.
- **PR Health Evaluation Engine** ([`src/ghdcbot/engine/pr_status.py`](file:///c:/Users/prith/OneDrive/Desktop/gitcord/Gitcord-GithubDiscordBot/src/ghdcbot/engine/pr_status.py)):
  - Analyzes CI/check-runs status (passed, failing, running).
  - Inspects CodeRabbit review status and unresolved review comments / threads.
  - Checks mergeability and merge conflict status.
  - Inspects mentor/reviewer approval counts and requested changes.
  - Formats user-friendly Discord status cards with actionable indicators.
- **GitHub Adapter Support** ([`src/ghdcbot/adapters/github/rest.py`](file:///c:/Users/prith/OneDrive/Desktop/gitcord/Gitcord-GithubDiscordBot/src/ghdcbot/adapters/github/rest.py)):
  - Added `get_pull_request_review_threads` GraphQL query helper to inspect resolved vs. unresolved review threads.
- **Unit Tests** ([`tests/test_pr_status.py`](file:///c:/Users/prith/OneDrive/Desktop/gitcord/Gitcord-GithubDiscordBot/tests/test_pr_status.py)):
  - Comprehensive suite of 56 test cases covering health evaluations, formatting, GraphQL thread parsing, edge cases, and error handling.

### AI Usage Disclosure:

We encourage contributors to use AI tools responsibly when creating Pull Requests. While AI can be a valuable aid, it is essential to ensure that your contributions meet the task requirements, build successfully, include relevant tests, and pass all linters. Submissions that do not meet these standards may be closed without warning to maintain the quality and integrity of the project. Please take the time to understand the changes you are proposing and their impact. AI slop is strongly discouraged and may lead to banning and blocking. Do not spam our repos with AI slop.

Check one of the checkboxes below:

- [ ] This PR does not contain AI-generated code at all.
- [x] This PR contains AI-generated code. I have read the [AI Usage Policy](https://github.com/AOSSIE-Org/Info/blob/main/AI-UsagePolicy.md) and this PR complies with this policy. I have tested the code locally and I am responsible for it.



## Checklist
<!-- Mark items with [x] to indicate completion -->
- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions
- [x] If applicable, I have made corresponding changes or additions to the documentation
- [x] If applicable, I have made corresponding changes or additions to tests
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [x] I have filled this PR template completely and carefully, and I understand that my PR may be closed without review otherwise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `/pr-status` command for individual pull request checks or paginated dashboards.
  * Reports CI status, mergeability, approvals, requested changes, draft state, and active review comments.
  * Classifies pull requests as safe to merge, needing attention, blocked, or draft.
  * Supports repository filtering, automatic repository detection, pagination, and configurable access controls.
* **Bug Fixes**
  * Improved handling of inaccessible or failed pull request data, including review-thread retrieval fallbacks.
* **Documentation**
  * Added `/pr-status` usage and behavior details to the README.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->