### PR TITLE
fix: skip bot-authored PRs for channel open announcements

### DIFF
--- a/src/ghdcbot/engine/notifications.py
+++ b/src/ghdcbot/engine/notifications.py
@@ -212,7 +212,7 @@ def send_pr_opened_channel_notification(
         return False
 
     author_github = event.github_user
-    if not author_github:
+    if not author_github or _is_github_bot_login(author_github):
         return False
 
     discord_user_id = _resolve_github_to_discord(storage, author_github)

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1151,6 +1151,26 @@ def test_pr_opened_channel_notification_skips_when_pr_opened_disabled() -> None:
     assert discord_writer.messages_sent == []
 
 
+def test_pr_opened_channel_notification_skips_bots() -> None:
+    storage = MockStorage()
+    discord_writer = MockDiscordWriter()
+    config = NotificationConfig(enabled=True, pr_opened=True)
+    policy = MutationPolicy(mode=RunMode.ACTIVE, github_write_allowed=True, discord_write_allowed=True)
+
+    result = send_pr_opened_channel_notification(
+        _pr_opened_event(github_user="dependabot[bot]"),
+        storage,
+        discord_writer,
+        policy,
+        config,
+        {"Gitcord-GithubDiscordBot": "1465995983791063140"},
+        "AOSSIE-Org",
+    )
+
+    assert result is False
+    assert discord_writer.messages == []
+
+
 def test_pr_opened_channel_notification_posts_unverified_author() -> None:
     storage = MockStorage()
     storage.verified_mappings = []

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1168,7 +1168,7 @@ def test_pr_opened_channel_notification_skips_bots() -> None:
     )
 
     assert result is False
-    assert discord_writer.messages == []
+    assert discord_writer.messages_sent == []
 
 
 def test_pr_opened_channel_notification_posts_unverified_author() -> None:


### PR DESCRIPTION
## Summary
- Skip `pr_opened` Discord channel announcements for GitHub bot accounts (e.g. `dependabot[bot]`)
- Reuses the existing `_is_github_bot_login` helper already used for GitHub link-nudge comments
- Adds unit test coverage for the skip behavior

## Context
Dependabot dependency PRs were flooding repo-mapped Discord channels with open-PR posts and `/link` nudge text.

## Test plan
- [x] Added `test_pr_opened_channel_notification_skips_bots`
- [ ] CI pytest green
- [ ] Confirm next dependabot PR does not post to mapped channel


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * PRs opened by GitHub bot accounts no longer generate Discord channel announcements.

* **Tests**
  * Added coverage to verify bot-authored PR notifications are skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->