### PR TITLE
feat: edit PR channel announcements on merge/close

### DIFF
--- a/src/ghdcbot/adapters/discord/api.py
+++ b/src/ghdcbot/adapters/discord/api.py
@@ -194,8 +194,16 @@ class DiscordApiAdapter:
 
     def send_message(self, channel_id: str, content: str) -> bool:
         """Post a read-only message to a channel. Content truncated to 2000 chars. Returns True on success."""
+        return self.create_message(channel_id, content) is not None
+
+    def create_message(self, channel_id: str, content: str) -> str | None:
+        """Post a channel message and return its Discord message ID (or None on failure).
+
+        Empty content is a no-op success that returns an empty string sentinel so callers
+        can distinguish \"nothing to send\" from a failed send (None).
+        """
         if not content:
-            return True
+            return ""
         text = content[:2000]
         try:
             response = self._client.request(
@@ -208,11 +216,51 @@ class DiscordApiAdapter:
                 "Discord send_message failed",
                 extra={"channel_id": channel_id, "error": str(exc)},
             )
-            return False
+            return None
         if response.status_code not in (200, 201):
             self._logger.warning(
                 "Discord send_message failed",
                 extra={"channel_id": channel_id, "status_code": response.status_code},
+            )
+            return None
+        try:
+            data = response.json()
+        except ValueError:
+            return None
+        message_id = data.get("id")
+        if not message_id:
+            return None
+        return str(message_id)
+
+    def edit_message(self, channel_id: str, message_id: str, content: str) -> bool:
+        """Edit an existing channel message. Returns True on success."""
+        if not channel_id or not message_id:
+            return False
+        text = (content or "")[:2000]
+        try:
+            response = self._client.request(
+                "PATCH",
+                f"/channels/{channel_id}/messages/{message_id}",
+                json={"content": text, "flags": 4},
+            )
+        except httpx.HTTPError as exc:
+            self._logger.warning(
+                "Discord edit_message failed",
+                extra={
+                    "channel_id": channel_id,
+                    "message_id": message_id,
+                    "error": str(exc),
+                },
+            )
+            return False
+        if response.status_code not in (200, 201):
+            self._logger.warning(
+                "Discord edit_message failed",
+                extra={
+                    "channel_id": channel_id,
+                    "message_id": message_id,
+                    "status_code": response.status_code,
+                },
             )
             return False
         return True

--- a/src/ghdcbot/adapters/discord/api.py
+++ b/src/ghdcbot/adapters/discord/api.py
@@ -196,20 +196,38 @@ class DiscordApiAdapter:
         """Post a read-only message to a channel. Content truncated to 2000 chars. Returns True on success."""
         return self.create_message(channel_id, content) is not None
 
-    def create_message(self, channel_id: str, content: str) -> str | None:
+    def create_message(
+        self,
+        channel_id: str,
+        content: str,
+        *,
+        embeds: list[dict] | None = None,
+    ) -> str | None:
         """Post a channel message and return its Discord message ID (or None on failure).
 
-        Empty content is a no-op success that returns an empty string sentinel so callers
-        can distinguish \"nothing to send\" from a failed send (None).
+        Empty content with no embeds is a no-op success that returns an empty string
+        sentinel so callers can distinguish \"nothing to send\" from a failed send (None).
+
+        ``SUPPRESS_EMBEDS`` is only set for plain-text posts so GitHub link previews are
+        hidden. It must not be set when custom embeds are included — Discord would hide
+        those embeds too and leave an empty-looking message.
         """
-        if not content:
+        embed_list = list(embeds or [])
+        if not content and not embed_list:
             return ""
-        text = content[:2000]
+        text = (content or "")[:2000]
+        payload: dict = {}
+        if text:
+            payload["content"] = text
+        if embed_list:
+            payload["embeds"] = embed_list[:10]
+        else:
+            payload["flags"] = 4  # SUPPRESS_EMBEDS — link previews only
         try:
             response = self._client.request(
                 "POST",
                 f"/channels/{channel_id}/messages",
-                json={"content": text, "flags": 4},  # 4 = SUPPRESS_EMBEDS (no link previews)
+                json=payload,
             )
         except httpx.HTTPError as exc:
             self._logger.warning(
@@ -232,16 +250,36 @@ class DiscordApiAdapter:
             return None
         return str(message_id)
 
-    def edit_message(self, channel_id: str, message_id: str, content: str) -> bool:
-        """Edit an existing channel message. Returns True on success."""
+    def edit_message(
+        self,
+        channel_id: str,
+        message_id: str,
+        content: str,
+        *,
+        embeds: list[dict] | None = None,
+    ) -> bool:
+        """Edit an existing channel message. Returns True on success.
+
+        When ``embeds`` is provided (including an empty list), the message embeds are
+        replaced. Pass ``embeds=[]`` to clear embeds after converting to plain text.
+
+        Never pairs custom embeds with ``SUPPRESS_EMBEDS`` (that flag hides them).
+        """
         if not channel_id or not message_id:
             return False
         text = (content or "")[:2000]
+        payload: dict = {"content": text}
+        if embeds is not None:
+            payload["embeds"] = list(embeds)[:10]
+            # Explicitly clear suppress-embeds if a prior edit set it.
+            payload["flags"] = 0
+        else:
+            payload["flags"] = 4
         try:
             response = self._client.request(
                 "PATCH",
                 f"/channels/{channel_id}/messages/{message_id}",
-                json={"content": text, "flags": 4},
+                json=payload,
             )
         except httpx.HTTPError as exc:
             self._logger.warning(

--- a/src/ghdcbot/adapters/github/rest.py
+++ b/src/ghdcbot/adapters/github/rest.py
@@ -907,6 +907,9 @@ class GitHubRestAdapter:
                         "title": pr.get("title"),
                         "merged_at": pr.get("merged_at"),
                     }
+                    merged_by = ((pr.get("merged_by") or {}).get("login") or "").strip()
+                    if merged_by:
+                        payload["merged_by"] = merged_by
                     if base_branch:
                         payload["base_branch"] = base_branch
                     if difficulty_labels:
@@ -1092,6 +1095,7 @@ class GitHubRestAdapter:
                         timeline_events, index, merged_at
                     ):
                         continue
+                    closed_by = ((event.get("actor") or {}).get("login") or "").strip() or author
                     yield ContributionEvent(
                         github_user=author,
                         event_type="pr_closed",
@@ -1102,6 +1106,7 @@ class GitHubRestAdapter:
                             "pr_title": pr.get("title"),
                             "title": pr.get("title"),
                             "pr_author": author,
+                            "closed_by": closed_by,
                             "repository": repo,
                             "html_url": pr.get("html_url"),
                             "closed_at": event.get("created_at"),

--- a/src/ghdcbot/adapters/storage/sqlite.py
+++ b/src/ghdcbot/adapters/storage/sqlite.py
@@ -138,6 +138,20 @@ class SqliteStorage:
                     ON social_profiles (discord_user_id);
                 CREATE INDEX IF NOT EXISTS idx_social_profiles_platform 
                     ON social_profiles (platform);
+                CREATE TABLE IF NOT EXISTS pr_channel_announcements (
+                    repo TEXT NOT NULL,
+                    pr_number INTEGER NOT NULL,
+                    channel_id TEXT NOT NULL,
+                    message_id TEXT NOT NULL,
+                    status TEXT NOT NULL DEFAULT 'open',
+                    pr_title TEXT,
+                    author_github TEXT,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    PRIMARY KEY (repo, pr_number)
+                );
+                CREATE INDEX IF NOT EXISTS idx_pr_channel_announcements_status
+                    ON pr_channel_announcements (status);
                 """
             )
 
@@ -726,6 +740,87 @@ class SqliteStorage:
             conn.execute(
                 "DELETE FROM notifications_sent WHERE dedupe_key = ?",
                 (dedupe_key,),
+            )
+
+    def save_pr_channel_announcement(
+        self,
+        *,
+        repo: str,
+        pr_number: int,
+        channel_id: str,
+        message_id: str,
+        pr_title: str | None = None,
+        author_github: str | None = None,
+        status: str = "open",
+    ) -> None:
+        """Track a newly posted PR-opened channel message (future lifecycle edits only)."""
+        now = datetime.now(timezone.utc).isoformat()
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO pr_channel_announcements
+                (repo, pr_number, channel_id, message_id, status, pr_title, author_github, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(repo, pr_number) DO UPDATE SET
+                    channel_id = excluded.channel_id,
+                    message_id = excluded.message_id,
+                    status = excluded.status,
+                    pr_title = COALESCE(excluded.pr_title, pr_channel_announcements.pr_title),
+                    author_github = COALESCE(excluded.author_github, pr_channel_announcements.author_github),
+                    updated_at = excluded.updated_at
+                """,
+                (
+                    repo,
+                    int(pr_number),
+                    channel_id,
+                    message_id,
+                    status,
+                    pr_title,
+                    author_github,
+                    now,
+                    now,
+                ),
+            )
+
+    def get_pr_channel_announcement(self, repo: str, pr_number: int) -> dict | None:
+        """Return tracked PR channel announcement or None (e.g. pre-feature opens)."""
+        with self._connect() as conn:
+            row = conn.execute(
+                """
+                SELECT repo, pr_number, channel_id, message_id, status, pr_title, author_github,
+                       created_at, updated_at
+                FROM pr_channel_announcements
+                WHERE repo = ? AND pr_number = ?
+                """,
+                (repo, int(pr_number)),
+            ).fetchone()
+        if not row:
+            return None
+        return {
+            "repo": row[0],
+            "pr_number": row[1],
+            "channel_id": row[2],
+            "message_id": row[3],
+            "status": row[4],
+            "pr_title": row[5],
+            "author_github": row[6],
+            "created_at": row[7],
+            "updated_at": row[8],
+        }
+
+    def mark_pr_channel_announcement_status(
+        self, repo: str, pr_number: int, status: str
+    ) -> None:
+        """Update lifecycle status for a tracked PR channel announcement."""
+        now = datetime.now(timezone.utc).isoformat()
+        with self._connect() as conn:
+            conn.execute(
+                """
+                UPDATE pr_channel_announcements
+                SET status = ?, updated_at = ?
+                WHERE repo = ? AND pr_number = ?
+                """,
+                (status, now, repo, int(pr_number)),
             )
 
     def mark_notification_sent(

--- a/src/ghdcbot/config/models.py
+++ b/src/ghdcbot/config/models.py
@@ -92,6 +92,9 @@ class NotificationConfig(BaseModel):
     pr_opened: bool = False  # PR opened → repo-mapped Discord channel (see discord.pr_open_channels); unverified authors still posted
     # When true, unverified PR authors get a GitcordApp comment on the PR asking them to /link.
     pr_opened_github_comment: bool = False
+    # Edit the tracked PR-opened channel message when that PR is later merged/closed.
+    # Only applies to announcements posted after this feature is deployed (no backfill).
+    update_pr_channel_on_lifecycle: bool = True
     coderabbit_reminders: bool = False  # Remind PR authors about old CodeRabbit review comments
     coderabbit_reminder_after_hours: int = 48  # Only remind if comment is at least this old
     coderabbit_bot_logins: list[str] | None = None  # Bot logins to treat as CodeRabbit; default ["coderabbitai", "coderabbitai[bot]"]

--- a/src/ghdcbot/engine/notifications.py
+++ b/src/ghdcbot/engine/notifications.py
@@ -201,7 +201,8 @@ def send_pr_opened_channel_notification(
         return False
 
     send_msg = getattr(discord_writer, "send_message", None)
-    if not callable(send_msg):
+    create_msg = getattr(discord_writer, "create_message", None)
+    if not callable(send_msg) and not callable(create_msg):
         return False
 
     notify_discord_id = discord_user_id or ""
@@ -219,8 +220,16 @@ def send_pr_opened_channel_notification(
     if not claimed:
         return False
 
+    message_id: str | None = None
     try:
-        sent = bool(send_msg(channel_id, message))
+        if callable(create_msg):
+            message_id = create_msg(channel_id, message)
+            sent = message_id is not None
+            # Empty-string sentinel from create_message means no-op success without an ID.
+            if message_id == "":
+                message_id = None
+        else:
+            sent = bool(send_msg(channel_id, message))
     except Exception as exc:
         _release_notification_claim(storage, dedupe_key)
         logger.warning(
@@ -231,10 +240,188 @@ def send_pr_opened_channel_notification(
         return False
 
     if sent:
+        if message_id:
+            save = getattr(storage, "save_pr_channel_announcement", None)
+            if callable(save):
+                try:
+                    save(
+                        repo=event.repo,
+                        pr_number=int(event.payload.get("pr_number")),
+                        channel_id=channel_id,
+                        message_id=message_id,
+                        pr_title=event.payload.get("title"),
+                        author_github=author_github,
+                        status="open",
+                    )
+                except Exception as exc:
+                    logger.warning(
+                        "Failed to track pr_opened channel message for lifecycle edits",
+                        exc_info=True,
+                        extra={
+                            "error": str(exc),
+                            "channel_id": channel_id,
+                            "repo": event.repo,
+                            "pr_number": event.payload.get("pr_number"),
+                        },
+                    )
         _audit_notification(storage, event, notify_discord_id, channel_id, author_github)
         return True
     _release_notification_claim(storage, dedupe_key)
     return False
+
+
+def update_pr_channel_announcement_for_event(
+    event: ContributionEvent,
+    storage: Storage,
+    discord_writer: DiscordWriter,
+    policy: MutationPolicy,
+    config: NotificationConfig,
+    github_org: str,
+) -> bool:
+    """Edit a tracked PR-opened channel message when the PR is merged or closed.
+
+    Only updates announcements posted after tracking was enabled (row in storage).
+    Old channel messages are left unchanged.
+    """
+    if not config.enabled or not getattr(config, "update_pr_channel_on_lifecycle", True):
+        return False
+    if event.event_type not in {"pr_merged", "pr_closed"}:
+        return False
+    if not policy.allow_discord_mutations:
+        return False
+
+    pr_number = event.payload.get("pr_number")
+    if pr_number is None:
+        return False
+
+    get_ann = getattr(storage, "get_pr_channel_announcement", None)
+    if not callable(get_ann):
+        return False
+    try:
+        tracked = get_ann(event.repo, int(pr_number))
+    except Exception as exc:
+        logger.warning(
+            "Failed to load tracked PR channel announcement",
+            exc_info=True,
+            extra={"error": str(exc), "repo": event.repo, "pr_number": pr_number},
+        )
+        return False
+    if not tracked:
+        # Pre-feature / untracked opens: do not invent edits for old Discord messages.
+        return False
+
+    status = "merged" if event.event_type == "pr_merged" else "closed"
+    if tracked.get("status") == status:
+        return False
+
+    actor = _pr_lifecycle_actor(event)
+    message = _build_pr_lifecycle_channel_message(
+        event,
+        github_org,
+        status=status,
+        actor_github=actor,
+        tracked=tracked,
+    )
+    if not message:
+        return False
+
+    dedupe_key = f"pr_channel_lifecycle:{event.repo}:{pr_number}:{status}"
+    try:
+        claimed = _claim_notification_sent(
+            storage, dedupe_key, event, "", tracked.get("channel_id"), actor
+        )
+    except Exception as exc:
+        logger.warning(
+            "Failed to claim PR channel lifecycle update",
+            exc_info=True,
+            extra={"error": str(exc), "repo": event.repo, "pr_number": pr_number},
+        )
+        return False
+    if not claimed:
+        return False
+
+    edit_msg = getattr(discord_writer, "edit_message", None)
+    if not callable(edit_msg):
+        _release_notification_claim(storage, dedupe_key)
+        return False
+
+    try:
+        edited = bool(
+            edit_msg(str(tracked["channel_id"]), str(tracked["message_id"]), message)
+        )
+    except Exception as exc:
+        _release_notification_claim(storage, dedupe_key)
+        logger.warning(
+            "Failed to edit PR channel announcement",
+            exc_info=True,
+            extra={
+                "error": str(exc),
+                "repo": event.repo,
+                "pr_number": pr_number,
+                "channel_id": tracked.get("channel_id"),
+                "message_id": tracked.get("message_id"),
+            },
+        )
+        return False
+
+    if not edited:
+        _release_notification_claim(storage, dedupe_key)
+        return False
+
+    mark = getattr(storage, "mark_pr_channel_announcement_status", None)
+    if callable(mark):
+        try:
+            mark(event.repo, int(pr_number), status)
+        except Exception as exc:
+            logger.warning(
+                "Failed to update PR channel announcement status after edit",
+                exc_info=True,
+                extra={"error": str(exc), "repo": event.repo, "pr_number": pr_number},
+            )
+    _audit_notification(storage, event, "", tracked.get("channel_id"), actor)
+    return True
+
+
+def _pr_lifecycle_actor(event: ContributionEvent) -> str:
+    """Prefer explicit merged_by/closed_by; fall back to event github_user."""
+    payload = event.payload or {}
+    if event.event_type == "pr_merged":
+        actor = payload.get("merged_by") or event.github_user
+    else:
+        actor = payload.get("closed_by") or payload.get("pr_author") or event.github_user
+    return (actor or "unknown").strip() or "unknown"
+
+
+def _build_pr_lifecycle_channel_message(
+    event: ContributionEvent,
+    github_org: str,
+    *,
+    status: str,
+    actor_github: str,
+    tracked: dict,
+) -> str | None:
+    pr_number = event.payload.get("pr_number")
+    if pr_number is None:
+        return None
+    title_raw = (
+        event.payload.get("title")
+        or event.payload.get("pr_title")
+        or tracked.get("pr_title")
+        or "Untitled"
+    )
+    pr_title = _sanitize_discord_pr_title(title_raw)
+    repo = event.repo
+    url = _suppress_discord_embed(
+        f"https://github.com/{github_org}/{repo}/pull/{pr_number}"
+    )
+    actor = (actor_github or "unknown").lstrip("@")
+    if status == "merged":
+        header = f"🟣 **Merged: [{repo} #{pr_number} — {pr_title}]({url})**"
+        status_line = f"**Status:** Merged by @{actor}"
+    else:
+        header = f"🔴 **Closed: [{repo} #{pr_number} — {pr_title}]({url})**"
+        status_line = f"**Status:** Closed by @{actor}"
+    return f"{header}\n\n{status_line}"
 
 
 def send_pr_opened_github_link_comment(

--- a/src/ghdcbot/engine/notifications.py
+++ b/src/ghdcbot/engine/notifications.py
@@ -408,11 +408,15 @@ def update_pr_channel_announcement_for_event(
         try:
             mark(event.repo, int(pr_number), status)
         except Exception as exc:
+            # Discord already edited; release claim so a later sync can retry
+            # status persistence (row may still be "open").
+            _release_notification_claim(storage, dedupe_key)
             logger.warning(
                 "Failed to update PR channel announcement status after edit",
                 exc_info=True,
                 extra={"error": str(exc), "repo": event.repo, "pr_number": pr_number},
             )
+            return False
     _audit_notification(storage, event, "", tracked.get("channel_id"), actor)
     return True
 

--- a/src/ghdcbot/engine/notifications.py
+++ b/src/ghdcbot/engine/notifications.py
@@ -315,15 +315,16 @@ def update_pr_channel_announcement_for_event(
         return False
 
     actor = _pr_lifecycle_actor(event)
-    message = _build_pr_lifecycle_channel_message(
+    built = _build_pr_lifecycle_channel_message(
         event,
         github_org,
         status=status,
         actor_github=actor,
         tracked=tracked,
     )
-    if not message:
+    if not built:
         return False
+    message, embeds = built
 
     dedupe_key = f"pr_channel_lifecycle:{event.repo}:{pr_number}:{status}"
     try:
@@ -347,8 +348,42 @@ def update_pr_channel_announcement_for_event(
 
     try:
         edited = bool(
-            edit_msg(str(tracked["channel_id"]), str(tracked["message_id"]), message)
+            edit_msg(
+                str(tracked["channel_id"]),
+                str(tracked["message_id"]),
+                message,
+                embeds=embeds,
+            )
         )
+    except TypeError:
+        # Older DiscordWriter mocks/adapters without embeds kwarg.
+        if embeds:
+            emb = embeds[0]
+            fallback = f"**{emb.get('title', '')}**\n\n{emb.get('description', '')}".strip()
+        else:
+            fallback = message or ""
+        try:
+            edited = bool(
+                edit_msg(
+                    str(tracked["channel_id"]),
+                    str(tracked["message_id"]),
+                    fallback,
+                )
+            )
+        except Exception as exc:
+            _release_notification_claim(storage, dedupe_key)
+            logger.warning(
+                "Failed to edit PR channel announcement",
+                exc_info=True,
+                extra={
+                    "error": str(exc),
+                    "repo": event.repo,
+                    "pr_number": pr_number,
+                    "channel_id": tracked.get("channel_id"),
+                    "message_id": tracked.get("message_id"),
+                },
+            )
+            return False
     except Exception as exc:
         _release_notification_claim(storage, dedupe_key)
         logger.warning(
@@ -392,6 +427,11 @@ def _pr_lifecycle_actor(event: ContributionEvent) -> str:
     return (actor or "unknown").strip() or "unknown"
 
 
+# GitHub Primer status colors (match PR badge hues in the GitHub UI).
+_GITHUB_MERGED_PURPLE = 0x8250DF  # Primer done/merged
+_GITHUB_CLOSED_RED = 0xCF222E  # Primer danger/closed
+
+
 def _build_pr_lifecycle_channel_message(
     event: ContributionEvent,
     github_org: str,
@@ -399,7 +439,12 @@ def _build_pr_lifecycle_channel_message(
     status: str,
     actor_github: str,
     tracked: dict,
-) -> str | None:
+) -> tuple[str, list[dict]] | None:
+    """Build a Discord embed for a PR merge/close channel edit.
+
+    Text + GitHub Primer purple/red live in one embed (no empty color-only box).
+    Plain content is left empty so Discord shows a single card.
+    """
     pr_number = event.payload.get("pr_number")
     if pr_number is None:
         return None
@@ -411,18 +456,29 @@ def _build_pr_lifecycle_channel_message(
     )
     pr_title = _sanitize_discord_pr_title(title_raw)
     repo = event.repo
-    url = _suppress_discord_embed(
-        f"https://github.com/{github_org}/{repo}/pull/{pr_number}"
-    )
+    raw_url = f"https://github.com/{github_org}/{repo}/pull/{pr_number}"
     actor = (actor_github or "unknown").lstrip("@")
     if status == "merged":
-        header = f"🟣 **Merged: [{repo} #{pr_number} — {pr_title}]({url})**"
+        label = "Merged"
         status_line = f"**Status:** Merged by @{actor}"
+        color = _GITHUB_MERGED_PURPLE
     else:
-        header = f"🔴 **Closed: [{repo} #{pr_number} — {pr_title}]({url})**"
+        label = "Closed"
         status_line = f"**Status:** Closed by @{actor}"
-    return f"{header}\n\n{status_line}"
-
+        color = _GITHUB_CLOSED_RED
+    # Discord embed titles are plain text (no markdown links); put the link in url.
+    title = f"{label}: {repo} #{pr_number} — {pr_title}"
+    if len(title) > 256:
+        title = title[:253] + "..."
+    embeds = [
+        {
+            "title": title,
+            "url": raw_url,
+            "description": status_line,
+            "color": color,
+        }
+    ]
+    return "", embeds
 
 def send_pr_opened_github_link_comment(
     event: ContributionEvent,

--- a/src/ghdcbot/engine/orchestrator.py
+++ b/src/ghdcbot/engine/orchestrator.py
@@ -23,6 +23,7 @@ from ghdcbot.engine.notifications import (
     send_notification_for_event,
     send_pr_opened_channel_notification,
     send_pr_opened_github_link_comment,
+    update_pr_channel_announcement_for_event,
 )
 from ghdcbot.engine.planning import plan_discord_roles
 from ghdcbot.engine.reporting import write_reports, write_activity_report
@@ -338,6 +339,23 @@ def _send_notifications_for_new_events(
                         "pr_author": event.payload.get("pr_author"),
                     },
                 )
+            if event.event_type in {"pr_merged", "pr_closed"}:
+                try:
+                    if update_pr_channel_announcement_for_event(
+                        event, storage, discord_writer, policy, config, github_org
+                    ):
+                        sent_count += 1
+                except Exception as exc:
+                    logger.warning(
+                        "PR channel lifecycle update failed (non-blocking)",
+                        exc_info=True,
+                        extra={
+                            "error": str(exc),
+                            "event_type": event.event_type,
+                            "repo": event.repo,
+                            "pr_number": event.payload.get("pr_number"),
+                        },
+                    )
             if send_notification_for_event(event, storage, discord_writer, policy, config, github_org):
                 sent_count += 1
     if sent_count > 0:

--- a/tests/test_discord_api_messages.py
+++ b/tests/test_discord_api_messages.py
@@ -1,0 +1,179 @@
+"""Direct HTTP-path tests for DiscordApiAdapter.create_message / edit_message."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+from ghdcbot.adapters.discord.api import DiscordApiAdapter
+
+
+def _adapter() -> tuple[DiscordApiAdapter, MagicMock]:
+    adapter = DiscordApiAdapter(token="test-token", guild_id="guild-1")
+    mock_client = MagicMock()
+    adapter._client = mock_client
+    return adapter, mock_client
+
+
+def test_create_message_empty_content_noop() -> None:
+    adapter, mock_client = _adapter()
+    assert adapter.create_message("chan-1", "") == ""
+    mock_client.request.assert_not_called()
+
+
+def test_create_message_success_returns_message_id() -> None:
+    adapter, mock_client = _adapter()
+    mock_client.request.return_value = httpx.Response(
+        200, json={"id": "msg-42"}, request=httpx.Request("POST", "https://discord.com")
+    )
+
+    message_id = adapter.create_message("chan-1", "hello")
+
+    assert message_id == "msg-42"
+    mock_client.request.assert_called_once()
+    method, path = mock_client.request.call_args.args[:2]
+    assert method == "POST"
+    assert path == "/channels/chan-1/messages"
+    payload = mock_client.request.call_args.kwargs["json"]
+    assert payload["content"] == "hello"
+    assert payload["flags"] == 4  # SUPPRESS_EMBEDS for plain text
+
+
+def test_create_message_with_embeds_skips_suppress_flag() -> None:
+    adapter, mock_client = _adapter()
+    mock_client.request.return_value = httpx.Response(
+        201, json={"id": "msg-9"}, request=httpx.Request("POST", "https://discord.com")
+    )
+    embeds = [{"title": "Merged", "color": 0x8250DF}]
+
+    message_id = adapter.create_message("chan-1", "", embeds=embeds)
+
+    assert message_id == "msg-9"
+    payload = mock_client.request.call_args.kwargs["json"]
+    assert payload["embeds"] == embeds
+    assert "flags" not in payload
+    assert "content" not in payload
+
+
+def test_create_message_truncates_at_2000_chars() -> None:
+    adapter, mock_client = _adapter()
+    mock_client.request.return_value = httpx.Response(
+        200, json={"id": "msg-1"}, request=httpx.Request("POST", "https://discord.com")
+    )
+    long_text = "a" * 2500
+
+    adapter.create_message("chan-1", long_text)
+
+    payload = mock_client.request.call_args.kwargs["json"]
+    assert len(payload["content"]) == 2000
+
+
+def test_create_message_http_error_returns_none() -> None:
+    adapter, mock_client = _adapter()
+    mock_client.request.side_effect = httpx.ConnectError("boom")
+
+    assert adapter.create_message("chan-1", "hello") is None
+
+
+@pytest.mark.parametrize("status_code", [400, 403, 500])
+def test_create_message_non_success_status_returns_none(status_code: int) -> None:
+    adapter, mock_client = _adapter()
+    mock_client.request.return_value = httpx.Response(
+        status_code, request=httpx.Request("POST", "https://discord.com")
+    )
+
+    assert adapter.create_message("chan-1", "hello") is None
+
+
+def test_create_message_malformed_json_returns_none() -> None:
+    adapter, mock_client = _adapter()
+    mock_client.request.return_value = httpx.Response(
+        200, text="not-json", request=httpx.Request("POST", "https://discord.com")
+    )
+
+    assert adapter.create_message("chan-1", "hello") is None
+
+
+def test_create_message_missing_id_returns_none() -> None:
+    adapter, mock_client = _adapter()
+    mock_client.request.return_value = httpx.Response(
+        200, json={"content": "ok"}, request=httpx.Request("POST", "https://discord.com")
+    )
+
+    assert adapter.create_message("chan-1", "hello") is None
+
+
+def test_send_message_delegates_to_create_message() -> None:
+    adapter, mock_client = _adapter()
+    mock_client.request.return_value = httpx.Response(
+        200, json={"id": "msg-1"}, request=httpx.Request("POST", "https://discord.com")
+    )
+
+    assert adapter.send_message("chan-1", "hi") is True
+    mock_client.request.assert_called_once()
+
+
+def test_edit_message_success() -> None:
+    adapter, mock_client = _adapter()
+    mock_client.request.return_value = httpx.Response(
+        200, json={"id": "msg-9"}, request=httpx.Request("PATCH", "https://discord.com")
+    )
+
+    assert adapter.edit_message("chan-1", "msg-9", "updated") is True
+    method, path = mock_client.request.call_args.args[:2]
+    assert method == "PATCH"
+    assert path == "/channels/chan-1/messages/msg-9"
+    payload = mock_client.request.call_args.kwargs["json"]
+    assert payload["content"] == "updated"
+    assert payload["flags"] == 4
+
+
+def test_edit_message_with_embeds_clears_suppress_flag() -> None:
+    adapter, mock_client = _adapter()
+    mock_client.request.return_value = httpx.Response(
+        200, json={"id": "msg-9"}, request=httpx.Request("PATCH", "https://discord.com")
+    )
+    embeds = [{"title": "Merged", "color": 0x8250DF}]
+
+    assert adapter.edit_message("chan-1", "msg-9", "", embeds=embeds) is True
+    payload = mock_client.request.call_args.kwargs["json"]
+    assert payload["content"] == ""
+    assert payload["embeds"] == embeds
+    assert payload["flags"] == 0
+
+
+def test_edit_message_truncates_at_2000_chars() -> None:
+    adapter, mock_client = _adapter()
+    mock_client.request.return_value = httpx.Response(
+        200, json={"id": "msg-9"}, request=httpx.Request("PATCH", "https://discord.com")
+    )
+
+    assert adapter.edit_message("chan-1", "msg-9", "b" * 2500) is True
+    payload = mock_client.request.call_args.kwargs["json"]
+    assert len(payload["content"]) == 2000
+
+
+def test_edit_message_missing_ids_returns_false() -> None:
+    adapter, mock_client = _adapter()
+    assert adapter.edit_message("", "msg-9", "x") is False
+    assert adapter.edit_message("chan-1", "", "x") is False
+    mock_client.request.assert_not_called()
+
+
+def test_edit_message_http_error_returns_false() -> None:
+    adapter, mock_client = _adapter()
+    mock_client.request.side_effect = httpx.TimeoutException("timeout")
+
+    assert adapter.edit_message("chan-1", "msg-9", "x") is False
+
+
+@pytest.mark.parametrize("status_code", [400, 404, 500])
+def test_edit_message_non_success_status_returns_false(status_code: int) -> None:
+    adapter, mock_client = _adapter()
+    mock_client.request.return_value = httpx.Response(
+        status_code, request=httpx.Request("PATCH", "https://discord.com")
+    )
+
+    assert adapter.edit_message("chan-1", "msg-9", "x") is False

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -20,6 +20,7 @@ from ghdcbot.engine.notifications import (
     send_notification_for_event,
     send_pr_opened_channel_notification,
     send_pr_opened_github_link_comment,
+    update_pr_channel_announcement_for_event,
 )
 
 
@@ -30,6 +31,7 @@ class MockStorage:
         self.verified_mappings: list[dict] = []
         self.notifications_sent: set[str] = set()
         self.audit_events: list[dict] = []
+        self.pr_channel_announcements: dict[tuple[str, int], dict] = {}
     
     def list_verified_identity_mappings(self) -> list[dict]:
         return self.verified_mappings
@@ -54,6 +56,29 @@ class MockStorage:
     def append_audit_event(self, event: dict) -> None:
         self.audit_events.append(event)
 
+    def save_pr_channel_announcement(self, **kwargs: object) -> None:
+        repo = str(kwargs["repo"])
+        pr_number = int(kwargs["pr_number"])  # type: ignore[arg-type]
+        self.pr_channel_announcements[(repo, pr_number)] = {
+            "repo": repo,
+            "pr_number": pr_number,
+            "channel_id": str(kwargs["channel_id"]),
+            "message_id": str(kwargs["message_id"]),
+            "status": str(kwargs.get("status") or "open"),
+            "pr_title": kwargs.get("pr_title"),
+            "author_github": kwargs.get("author_github"),
+        }
+
+    def get_pr_channel_announcement(self, repo: str, pr_number: int) -> dict | None:
+        return self.pr_channel_announcements.get((repo, int(pr_number)))
+
+    def mark_pr_channel_announcement_status(
+        self, repo: str, pr_number: int, status: str
+    ) -> None:
+        row = self.pr_channel_announcements.get((repo, int(pr_number)))
+        if row:
+            row["status"] = status
+
 
 class MockDiscordWriter:
     """Mock Discord writer for testing."""
@@ -61,6 +86,8 @@ class MockDiscordWriter:
     def __init__(self) -> None:
         self.dms_sent: list[tuple[str, str]] = []
         self.messages_sent: list[tuple[str, str]] = []
+        self.messages_edited: list[tuple[str, str, str]] = []
+        self._next_message_id = 1000
     
     def send_dm(self, discord_user_id: str, content: str) -> bool:
         self.dms_sent.append((discord_user_id, content))
@@ -68,6 +95,17 @@ class MockDiscordWriter:
     
     def send_message(self, channel_id: str, content: str) -> bool:
         self.messages_sent.append((channel_id, content))
+        return True
+
+    def create_message(self, channel_id: str, content: str) -> str | None:
+        if not content:
+            return ""
+        self.messages_sent.append((channel_id, content))
+        self._next_message_id += 1
+        return str(self._next_message_id)
+
+    def edit_message(self, channel_id: str, message_id: str, content: str) -> bool:
+        self.messages_edited.append((channel_id, message_id, content))
         return True
 
 
@@ -1054,6 +1092,135 @@ def test_pr_opened_channel_notification_skips_when_discord_mutations_disallowed(
     assert result is False
     assert discord_writer.messages_sent == []
     assert policy.allow_discord_mutations is False
+
+
+def test_pr_opened_channel_notification_tracks_message_id() -> None:
+    storage = MockStorage()
+    storage.verified_mappings = [{"discord_user_id": "999", "github_user": "alice"}]
+    discord_writer = MockDiscordWriter()
+    config = NotificationConfig(enabled=True, pr_opened=True)
+    policy = MutationPolicy(mode=RunMode.ACTIVE, github_write_allowed=True, discord_write_allowed=True)
+
+    assert send_pr_opened_channel_notification(
+        _pr_opened_event(),
+        storage,
+        discord_writer,
+        policy,
+        config,
+        {"Gitcord-GithubDiscordBot": "1465995983791063140"},
+        "AOSSIE-Org",
+    )
+    tracked = storage.get_pr_channel_announcement("Gitcord-GithubDiscordBot", 42)
+    assert tracked is not None
+    assert tracked["channel_id"] == "1465995983791063140"
+    assert tracked["message_id"]
+    assert tracked["status"] == "open"
+
+
+def test_update_pr_channel_announcement_edits_on_merge() -> None:
+    storage = MockStorage()
+    discord_writer = MockDiscordWriter()
+    storage.save_pr_channel_announcement(
+        repo="Gitcord-GithubDiscordBot",
+        pr_number=42,
+        channel_id="chan-1",
+        message_id="msg-9",
+        pr_title="Test PR",
+        author_github="alice",
+        status="open",
+    )
+    config = NotificationConfig(enabled=True, update_pr_channel_on_lifecycle=True)
+    policy = MutationPolicy(mode=RunMode.ACTIVE, github_write_allowed=True, discord_write_allowed=True)
+    event = ContributionEvent(
+        github_user="alice",
+        event_type="pr_merged",
+        repo="Gitcord-GithubDiscordBot",
+        created_at=datetime.now(UTC),
+        payload={"pr_number": 42, "title": "Test PR", "merged_by": "mentor1"},
+    )
+
+    assert update_pr_channel_announcement_for_event(
+        event, storage, discord_writer, policy, config, "AOSSIE-Org"
+    )
+    assert len(discord_writer.messages_edited) == 1
+    channel_id, message_id, content = discord_writer.messages_edited[0]
+    assert channel_id == "chan-1"
+    assert message_id == "msg-9"
+    assert "Merged:" in content
+    assert "Merged by @mentor1" in content
+    assert storage.get_pr_channel_announcement("Gitcord-GithubDiscordBot", 42)["status"] == "merged"
+
+
+def test_update_pr_channel_announcement_edits_on_close() -> None:
+    storage = MockStorage()
+    discord_writer = MockDiscordWriter()
+    storage.save_pr_channel_announcement(
+        repo="MiniChain",
+        pr_number=7,
+        channel_id="chan-2",
+        message_id="msg-2",
+        pr_title="WIP",
+        author_github="bob",
+        status="open",
+    )
+    config = NotificationConfig(enabled=True, update_pr_channel_on_lifecycle=True)
+    policy = MutationPolicy(mode=RunMode.ACTIVE, github_write_allowed=True, discord_write_allowed=True)
+    event = ContributionEvent(
+        github_user="bob",
+        event_type="pr_closed",
+        repo="MiniChain",
+        created_at=datetime.now(UTC),
+        payload={"pr_number": 7, "title": "WIP", "closed_by": "bob"},
+    )
+
+    assert update_pr_channel_announcement_for_event(
+        event, storage, discord_writer, policy, config, "StabilityNexus"
+    )
+    assert len(discord_writer.messages_edited) == 1
+    content = discord_writer.messages_edited[0][2]
+    assert "Closed:" in content
+    assert "Closed by @bob" in content
+
+
+def test_update_pr_channel_announcement_skips_untracked_old_messages() -> None:
+    storage = MockStorage()
+    discord_writer = MockDiscordWriter()
+    config = NotificationConfig(enabled=True, update_pr_channel_on_lifecycle=True)
+    policy = MutationPolicy(mode=RunMode.ACTIVE, github_write_allowed=True, discord_write_allowed=True)
+    event = ContributionEvent(
+        github_user="alice",
+        event_type="pr_merged",
+        repo="Gitcord-GithubDiscordBot",
+        created_at=datetime.now(UTC),
+        payload={"pr_number": 99, "title": "Old PR", "merged_by": "alice"},
+    )
+
+    assert (
+        update_pr_channel_announcement_for_event(
+            event, storage, discord_writer, policy, config, "AOSSIE-Org"
+        )
+        is False
+    )
+    assert discord_writer.messages_edited == []
+
+
+def test_sqlite_pr_channel_announcement_roundtrip(tmp_path) -> None:
+    storage = SqliteStorage(tmp_path / "state.db")
+    storage.init_schema()
+    storage.save_pr_channel_announcement(
+        repo="RepoA",
+        pr_number=3,
+        channel_id="c1",
+        message_id="m1",
+        pr_title="Hello",
+        author_github="alice",
+    )
+    row = storage.get_pr_channel_announcement("RepoA", 3)
+    assert row is not None
+    assert row["message_id"] == "m1"
+    assert storage.get_pr_channel_announcement("RepoA", 4) is None
+    storage.mark_pr_channel_announcement_status("RepoA", 3, "merged")
+    assert storage.get_pr_channel_announcement("RepoA", 3)["status"] == "merged"
 
 
 class MockGithubWriter:

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1153,7 +1153,9 @@ def test_update_pr_channel_announcement_edits_on_merge() -> None:
     channel_id, message_id, content, embeds = discord_writer.messages_edited[0]
     assert channel_id == "chan-1"
     assert message_id == "msg-9"
-    assert embeds and embeds[0]["color"] == 0x8250DF
+    assert content == ""
+    assert embeds
+    assert embeds[0]["color"] == 0x8250DF
     assert "Merged:" in embeds[0]["title"]
     assert "Merged by @mentor1" in embeds[0]["description"]
     assert storage.get_pr_channel_announcement("Gitcord-GithubDiscordBot", 42)["status"] == "merged"
@@ -1186,7 +1188,8 @@ def test_update_pr_channel_announcement_edits_on_close() -> None:
     )
     assert len(discord_writer.messages_edited) == 1
     embeds = discord_writer.messages_edited[0][3]
-    assert embeds and embeds[0]["color"] == 0xCF222E
+    assert embeds
+    assert embeds[0]["color"] == 0xCF222E
     assert "Closed:" in embeds[0]["title"]
     assert "Closed by @bob" in embeds[0]["description"]
 

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1216,6 +1216,47 @@ def test_update_pr_channel_announcement_skips_untracked_old_messages() -> None:
     assert discord_writer.messages_edited == []
 
 
+def test_update_pr_channel_announcement_releases_claim_when_status_mark_fails() -> None:
+    """If Discord edit succeeds but status persistence fails, release claim for retry."""
+    storage = MockStorage()
+    discord_writer = MockDiscordWriter()
+    storage.save_pr_channel_announcement(
+        repo="Gitcord-GithubDiscordBot",
+        pr_number=42,
+        channel_id="chan-1",
+        message_id="msg-9",
+        pr_title="Test PR",
+        author_github="alice",
+        status="open",
+    )
+
+    def _boom(repo: str, pr_number: int, status: str) -> None:
+        raise RuntimeError("db locked")
+
+    storage.mark_pr_channel_announcement_status = _boom  # type: ignore[method-assign]
+    config = NotificationConfig(enabled=True, update_pr_channel_on_lifecycle=True)
+    policy = MutationPolicy(mode=RunMode.ACTIVE, github_write_allowed=True, discord_write_allowed=True)
+    event = ContributionEvent(
+        github_user="alice",
+        event_type="pr_merged",
+        repo="Gitcord-GithubDiscordBot",
+        created_at=datetime.now(UTC),
+        payload={"pr_number": 42, "title": "Test PR", "merged_by": "mentor1"},
+    )
+
+    assert (
+        update_pr_channel_announcement_for_event(
+            event, storage, discord_writer, policy, config, "AOSSIE-Org"
+        )
+        is False
+    )
+    assert len(discord_writer.messages_edited) == 1
+    dedupe_key = "pr_channel_lifecycle:Gitcord-GithubDiscordBot:42:merged"
+    assert not storage.was_notification_sent(dedupe_key)
+    # Status stayed open so a later sync can retry mark after claim release.
+    assert storage.get_pr_channel_announcement("Gitcord-GithubDiscordBot", 42)["status"] == "open"
+
+
 def test_sqlite_pr_channel_announcement_roundtrip(tmp_path) -> None:
     storage = SqliteStorage(tmp_path / "state.db")
     storage.init_schema()

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -104,8 +104,15 @@ class MockDiscordWriter:
         self._next_message_id += 1
         return str(self._next_message_id)
 
-    def edit_message(self, channel_id: str, message_id: str, content: str) -> bool:
-        self.messages_edited.append((channel_id, message_id, content))
+    def edit_message(
+        self,
+        channel_id: str,
+        message_id: str,
+        content: str,
+        *,
+        embeds: list[dict] | None = None,
+    ) -> bool:
+        self.messages_edited.append((channel_id, message_id, content, embeds))
         return True
 
 
@@ -1143,11 +1150,12 @@ def test_update_pr_channel_announcement_edits_on_merge() -> None:
         event, storage, discord_writer, policy, config, "AOSSIE-Org"
     )
     assert len(discord_writer.messages_edited) == 1
-    channel_id, message_id, content = discord_writer.messages_edited[0]
+    channel_id, message_id, content, embeds = discord_writer.messages_edited[0]
     assert channel_id == "chan-1"
     assert message_id == "msg-9"
-    assert "Merged:" in content
-    assert "Merged by @mentor1" in content
+    assert embeds and embeds[0]["color"] == 0x8250DF
+    assert "Merged:" in embeds[0]["title"]
+    assert "Merged by @mentor1" in embeds[0]["description"]
     assert storage.get_pr_channel_announcement("Gitcord-GithubDiscordBot", 42)["status"] == "merged"
 
 
@@ -1177,9 +1185,10 @@ def test_update_pr_channel_announcement_edits_on_close() -> None:
         event, storage, discord_writer, policy, config, "StabilityNexus"
     )
     assert len(discord_writer.messages_edited) == 1
-    content = discord_writer.messages_edited[0][2]
-    assert "Closed:" in content
-    assert "Closed by @bob" in content
+    embeds = discord_writer.messages_edited[0][3]
+    assert embeds and embeds[0]["color"] == 0xCF222E
+    assert "Closed:" in embeds[0]["title"]
+    assert "Closed by @bob" in embeds[0]["description"]
 
 
 def test_update_pr_channel_announcement_skips_untracked_old_messages() -> None:


### PR DESCRIPTION
## Summary
- When Gitcord posts a PR-opened message to a mapped Discord channel, it now stores the Discord `message_id` (new SQLite table; **no backfill** of older announcements).
- On later `pr_merged` / `pr_closed`, that same message is edited in place to show merged/closed status with `@github_username`.
- Untracked/old channel messages are left unchanged. DMs for merge/close still work as before.
- Config flag: `notifications.update_pr_channel_on_lifecycle` (default `true`; safe because only tracked future posts are edited).

## Test plan
- [x] `pytest tests/test_notifications.py` (and related lifecycle tests)
- [x] ruff on touched files
- [ ] Deploy/restart bot + scheduler
- [ ] Open a new mapped-repo PR → channel announcement appears
- [ ] Merge that PR → same Discord message updates to `Merged by @...`
- [ ] Close another tracked PR without merge → same message updates to `Closed by @...`
- [ ] Confirm an older pre-feature channel announcement is not edited


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - PR announcements in Discord can now be updated when a pull request is merged or closed.
  - Updated announcements identify who merged or closed the pull request.
  - Added support for rich embeds and link-preview control.
  - Added a setting to enable or disable lifecycle updates, enabled by default.
  - Review comments from the same reviewer are now consolidated more reliably.

- **Bug Fixes**
  - Improved handling of empty, failed, or invalid Discord message responses.
  - Untracked announcements are safely skipped during lifecycle updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->