### PR TITLE
fix: stop comment-only review DMs; coalesce result notifications

### DIFF
--- a/config/aussie.yaml
+++ b/config/aussie.yaml
@@ -75,7 +75,7 @@ discord:
     issue_assignment: false          # Off: avoids DM flood from assignment events (use /assign-issue manually)
     pr_review_requested: true
     pr_review_result: true
-    pr_review_comment: true
+    pr_review_comment: false
     pr_merged: true
     pr_closed: true
     issue_reopened: true

--- a/config/examples/aussie-first-sync.yaml
+++ b/config/examples/aussie-first-sync.yaml
@@ -57,7 +57,7 @@ discord:
     issue_assignment: true
     pr_review_requested: true
     pr_review_result: true
-    pr_review_comment: true
+    pr_review_comment: false
     pr_merged: true
     pr_closed: true
     issue_reopened: true

--- a/config/examples/aussie.yaml
+++ b/config/examples/aussie.yaml
@@ -53,7 +53,7 @@ discord:
     issue_assignment: true           # 📋 Issue assigned to a user
     pr_review_requested: true        # 👀 Reviewer requested on a PR
     pr_review_result: true           # ✅ PR approved or 🔁 changes requested
-    pr_review_comment: true          # 💬 Comment posted on PR review
+    pr_review_comment: false         # 💬 Off: comment-only reviews are too noisy for DMs
     pr_merged: true                  # 🎉 PR merged to main
     pr_closed: true                  # 🚫 PR closed without merge
     issue_reopened: true             # 📌 Issue reopened

--- a/config/examples/remote-gitcord-aossie.yaml
+++ b/config/examples/remote-gitcord-aossie.yaml
@@ -83,7 +83,7 @@ discord:
     issue_assignment: false
     pr_review_requested: true
     pr_review_result: true
-    pr_review_comment: true
+    pr_review_comment: false
     pr_merged: true
     pr_closed: true
     issue_reopened: true

--- a/config/examples/remote-gitcord-stability-nexus.yaml
+++ b/config/examples/remote-gitcord-stability-nexus.yaml
@@ -96,7 +96,7 @@ discord:
     issue_assignment: false
     pr_review_requested: true
     pr_review_result: true
-    pr_review_comment: true
+    pr_review_comment: false
     pr_merged: true
     pr_closed: true
     issue_reopened: true

--- a/src/ghdcbot/config/models.py
+++ b/src/ghdcbot/config/models.py
@@ -84,7 +84,9 @@ class NotificationConfig(BaseModel):
     issue_assignment: bool = True
     pr_review_requested: bool = True
     pr_review_result: bool = True  # APPROVED / CHANGES_REQUESTED
-    pr_review_comment: bool = True  # COMMENT reviews on a PR
+    # Off by default: GitHub review "comments" (incl. CodeRabbit rounds and author
+    # replies) are too noisy for Discord DMs. Use pr_review_result for signal.
+    pr_review_comment: bool = False
     pr_merged: bool = True
     pr_closed: bool = True  # PR closed without merge
     issue_reopened: bool = True  # Issue reopened (notifies assignee)

--- a/src/ghdcbot/config/models.py
+++ b/src/ghdcbot/config/models.py
@@ -84,8 +84,8 @@ class NotificationConfig(BaseModel):
     issue_assignment: bool = True
     pr_review_requested: bool = True
     pr_review_result: bool = True  # APPROVED / CHANGES_REQUESTED
-    # Off by default: GitHub review "comments" (incl. CodeRabbit rounds and author
-    # replies) are too noisy for Discord DMs. Use pr_review_result for signal.
+    # Ignored at runtime: comment-only review DMs are always skipped in the
+    # notification engine (too noisy). Kept for backward-compatible YAML.
     pr_review_comment: bool = False
     pr_merged: bool = True
     pr_closed: bool = True  # PR closed without merge

--- a/src/ghdcbot/engine/notifications.py
+++ b/src/ghdcbot/engine/notifications.py
@@ -59,10 +59,19 @@ def send_notification_for_event(
             # Notify PR author, not reviewer
             target_github_user = event.payload.get("pr_author")
         elif state in ("COMMENT", "COMMENTED"):
-            if not config.pr_review_comment:
-                return False
-            event_type_key = "pr_review_comment"
-            target_github_user = event.payload.get("pr_author")
+            # Never DM for comment-only reviews (CodeRabbit rounds, inline chatter).
+            # Signal stays on CHANGES_REQUESTED / APPROVED via pr_review_result.
+            # Config flag is ignored so a remote gitcord.yaml cannot re-enable spam.
+            logger.info(
+                "Skipping comment-only review notification (DMs disabled for COMMENT)",
+                extra={
+                    "pr_number": event.payload.get("pr_number"),
+                    "reviewer": event.github_user,
+                    "pr_author": event.payload.get("pr_author"),
+                    "repo": event.repo,
+                },
+            )
+            return False
         else:
             # DISMISSED or other states - no notification
             logger.debug(

--- a/src/ghdcbot/engine/notifications.py
+++ b/src/ghdcbot/engine/notifications.py
@@ -103,7 +103,26 @@ def send_notification_for_event(
             extra={"event_type": event.event_type, "payload": event.payload, "event_github_user": event.github_user},
         )
         return False
-    
+
+    # Author replies on their own PR often appear as COMMENTED "reviews" in the
+    # GitHub API. Never DM the author that they reviewed their own PR.
+    if event.event_type == "pr_reviewed":
+        reviewer_key = (event.github_user or "").strip().lower()
+        author_key = (target_github_user or "").strip().lower()
+        if reviewer_key and author_key and reviewer_key == author_key:
+            logger.info(
+                "Skipping self-review notification",
+                extra={
+                    "github_user": event.github_user,
+                    "pr_author": target_github_user,
+                    "repo": event.repo,
+                    "pr_number": event.payload.get("pr_number"),
+                    "review_id": event.payload.get("review_id"),
+                    "review_state": event.payload.get("state"),
+                },
+            )
+            return False
+
     # Resolve GitHub user to Discord user (verified only)
     discord_user_id = _resolve_github_to_discord(storage, target_github_user)
     if not discord_user_id:

--- a/src/ghdcbot/engine/notifications.py
+++ b/src/ghdcbot/engine/notifications.py
@@ -415,17 +415,22 @@ def _resolve_github_to_discord(storage: Storage, github_user: str) -> str | None
 
 def _build_dedupe_key(event: ContributionEvent, target_github_user: str) -> str:
     """Build deduplication key: event_type:repo:target:target_github_user (lowercase for case-insensitivity).
-    
-    For pr_reviewed events, includes review_id to allow multiple notifications for different reviews.
+
+    For pr_reviewed COMMENT/COMMENTED events, coalesce by reviewer (not review_id) so
+    bots like CodeRabbit that submit many review rounds on one PR only DM once.
+    APPROVED / CHANGES_REQUESTED still include review_id so distinct reviews notify.
     """
     target = event.payload.get("issue_number") or event.payload.get("pr_number") or "unknown"
     # Use target_github_user (who receives notification) for dedupe; normalize to lowercase (GitHub is case-insensitive)
     user_key = (target_github_user or "").strip().lower()
-    
-    # For pr_reviewed events, include review_id and state to allow separate notifications for different reviews
+
     if event.event_type == "pr_reviewed":
+        state = (event.payload.get("state") or "").upper()
+        reviewer = (event.github_user or "").strip().lower() or "unknown"
+        # Comment-only reviews: one DM per reviewer per PR (stops CodeRabbit spam).
+        if state in {"COMMENT", "COMMENTED"}:
+            return f"{event.event_type}:{event.repo}:{target}:{user_key}:{reviewer}:COMMENT"
         review_id = event.payload.get("review_id")
-        state = event.payload.get("state", "").upper()
         if review_id:
             return f"{event.event_type}:{event.repo}:{target}:{user_key}:{review_id}:{state}"
 
@@ -436,7 +441,7 @@ def _build_dedupe_key(event: ContributionEvent, target_github_user: str) -> str:
     if event.event_type in {"issue_reopened", "pr_reopened"}:
         reopened_at = event.payload.get("reopened_at") or event.created_at.isoformat()
         return f"{event.event_type}:{event.repo}:{target}:{user_key}:{reopened_at}"
-    
+
     return f"{event.event_type}:{event.repo}:{target}:{user_key}"
 
 

--- a/src/ghdcbot/engine/notifications.py
+++ b/src/ghdcbot/engine/notifications.py
@@ -435,9 +435,8 @@ def _resolve_github_to_discord(storage: Storage, github_user: str) -> str | None
 def _build_dedupe_key(event: ContributionEvent, target_github_user: str) -> str:
     """Build deduplication key: event_type:repo:target:target_github_user (lowercase for case-insensitivity).
 
-    For pr_reviewed COMMENT/COMMENTED events, coalesce by reviewer (not review_id) so
-    bots like CodeRabbit that submit many review rounds on one PR only DM once.
-    APPROVED / CHANGES_REQUESTED still include review_id so distinct reviews notify.
+    For all pr_reviewed states, coalesce by reviewer + state (not review_id) so many
+    messages/review rounds from the same reviewer only produce one DM per state.
     """
     target = event.payload.get("issue_number") or event.payload.get("pr_number") or "unknown"
     # Use target_github_user (who receives notification) for dedupe; normalize to lowercase (GitHub is case-insensitive)
@@ -446,12 +445,11 @@ def _build_dedupe_key(event: ContributionEvent, target_github_user: str) -> str:
     if event.event_type == "pr_reviewed":
         state = (event.payload.get("state") or "").upper()
         reviewer = (event.github_user or "").strip().lower() or "unknown"
-        # Comment-only reviews: one DM per reviewer per PR (stops CodeRabbit spam).
+        # Normalize GitHub's COMMENTED → COMMENT for a stable key.
         if state in {"COMMENT", "COMMENTED"}:
-            return f"{event.event_type}:{event.repo}:{target}:{user_key}:{reviewer}:COMMENT"
-        review_id = event.payload.get("review_id")
-        if review_id:
-            return f"{event.event_type}:{event.repo}:{target}:{user_key}:{review_id}:{state}"
+            state = "COMMENT"
+        if state:
+            return f"{event.event_type}:{event.repo}:{target}:{user_key}:{reviewer}:{state}"
 
     if event.event_type == "pr_closed":
         closed_at = event.payload.get("closed_at") or event.created_at.isoformat()

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -510,7 +510,7 @@ def test_send_notification_pr_reviewed_approved() -> None:
 
 
 def test_send_notification_pr_reviewed_comment() -> None:
-    """Test notification for PR review comments when enabled."""
+    """Comment-only reviews never DM, even when pr_review_comment is true."""
     storage = MockStorage()
     storage.verified_mappings = [
         {"discord_user_id": "discord123", "github_user": "contributor"},
@@ -537,10 +537,8 @@ def test_send_notification_pr_reviewed_comment() -> None:
         event, storage, discord_writer, policy, config, "test-org"
     )
 
-    assert result is True
-    assert len(discord_writer.dms_sent) == 1
-    assert "New Review Comments" in discord_writer.dms_sent[0][1]
-    assert "reviewer" in discord_writer.dms_sent[0][1]
+    assert result is False
+    assert discord_writer.dms_sent == []
 
 
 def test_send_notification_skips_self_review_comment() -> None:
@@ -640,7 +638,7 @@ def test_send_notification_pr_reviewed_comment_dedupe() -> None:
 
 
 def test_pr_review_comment_coalesces_multiple_review_ids_from_same_reviewer() -> None:
-    """CodeRabbit-style spam: many COMMENT reviews on one PR → one DM."""
+    """Comment-only reviews are hard-disabled; no DMs even across many review_ids."""
     storage = MockStorage()
     storage.verified_mappings = [
         {"discord_user_id": "discord123", "github_user": "contributor"},
@@ -665,15 +663,11 @@ def test_pr_review_comment_coalesces_multiple_review_ids_from_same_reviewer() ->
 
     assert send_notification_for_event(
         _event(1001), storage, discord_writer, policy, config, "AOSSIE-Org"
-    )
+    ) is False
     assert send_notification_for_event(
         _event(1002), storage, discord_writer, policy, config, "AOSSIE-Org"
     ) is False
-    assert send_notification_for_event(
-        _event(1003), storage, discord_writer, policy, config, "AOSSIE-Org"
-    ) is False
-    assert len(discord_writer.dms_sent) == 1
-    assert "New Review Comments" in discord_writer.dms_sent[0][1]
+    assert discord_writer.dms_sent == []
 
 
 def test_changes_requested_coalesces_multiple_reviews_from_same_reviewer() -> None:

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -581,7 +581,7 @@ def test_send_notification_pr_reviewed_comment_dedupe() -> None:
         {"discord_user_id": "discord123", "github_user": "contributor"},
     ]
     storage.notifications_sent.add(
-        "pr_reviewed:test-repo:456:contributor:9001:COMMENT"
+        "pr_reviewed:test-repo:456:contributor:reviewer:COMMENT"
     )
     discord_writer = MockDiscordWriter()
     config = NotificationConfig(enabled=True, pr_review_comment=True)
@@ -606,6 +606,69 @@ def test_send_notification_pr_reviewed_comment_dedupe() -> None:
 
     assert result is False
     assert len(discord_writer.dms_sent) == 0
+
+
+def test_pr_review_comment_coalesces_multiple_review_ids_from_same_reviewer() -> None:
+    """CodeRabbit-style spam: many COMMENT reviews on one PR → one DM."""
+    storage = MockStorage()
+    storage.verified_mappings = [
+        {"discord_user_id": "discord123", "github_user": "contributor"},
+    ]
+    discord_writer = MockDiscordWriter()
+    config = NotificationConfig(enabled=True, pr_review_comment=True)
+    policy = MutationPolicy(mode=RunMode.ACTIVE, github_write_allowed=True, discord_write_allowed=True)
+
+    def _event(review_id: int) -> ContributionEvent:
+        return ContributionEvent(
+            github_user="coderabbitai[bot]",
+            event_type="pr_reviewed",
+            repo="Gitcord-GithubDiscordBot",
+            created_at=datetime.now(UTC),
+            payload={
+                "pr_number": 56,
+                "state": "COMMENTED",
+                "pr_author": "contributor",
+                "review_id": review_id,
+            },
+        )
+
+    assert send_notification_for_event(
+        _event(1001), storage, discord_writer, policy, config, "AOSSIE-Org"
+    )
+    assert send_notification_for_event(
+        _event(1002), storage, discord_writer, policy, config, "AOSSIE-Org"
+    ) is False
+    assert send_notification_for_event(
+        _event(1003), storage, discord_writer, policy, config, "AOSSIE-Org"
+    ) is False
+    assert len(discord_writer.dms_sent) == 1
+    assert "New Review Comments" in discord_writer.dms_sent[0][1]
+
+
+def test_build_dedupe_key_comment_reviews_ignore_review_id() -> None:
+    base = {
+        "pr_number": 56,
+        "state": "COMMENT",
+        "pr_author": "contributor",
+    }
+    e1 = ContributionEvent(
+        github_user="coderabbitai[bot]",
+        event_type="pr_reviewed",
+        repo="r",
+        created_at=datetime.now(UTC),
+        payload={**base, "review_id": 1},
+    )
+    e2 = ContributionEvent(
+        github_user="coderabbitai[bot]",
+        event_type="pr_reviewed",
+        repo="r",
+        created_at=datetime.now(UTC),
+        payload={**base, "review_id": 2, "state": "COMMENTED"},
+    )
+    key1 = _build_dedupe_key(e1, "contributor")
+    key2 = _build_dedupe_key(e2, "contributor")
+    assert key1 == key2
+    assert key1 == "pr_reviewed:r:56:contributor:coderabbitai[bot]:COMMENT"
 
 
 def test_send_notification_channel_mode() -> None:

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -543,6 +543,37 @@ def test_send_notification_pr_reviewed_comment() -> None:
     assert "reviewer" in discord_writer.dms_sent[0][1]
 
 
+def test_send_notification_skips_self_review_comment() -> None:
+    """PR author replies show up as COMMENTED reviews — do not DM them as reviewer."""
+    storage = MockStorage()
+    storage.verified_mappings = [
+        {"discord_user_id": "discord123", "github_user": "Sashang-debug"},
+    ]
+    discord_writer = MockDiscordWriter()
+    config = NotificationConfig(enabled=True, pr_review_comment=True)
+    policy = MutationPolicy(mode=RunMode.ACTIVE, github_write_allowed=True, discord_write_allowed=True)
+
+    event = ContributionEvent(
+        github_user="Sashang-debug",
+        event_type="pr_reviewed",
+        repo="Gitcord-GithubDiscordBot",
+        created_at=datetime.now(UTC),
+        payload={
+            "pr_number": 51,
+            "state": "COMMENTED",
+            "pr_author": "sashang-debug",  # case differs from github_user
+            "review_id": 4999427982,
+        },
+    )
+
+    result = send_notification_for_event(
+        event, storage, discord_writer, policy, config, "AOSSIE-Org"
+    )
+
+    assert result is False
+    assert discord_writer.dms_sent == []
+
+
 def test_send_notification_pr_reviewed_comment_disabled() -> None:
     """Test that COMMENT reviews are skipped when pr_review_comment is false."""
     storage = MockStorage()

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -676,6 +676,40 @@ def test_pr_review_comment_coalesces_multiple_review_ids_from_same_reviewer() ->
     assert "New Review Comments" in discord_writer.dms_sent[0][1]
 
 
+def test_changes_requested_coalesces_multiple_reviews_from_same_reviewer() -> None:
+    """Many CHANGES_REQUESTED rounds / messages from one reviewer → one DM."""
+    storage = MockStorage()
+    storage.verified_mappings = [
+        {"discord_user_id": "discord123", "github_user": "contributor"},
+    ]
+    discord_writer = MockDiscordWriter()
+    config = NotificationConfig(enabled=True, pr_review_result=True)
+    policy = MutationPolicy(mode=RunMode.ACTIVE, github_write_allowed=True, discord_write_allowed=True)
+
+    def _event(review_id: int) -> ContributionEvent:
+        return ContributionEvent(
+            github_user="mentor1",
+            event_type="pr_reviewed",
+            repo="Gitcord-GithubDiscordBot",
+            created_at=datetime.now(UTC),
+            payload={
+                "pr_number": 56,
+                "state": "CHANGES_REQUESTED",
+                "pr_author": "contributor",
+                "review_id": review_id,
+            },
+        )
+
+    assert send_notification_for_event(
+        _event(2001), storage, discord_writer, policy, config, "AOSSIE-Org"
+    )
+    assert send_notification_for_event(
+        _event(2002), storage, discord_writer, policy, config, "AOSSIE-Org"
+    ) is False
+    assert len(discord_writer.dms_sent) == 1
+    assert "Changes Requested" in discord_writer.dms_sent[0][1]
+
+
 def test_build_dedupe_key_comment_reviews_ignore_review_id() -> None:
     base = {
         "pr_number": 56,


### PR DESCRIPTION
## Summary
- Hard-disable Discord DMs for comment-only PR reviews (CodeRabbit rounds, chatter, author replies) — remote `pr_review_comment: true` cannot re-enable them
- Keep **changes requested** / **approved** DMs, coalesced to **one per reviewer per PR**
- Skip self-review DMs when the PR author appears as the reviewer

Split out of #56 (channel announcement edits) so that feature stays scoped.

## Test plan
- [x] `pytest tests/test_notifications.py`
- [x] Sync after a CodeRabbit COMMENT review → no contributor DM
- [x] Reviewer requests changes twice → one DM
- [x] Author reply on own PR → no self-review DM

Made with [Cursor](https://cursor.com)