### PR TITLE
feat: add mentor /help-link for assisted identity linking

### DIFF
--- a/QUICK_START_GUIDE.txt
+++ b/QUICK_START_GUIDE.txt
@@ -37,10 +37,12 @@ Tips:
 /unlink               Remove your GitHub link
 
 
-3. MENTOR COMMAND
------------------
+3. MENTOR COMMANDS
+------------------
 /sync                 Manually sync GitHub events and send notifications
-                      (requires a mentor role from discord.command_permissions)
+/help-link @member    Help a stuck contributor: they get Start linking →
+                      username box → same verify steps as /link
+                      (both require a mentor role from discord.command_permissions)
 
 
 4. WHAT HAPPENS AFTER YOU VERIFY

--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ Contributor-facing cheat sheet: [`QUICK_START_GUIDE.txt`](QUICK_START_GUIDE.txt)
 
 - `/link` - Link your Discord account to GitHub (creates verification code)
 - `/verify-link` - Verify your GitHub link after adding code to bio/gist
+- `/help-link` - Mentor-only: help a tagged Discord member start the private linking flow
 - `/profile` - Show contributor profile (GitHub, verification, socials, roles); optional Discord member
 - `/who-is` - Look up a GitHub username, find the verified Discord account, and see whether verification is current or stale
 - `/unlink` - Unlink your GitHub identity
@@ -301,7 +302,7 @@ Contributor-facing cheat sheet: [`QUICK_START_GUIDE.txt`](QUICK_START_GUIDE.txt)
 
 - `/sync` - Manually sync GitHub events and send notifications
 
-**Note:** `/sync` requires a mentor role configured in `discord.command_permissions`. The bot can also auto-detect PR URLs in configured channels and post passive previews.
+**Note:** `/sync` and `/help-link` require a mentor role configured in `discord.command_permissions`. The bot can also auto-detect PR URLs in configured channels and post passive previews.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ Contributor-facing cheat sheet: [`QUICK_START_GUIDE.txt`](QUICK_START_GUIDE.txt)
 
 - `/link` - Link your Discord account to GitHub (creates verification code)
 - `/verify-link` - Verify your GitHub link after adding code to bio/gist
-- `/help-link` - Mentor-only: help a tagged Discord member start the private linking flow
+- `/help-link` - Mentor-only: help a tagged Discord member start the linking flow (DM preferred; channel fallback is visible but target-only)
 - `/profile` - Show contributor profile (GitHub, verification, socials, roles); optional Discord member
 - `/who-is` - Look up a GitHub username, find the verified Discord account, and see whether verification is current or stale
 - `/unlink` - Unlink your GitHub identity

--- a/config/examples/remote-gitcord-aossie.yaml
+++ b/config/examples/remote-gitcord-aossie.yaml
@@ -60,6 +60,10 @@ discord:
       role_names:
       - Mentor
       allow_discord_administrators: true
+    help-link:
+      role_names:
+      - Mentor
+      allow_discord_administrators: true
   activity_channel_id: null
   pr_preview_channels: []
   pr_open_channels:

--- a/config/examples/remote-gitcord-stability-nexus.yaml
+++ b/config/examples/remote-gitcord-stability-nexus.yaml
@@ -60,6 +60,10 @@ discord:
       role_names:
       - Mentor
       allow_discord_administrators: true
+    help-link:
+      role_names:
+      - Mentor
+      allow_discord_administrators: true
   activity_channel_id: null
   pr_preview_channels: []
   pr_open_channels:

--- a/docs/IDENTITY_VERIFICATION.md
+++ b/docs/IDENTITY_VERIFICATION.md
@@ -17,16 +17,20 @@ The project uses a lightweight verification-code flow instead of OAuth:
 
 The older `/verify-link github_username` command remains available and uses the same verification logic.
 
+Mentors can also start the same flow for a stuck contributor with `/help-link @member` (mentor-gated). That opens a private **Start linking** button (DM preferred, channel fallback), then a username modal, then the same verification embed/buttons as `/link`.
+
 ## Main Files
 
 | File | Purpose |
 | --- | --- |
-| `src/ghdcbot/bot.py` | Discord slash commands and identity verification buttons: `/link`, `/verify-link`, `/profile`, `/unlink`. |
+| `src/ghdcbot/bot.py` | Discord slash commands and identity verification buttons: `/link`, `/verify-link`, `/help-link`, `/profile`, `/unlink`. |
+| `src/ghdcbot/help_link.py` | Mentor `/help-link` sessions, Start linking button, username modal, DM/channel delivery. |
 | `src/ghdcbot/engine/identity_linking.py` | Business logic for creating claims, verifying claims, generating codes, audit events, and unlinking. |
 | `src/ghdcbot/adapters/github/identity.py` | Read-only GitHub adapter that searches the user's bio and public gists for the code. |
 | `src/ghdcbot/adapters/storage/sqlite.py` | SQLite schema and persistence for pending and verified identity links. |
 | `src/ghdcbot/cli.py` | CLI version of the same `link` and `verify-link` workflow. |
 | `tests/test_identity_linking.py` | Tests covering code generation, verification, impersonation protection, stale refresh, unlinking, and status. |
+| `tests/test_help_link.py` | Tests for mentor help sessions, Start button gating, modal claim creation, and DM/channel delivery. |
 
 ## High-Level Flow
 

--- a/docs/IDENTITY_VERIFICATION.md
+++ b/docs/IDENTITY_VERIFICATION.md
@@ -17,7 +17,7 @@ The project uses a lightweight verification-code flow instead of OAuth:
 
 The older `/verify-link github_username` command remains available and uses the same verification logic.
 
-Mentors can also start the same flow for a stuck contributor with `/help-link @member` (mentor-gated). That opens a private **Start linking** button (DM preferred, channel fallback), then a username modal, then the same verification embed/buttons as `/link`.
+Mentors can also start the same flow for a stuck contributor with `/help-link @member` (mentor-gated). That opens a **target-only** **Start linking** button (DM preferred; if DMs are closed, a channel message that others can see but only the tagged member can use), then a username modal, then the same verification embed/buttons as `/link`.
 
 ## Main Files
 

--- a/src/ghdcbot/bot.py
+++ b/src/ghdcbot/bot.py
@@ -872,7 +872,7 @@ def run_bot(config_path: str) -> None:
 
     @tree.command(
         name=SLASH_CMD_HELP_LINK,
-        description="Help a contributor link GitHub (mentor-only; opens private Start linking)",
+        description="Help a contributor link GitHub (mentor-only; target-only Start linking)",
         guild=discord.Object(id=guild_id),
     )
     @app_commands.describe(contributor="Discord member who needs help linking GitHub")
@@ -896,7 +896,7 @@ def run_bot(config_path: str) -> None:
         if getattr(config, "identity", None) is not None:
             max_age_days = getattr(config.identity, "verified_max_age_days", None)
 
-        help_link_sessions.create(
+        session = help_link_sessions.create(
             mentor_discord_id=mentor_id,
             target_discord_id=target_id,
         )
@@ -905,6 +905,7 @@ def run_bot(config_path: str) -> None:
             storage=storage,
             target_discord_id=target_id,
             mentor_discord_id=mentor_id,
+            session_id=session.session_id,
             profile_settings_url=profile_settings_url,
             verification_view_factory=IdentityVerificationView,
             build_verification_embed=build_identity_verification_embed,
@@ -919,7 +920,7 @@ def run_bot(config_path: str) -> None:
                 view=view,
             )
         except Exception:
-            help_link_sessions.clear(target_id)
+            help_link_sessions.clear_if_match(target_id, session.session_id)
             logger.exception("help-link delivery failed")
             await interaction.followup.send(
                 "❌ Could not start linking help. Please try again.",

--- a/src/ghdcbot/bot.py
+++ b/src/ghdcbot/bot.py
@@ -49,9 +49,16 @@ from ghdcbot.discord_command_permissions import (
 )
 from ghdcbot.adapters.discord.social_commands import register_social_commands
 from ghdcbot.engine.social_profiles import SocialProfileService
+from ghdcbot.help_link import (
+    HELP_LINK_COMMAND_NAME,
+    HelpLinkSessionStore,
+    HelpLinkStartView,
+    deliver_help_link_prompt,
+)
 
 # Slash command names used for permission checks (must match @tree.command name=...)
 SLASH_CMD_SYNC = "sync"
+SLASH_CMD_HELP_LINK = HELP_LINK_COMMAND_NAME
 
 VERIFICATION_CODE_REMOVAL_NOTE = (
     "You may now safely remove the verification code from your GitHub bio. "
@@ -301,7 +308,7 @@ class IdentityVerificationView(discord.ui.View):
 
 
 def run_bot(config_path: str) -> None:
-    """Run the Discord bot with /link, /verify-link, /profile, /identity status, and /summary."""
+    """Run the Discord bot with /link, /verify-link, /help-link, /profile, and /summary."""
     config = load_config(config_path)
     configure_logging(config.runtime.log_level)
     logger = logging.getLogger("ghdcbot.bot")
@@ -310,6 +317,7 @@ def run_bot(config_path: str) -> None:
         config_path,
         config.runtime.data_dir,
     )
+    help_link_sessions = HelpLinkSessionStore()
     repo_contributor_roles = getattr(config, "repo_contributor_roles", None) or {}
     if repo_contributor_roles:
         logger.info(
@@ -861,6 +869,65 @@ def run_bot(config_path: str) -> None:
             return slash_command_allowed(interaction, config, command_name)
 
         return check
+
+    @tree.command(
+        name=SLASH_CMD_HELP_LINK,
+        description="Help a contributor link GitHub (mentor-only; opens private Start linking)",
+        guild=discord.Object(id=guild_id),
+    )
+    @app_commands.describe(contributor="Discord member who needs help linking GitHub")
+    @app_commands.check(command_permission_check(SLASH_CMD_HELP_LINK))
+    @app_commands.checks.cooldown(1, 15.0, key=lambda i: (i.guild_id, i.user.id))
+    async def help_link_cmd(
+        interaction: discord.Interaction, contributor: discord.Member
+    ) -> None:
+        await interaction.response.defer(ephemeral=True)
+
+        if contributor.bot:
+            await interaction.followup.send(
+                "❌ Cannot help link a bot account.",
+                ephemeral=True,
+            )
+            return
+
+        target_id = str(contributor.id)
+        mentor_id = str(interaction.user.id)
+        max_age_days = None
+        if getattr(config, "identity", None) is not None:
+            max_age_days = getattr(config.identity, "verified_max_age_days", None)
+
+        help_link_sessions.create(
+            mentor_discord_id=mentor_id,
+            target_discord_id=target_id,
+        )
+        view = HelpLinkStartView(
+            service=service,
+            storage=storage,
+            target_discord_id=target_id,
+            mentor_discord_id=mentor_id,
+            profile_settings_url=profile_settings_url,
+            verification_view_factory=IdentityVerificationView,
+            build_verification_embed=build_identity_verification_embed,
+            session_store=help_link_sessions,
+            max_age_days=max_age_days,
+        )
+        try:
+            status = await deliver_help_link_prompt(
+                interaction=interaction,
+                contributor=contributor,
+                mentor=interaction.user,
+                view=view,
+            )
+        except Exception:
+            help_link_sessions.clear(target_id)
+            logger.exception("help-link delivery failed")
+            await interaction.followup.send(
+                "❌ Could not start linking help. Please try again.",
+                ephemeral=True,
+            )
+            return
+
+        await interaction.followup.send(status, ephemeral=True)
 
     @client.event
     async def on_message(message: discord.Message) -> None:

--- a/src/ghdcbot/config/models.py
+++ b/src/ghdcbot/config/models.py
@@ -67,7 +67,7 @@ class GitHubConfig(BaseModel):
 
 
 class SlashCommandPermissionRule(BaseModel):
-    """Who may run a restricted slash command (e.g. assign-issue, issue-requests, sync).
+    """Who may run a restricted slash command (e.g. assign-issue, issue-requests, sync, help-link).
 
     If a command is omitted from ``discord.command_permissions``, the bot falls back to
     ``assignments.issue_assignees`` (role name match), for backward compatibility.

--- a/src/ghdcbot/help_link.py
+++ b/src/ghdcbot/help_link.py
@@ -1,0 +1,275 @@
+"""Mentor-assisted identity linking: /help-link → private Start button → modal → /link verify UI."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any, Callable
+
+import discord
+
+logger = logging.getLogger("ghdcbot.help_link")
+
+HELP_LINK_SESSION_TTL = timedelta(minutes=20)
+HELP_LINK_COMMAND_NAME = "help-link"
+
+
+@dataclass(frozen=True)
+class HelpLinkSession:
+    """Short-lived mentor→contributor help session."""
+
+    mentor_discord_id: str
+    target_discord_id: str
+    created_at: datetime
+    expires_at: datetime
+
+    def is_expired(self, now: datetime | None = None) -> bool:
+        now = now or datetime.now(timezone.utc)
+        return now >= self.expires_at
+
+
+class HelpLinkSessionStore:
+    """In-memory sessions (one active help flow per target Discord user)."""
+
+    def __init__(self, *, ttl: timedelta = HELP_LINK_SESSION_TTL) -> None:
+        self._ttl = ttl
+        self._by_target: dict[str, HelpLinkSession] = {}
+
+    def create(self, *, mentor_discord_id: str, target_discord_id: str) -> HelpLinkSession:
+        now = datetime.now(timezone.utc)
+        session = HelpLinkSession(
+            mentor_discord_id=str(mentor_discord_id),
+            target_discord_id=str(target_discord_id),
+            created_at=now,
+            expires_at=now + self._ttl,
+        )
+        self._by_target[session.target_discord_id] = session
+        return session
+
+    def get_active(self, target_discord_id: str) -> HelpLinkSession | None:
+        session = self._by_target.get(str(target_discord_id))
+        if session is None:
+            return None
+        if session.is_expired():
+            self._by_target.pop(str(target_discord_id), None)
+            return None
+        return session
+
+    def clear(self, target_discord_id: str) -> None:
+        self._by_target.pop(str(target_discord_id), None)
+
+
+def build_help_link_prompt_embed(*, mentor_mention: str) -> discord.Embed:
+    """Public/DM prompt shown only for the tagged contributor."""
+    return discord.Embed(
+        title="Link your GitHub with Gitcord",
+        description=(
+            f"{mentor_mention} asked Gitcord to help you link your GitHub account.\n\n"
+            "Click **Start linking**, enter your GitHub username, then verify with the code "
+            "(same steps as `/link`)."
+        ),
+        color=0x2563EB,
+    )
+
+
+class HelpLinkUsernameModal(discord.ui.Modal, title="Link your GitHub"):
+    """Modal box: contributor enters GitHub username, then gets standard verify UI."""
+
+    github_username = discord.ui.TextInput(
+        label="GitHub username",
+        placeholder="e.g. octocat",
+        min_length=1,
+        max_length=39,
+        required=True,
+    )
+
+    def __init__(
+        self,
+        *,
+        service: Any,
+        storage: Any,
+        target_discord_id: str,
+        profile_settings_url: str,
+        verification_view_factory: Callable[..., discord.ui.View],
+        build_verification_embed: Callable[..., discord.Embed],
+        session_store: HelpLinkSessionStore,
+        max_age_days: int | None = None,
+    ) -> None:
+        super().__init__()
+        self.service = service
+        self.storage = storage
+        self.target_discord_id = str(target_discord_id)
+        self.profile_settings_url = profile_settings_url
+        self.verification_view_factory = verification_view_factory
+        self.build_verification_embed = build_verification_embed
+        self.session_store = session_store
+        self.max_age_days = max_age_days
+
+    async def on_submit(self, interaction: discord.Interaction) -> None:
+        if str(interaction.user.id) != self.target_discord_id:
+            await interaction.response.send_message(
+                "This linking form belongs to another Discord user.",
+                ephemeral=True,
+            )
+            return
+
+        session = self.session_store.get_active(self.target_discord_id)
+        if session is None:
+            await interaction.response.send_message(
+                "This help session expired. Ask a mentor to run `/help-link` again.",
+                ephemeral=True,
+            )
+            return
+
+        github_username = str(self.github_username.value).strip()
+        if not github_username:
+            await interaction.response.send_message(
+                "Please enter a GitHub username.",
+                ephemeral=True,
+            )
+            return
+
+        await interaction.response.defer(ephemeral=True)
+        try:
+            claim = await asyncio.to_thread(
+                self.service.create_claim,
+                self.target_discord_id,
+                github_username,
+                max_age_days=self.max_age_days,
+            )
+        except ValueError as exc:
+            await interaction.followup.send(f"Cannot create link: {exc}", ephemeral=True)
+            return
+
+        embed = self.build_verification_embed(
+            claim, profile_settings_url=self.profile_settings_url
+        )
+        view = self.verification_view_factory(
+            service=self.service,
+            storage=self.storage,
+            discord_user_id=self.target_discord_id,
+            github_user=github_username,
+            profile_settings_url=self.profile_settings_url,
+        )
+        self.session_store.clear(self.target_discord_id)
+        await interaction.followup.send(embed=embed, view=view, ephemeral=True)
+
+
+class HelpLinkStartView(discord.ui.View):
+    """Channel/DM button: only the tagged contributor can open the username modal."""
+
+    def __init__(
+        self,
+        *,
+        service: Any,
+        storage: Any,
+        target_discord_id: str,
+        mentor_discord_id: str,
+        profile_settings_url: str,
+        verification_view_factory: Callable[..., discord.ui.View],
+        build_verification_embed: Callable[..., discord.Embed],
+        session_store: HelpLinkSessionStore,
+        max_age_days: int | None = None,
+        timeout: float = HELP_LINK_SESSION_TTL.total_seconds(),
+    ) -> None:
+        super().__init__(timeout=timeout)
+        self.service = service
+        self.storage = storage
+        self.target_discord_id = str(target_discord_id)
+        self.mentor_discord_id = str(mentor_discord_id)
+        self.profile_settings_url = profile_settings_url
+        self.verification_view_factory = verification_view_factory
+        self.build_verification_embed = build_verification_embed
+        self.session_store = session_store
+        self.max_age_days = max_age_days
+
+        start_button = discord.ui.Button(
+            label="Start linking",
+            style=discord.ButtonStyle.primary,
+            custom_id=f"help_link_start:{self.target_discord_id}",
+        )
+        start_button.callback = self.start_linking
+        self.add_item(start_button)
+
+    async def start_linking(self, interaction: discord.Interaction) -> None:
+        clicker_id = str(interaction.user.id)
+        if clicker_id != self.target_discord_id:
+            await interaction.response.send_message(
+                "This linking help is only for the tagged Discord user.",
+                ephemeral=True,
+            )
+            return
+
+        session = self.session_store.get_active(self.target_discord_id)
+        if session is None:
+            await interaction.response.send_message(
+                "This help session expired. Ask a mentor to run `/help-link` again.",
+                ephemeral=True,
+            )
+            return
+
+        modal = HelpLinkUsernameModal(
+            service=self.service,
+            storage=self.storage,
+            target_discord_id=self.target_discord_id,
+            profile_settings_url=self.profile_settings_url,
+            verification_view_factory=self.verification_view_factory,
+            build_verification_embed=self.build_verification_embed,
+            session_store=self.session_store,
+            max_age_days=self.max_age_days,
+        )
+        await interaction.response.send_modal(modal)
+
+    async def on_timeout(self) -> None:
+        self.session_store.clear(self.target_discord_id)
+        for item in self.children:
+            item.disabled = True
+
+
+async def deliver_help_link_prompt(
+    *,
+    interaction: discord.Interaction,
+    contributor: discord.abc.User,
+    mentor: discord.abc.User,
+    view: HelpLinkStartView,
+) -> str:
+    """DM the contributor; fall back to a channel ping if DMs are closed.
+
+    Returns a short status string for the mentor ephemeral reply.
+    """
+    embed = build_help_link_prompt_embed(mentor_mention=mentor.mention)
+    try:
+        await contributor.send(embed=embed, view=view)
+        return (
+            f"✅ Help started for {contributor.mention}. "
+            "I sent them a private DM with **Start linking**."
+        )
+    except (discord.Forbidden, discord.HTTPException) as exc:
+        logger.info(
+            "help-link DM failed for %s; falling back to channel: %s",
+            contributor.id,
+            exc,
+        )
+
+    channel = interaction.channel
+    if channel is None or not hasattr(channel, "send"):
+        return (
+            f"⚠️ Could not DM {contributor.mention} and no channel is available for a fallback. "
+            "Ask them to enable DMs from server members, then retry `/help-link`."
+        )
+
+    await channel.send(
+        content=(
+            f"{contributor.mention} — a mentor asked Gitcord to help you link GitHub. "
+            "Only you can use the button below."
+        ),
+        embed=embed,
+        view=view,
+    )
+    return (
+        f"✅ Help started for {contributor.mention}. "
+        "DMs were closed, so I posted a **Start linking** button in this channel "
+        "(only they can use it)."
+    )

--- a/src/ghdcbot/help_link.py
+++ b/src/ghdcbot/help_link.py
@@ -1,9 +1,10 @@
-"""Mentor-assisted identity linking: /help-link → private Start button → modal → /link verify UI."""
+"""Mentor-assisted identity linking: /help-link → Start button → modal → /link verify UI."""
 
 from __future__ import annotations
 
 import asyncio
 import logging
+import uuid
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Any, Callable
@@ -20,6 +21,7 @@ HELP_LINK_COMMAND_NAME = "help-link"
 class HelpLinkSession:
     """Short-lived mentor→contributor help session."""
 
+    session_id: str
     mentor_discord_id: str
     target_discord_id: str
     created_at: datetime
@@ -40,6 +42,7 @@ class HelpLinkSessionStore:
     def create(self, *, mentor_discord_id: str, target_discord_id: str) -> HelpLinkSession:
         now = datetime.now(timezone.utc)
         session = HelpLinkSession(
+            session_id=uuid.uuid4().hex,
             mentor_discord_id=str(mentor_discord_id),
             target_discord_id=str(target_discord_id),
             created_at=now,
@@ -57,12 +60,29 @@ class HelpLinkSessionStore:
             return None
         return session
 
+    def get_active_matching(
+        self, target_discord_id: str, session_id: str
+    ) -> HelpLinkSession | None:
+        """Return the active session only if it still matches ``session_id``."""
+        session = self.get_active(target_discord_id)
+        if session is None or session.session_id != session_id:
+            return None
+        return session
+
     def clear(self, target_discord_id: str) -> None:
         self._by_target.pop(str(target_discord_id), None)
 
+    def clear_if_match(self, target_discord_id: str, session_id: str) -> bool:
+        """Clear the active session only when it still belongs to ``session_id``."""
+        session = self._by_target.get(str(target_discord_id))
+        if session is None or session.session_id != session_id:
+            return False
+        self._by_target.pop(str(target_discord_id), None)
+        return True
+
 
 def build_help_link_prompt_embed(*, mentor_mention: str) -> discord.Embed:
-    """Public/DM prompt shown only for the tagged contributor."""
+    """DM/channel prompt for the tagged contributor (channel fallback is visible)."""
     return discord.Embed(
         title="Link your GitHub with Gitcord",
         description=(
@@ -91,6 +111,7 @@ class HelpLinkUsernameModal(discord.ui.Modal, title="Link your GitHub"):
         service: Any,
         storage: Any,
         target_discord_id: str,
+        session_id: str,
         profile_settings_url: str,
         verification_view_factory: Callable[..., discord.ui.View],
         build_verification_embed: Callable[..., discord.Embed],
@@ -101,6 +122,7 @@ class HelpLinkUsernameModal(discord.ui.Modal, title="Link your GitHub"):
         self.service = service
         self.storage = storage
         self.target_discord_id = str(target_discord_id)
+        self.session_id = session_id
         self.profile_settings_url = profile_settings_url
         self.verification_view_factory = verification_view_factory
         self.build_verification_embed = build_verification_embed
@@ -115,7 +137,9 @@ class HelpLinkUsernameModal(discord.ui.Modal, title="Link your GitHub"):
             )
             return
 
-        session = self.session_store.get_active(self.target_discord_id)
+        session = self.session_store.get_active_matching(
+            self.target_discord_id, self.session_id
+        )
         if session is None:
             await interaction.response.send_message(
                 "This help session expired. Ask a mentor to run `/help-link` again.",
@@ -153,7 +177,7 @@ class HelpLinkUsernameModal(discord.ui.Modal, title="Link your GitHub"):
             github_user=github_username,
             profile_settings_url=self.profile_settings_url,
         )
-        self.session_store.clear(self.target_discord_id)
+        self.session_store.clear_if_match(self.target_discord_id, self.session_id)
         await interaction.followup.send(embed=embed, view=view, ephemeral=True)
 
 
@@ -167,6 +191,7 @@ class HelpLinkStartView(discord.ui.View):
         storage: Any,
         target_discord_id: str,
         mentor_discord_id: str,
+        session_id: str,
         profile_settings_url: str,
         verification_view_factory: Callable[..., discord.ui.View],
         build_verification_embed: Callable[..., discord.Embed],
@@ -179,6 +204,7 @@ class HelpLinkStartView(discord.ui.View):
         self.storage = storage
         self.target_discord_id = str(target_discord_id)
         self.mentor_discord_id = str(mentor_discord_id)
+        self.session_id = session_id
         self.profile_settings_url = profile_settings_url
         self.verification_view_factory = verification_view_factory
         self.build_verification_embed = build_verification_embed
@@ -188,7 +214,7 @@ class HelpLinkStartView(discord.ui.View):
         start_button = discord.ui.Button(
             label="Start linking",
             style=discord.ButtonStyle.primary,
-            custom_id=f"help_link_start:{self.target_discord_id}",
+            custom_id=f"help_link_start:{self.target_discord_id}:{self.session_id}",
         )
         start_button.callback = self.start_linking
         self.add_item(start_button)
@@ -202,7 +228,9 @@ class HelpLinkStartView(discord.ui.View):
             )
             return
 
-        session = self.session_store.get_active(self.target_discord_id)
+        session = self.session_store.get_active_matching(
+            self.target_discord_id, self.session_id
+        )
         if session is None:
             await interaction.response.send_message(
                 "This help session expired. Ask a mentor to run `/help-link` again.",
@@ -214,6 +242,7 @@ class HelpLinkStartView(discord.ui.View):
             service=self.service,
             storage=self.storage,
             target_discord_id=self.target_discord_id,
+            session_id=self.session_id,
             profile_settings_url=self.profile_settings_url,
             verification_view_factory=self.verification_view_factory,
             build_verification_embed=self.build_verification_embed,
@@ -223,7 +252,9 @@ class HelpLinkStartView(discord.ui.View):
         await interaction.response.send_modal(modal)
 
     async def on_timeout(self) -> None:
-        self.session_store.clear(self.target_discord_id)
+        # Only clear if this view still owns the active session (a newer /help-link
+        # may have replaced it before this timeout fired).
+        self.session_store.clear_if_match(self.target_discord_id, self.session_id)
         for item in self.children:
             item.disabled = True
 
@@ -238,13 +269,14 @@ async def deliver_help_link_prompt(
     """DM the contributor; fall back to a channel ping if DMs are closed.
 
     Returns a short status string for the mentor ephemeral reply.
+    Channel fallback is visible to others; only the tagged user can use the button.
     """
     embed = build_help_link_prompt_embed(mentor_mention=mentor.mention)
     try:
         await contributor.send(embed=embed, view=view)
         return (
             f"✅ Help started for {contributor.mention}. "
-            "I sent them a private DM with **Start linking**."
+            "I sent them a DM with **Start linking**."
         )
     except (discord.Forbidden, discord.HTTPException) as exc:
         logger.info(
@@ -271,5 +303,5 @@ async def deliver_help_link_prompt(
     return (
         f"✅ Help started for {contributor.mention}. "
         "DMs were closed, so I posted a **Start linking** button in this channel "
-        "(only they can use it)."
+        "(visible here; only they can use it)."
     )

--- a/tests/test_help_link.py
+++ b/tests/test_help_link.py
@@ -1,0 +1,317 @@
+"""Tests for mentor-assisted /help-link flow."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import discord
+import pytest
+
+from ghdcbot.adapters.github.identity import VerificationMatch
+from ghdcbot.adapters.storage.sqlite import SqliteStorage
+from ghdcbot.bot import IdentityVerificationView, build_identity_verification_embed
+from ghdcbot.config.models import DiscordConfig, SlashCommandPermissionRule
+from ghdcbot.discord_command_permissions import slash_command_allowed
+from ghdcbot.engine.identity_linking import IdentityLinkService
+from ghdcbot.help_link import (
+    HELP_LINK_COMMAND_NAME,
+    HelpLinkSession,
+    HelpLinkSessionStore,
+    HelpLinkStartView,
+    HelpLinkUsernameModal,
+    build_help_link_prompt_embed,
+    deliver_help_link_prompt,
+)
+
+
+class _GitHubIdentityAlways:
+    def __init__(self, found: bool, location: str | None = None) -> None:
+        self._found = found
+        self._location = location
+
+    def search_verification_code(self, github_user: str, code: str) -> VerificationMatch:  # noqa: ARG002
+        return VerificationMatch(found=self._found, location=self._location)
+
+
+class _FakeInteractionResponse:
+    def __init__(self) -> None:
+        self.deferred = False
+        self.messages: list[dict] = []
+        self.modals: list[Any] = []
+        self._done = False
+
+    def is_done(self) -> bool:
+        return self._done
+
+    async def defer(self, *, ephemeral: bool = False) -> None:  # noqa: ARG002
+        self.deferred = True
+        self._done = True
+
+    async def send_message(self, content: str, *, ephemeral: bool = False) -> None:
+        self.messages.append({"content": content, "ephemeral": ephemeral})
+        self._done = True
+
+    async def send_modal(self, modal: discord.ui.Modal) -> None:
+        self.modals.append(modal)
+        self._done = True
+
+
+class _FakeFollowup:
+    def __init__(self) -> None:
+        self.messages: list[dict] = []
+
+    async def send(self, content: str | None = None, **kwargs: Any) -> None:
+        self.messages.append({"content": content, **kwargs})
+
+
+class _FakeButtonInteraction:
+    def __init__(self, discord_user_id: str) -> None:
+        self.user = SimpleNamespace(id=discord_user_id)
+        self.response = _FakeInteractionResponse()
+        self.followup = _FakeFollowup()
+
+
+class _FakeMember:
+    def __init__(self, user_id: int, *, bot: bool = False, mention: str | None = None) -> None:
+        self.id = user_id
+        self.bot = bot
+        self.mention = mention or f"<@{user_id}>"
+
+    async def send(self, **kwargs: Any) -> None:
+        self.last_dm = kwargs
+
+
+class _ForbiddenMember(_FakeMember):
+    async def send(self, **kwargs: Any) -> None:  # noqa: ARG002
+        response = SimpleNamespace(status=403, reason="Forbidden")
+        raise discord.Forbidden(response, "dm closed")
+
+
+class _FakeChannel:
+    def __init__(self) -> None:
+        self.messages: list[dict] = []
+
+    async def send(self, **kwargs: Any) -> None:
+        self.messages.append(kwargs)
+
+
+def test_help_link_session_store_expires() -> None:
+    store = HelpLinkSessionStore(ttl=timedelta(minutes=20))
+    now = datetime.now(timezone.utc)
+    store._by_target["t1"] = HelpLinkSession(
+        mentor_discord_id="m1",
+        target_discord_id="t1",
+        created_at=now - timedelta(minutes=30),
+        expires_at=now - timedelta(minutes=10),
+    )
+    assert store.get_active("t1") is None
+    assert "t1" not in store._by_target
+
+
+def test_help_link_session_replaces_previous_for_same_target() -> None:
+    store = HelpLinkSessionStore()
+    first = store.create(mentor_discord_id="m1", target_discord_id="t1")
+    second = store.create(mentor_discord_id="m2", target_discord_id="t1")
+    assert store.get_active("t1") is second
+    assert first is not second
+
+
+def test_help_link_prompt_embed_mentions_mentor() -> None:
+    embed = build_help_link_prompt_embed(mentor_mention="<@99>")
+    assert "<@99>" in embed.description
+    assert "Start linking" in embed.description
+
+
+def test_start_view_rejects_other_users(tmp_path: Path) -> None:
+    storage = SqliteStorage(data_dir=str(tmp_path))
+    storage.init_schema()
+    svc = IdentityLinkService(storage=storage, github_identity=_GitHubIdentityAlways(False))
+    store = HelpLinkSessionStore()
+    store.create(mentor_discord_id="m1", target_discord_id="t1")
+    view = HelpLinkStartView(
+        service=svc,
+        storage=storage,
+        target_discord_id="t1",
+        mentor_discord_id="m1",
+        profile_settings_url="https://github.com/settings/profile",
+        verification_view_factory=IdentityVerificationView,
+        build_verification_embed=build_identity_verification_embed,
+        session_store=store,
+    )
+    interaction = _FakeButtonInteraction("someone-else")
+    asyncio.run(view.start_linking(interaction))
+    assert interaction.response.modals == []
+    assert "only for the tagged" in interaction.response.messages[0]["content"]
+
+
+def test_start_view_rejects_expired_session(tmp_path: Path) -> None:
+    storage = SqliteStorage(data_dir=str(tmp_path))
+    storage.init_schema()
+    svc = IdentityLinkService(storage=storage, github_identity=_GitHubIdentityAlways(False))
+    store = HelpLinkSessionStore()
+    view = HelpLinkStartView(
+        service=svc,
+        storage=storage,
+        target_discord_id="t1",
+        mentor_discord_id="m1",
+        profile_settings_url="https://github.com/settings/profile",
+        verification_view_factory=IdentityVerificationView,
+        build_verification_embed=build_identity_verification_embed,
+        session_store=store,
+    )
+    interaction = _FakeButtonInteraction("t1")
+    asyncio.run(view.start_linking(interaction))
+    assert interaction.response.modals == []
+    assert "expired" in interaction.response.messages[0]["content"].lower()
+
+
+def test_start_view_opens_modal_for_target(tmp_path: Path) -> None:
+    storage = SqliteStorage(data_dir=str(tmp_path))
+    storage.init_schema()
+    svc = IdentityLinkService(storage=storage, github_identity=_GitHubIdentityAlways(False))
+    store = HelpLinkSessionStore()
+    store.create(mentor_discord_id="m1", target_discord_id="t1")
+    view = HelpLinkStartView(
+        service=svc,
+        storage=storage,
+        target_discord_id="t1",
+        mentor_discord_id="m1",
+        profile_settings_url="https://github.com/settings/profile",
+        verification_view_factory=IdentityVerificationView,
+        build_verification_embed=build_identity_verification_embed,
+        session_store=store,
+    )
+    interaction = _FakeButtonInteraction("t1")
+    asyncio.run(view.start_linking(interaction))
+    assert len(interaction.response.modals) == 1
+    assert isinstance(interaction.response.modals[0], HelpLinkUsernameModal)
+
+
+def test_modal_creates_claim_and_sends_verify_ui(tmp_path: Path) -> None:
+    storage = SqliteStorage(data_dir=str(tmp_path))
+    storage.init_schema()
+    svc = IdentityLinkService(storage=storage, github_identity=_GitHubIdentityAlways(False))
+    store = HelpLinkSessionStore()
+    store.create(mentor_discord_id="m1", target_discord_id="t1")
+    modal = HelpLinkUsernameModal(
+        service=svc,
+        storage=storage,
+        target_discord_id="t1",
+        profile_settings_url="https://github.com/settings/profile",
+        verification_view_factory=IdentityVerificationView,
+        build_verification_embed=build_identity_verification_embed,
+        session_store=store,
+    )
+    modal.github_username._value = "octocat"
+
+    interaction = _FakeButtonInteraction("t1")
+    asyncio.run(modal.on_submit(interaction))
+
+    row = storage.get_identity_link("t1", "octocat")
+    assert row is not None
+    assert row["verified"] == 0
+    assert store.get_active("t1") is None
+    assert interaction.response.deferred is True
+    assert len(interaction.followup.messages) == 1
+    sent = interaction.followup.messages[0]
+    assert sent.get("ephemeral") is True
+    assert sent.get("embed") is not None
+    assert isinstance(sent.get("view"), IdentityVerificationView)
+
+
+def test_deliver_help_link_prefers_dm() -> None:
+    contributor = _FakeMember(42)
+    mentor = _FakeMember(7, mention="<@7>")
+    interaction = SimpleNamespace(channel=_FakeChannel())
+    store = HelpLinkSessionStore()
+    store.create(mentor_discord_id="7", target_discord_id="42")
+    view = HelpLinkStartView(
+        service=SimpleNamespace(),
+        storage=SimpleNamespace(),
+        target_discord_id="42",
+        mentor_discord_id="7",
+        profile_settings_url="https://github.com/settings/profile",
+        verification_view_factory=IdentityVerificationView,
+        build_verification_embed=build_identity_verification_embed,
+        session_store=store,
+    )
+
+    status = asyncio.run(
+        deliver_help_link_prompt(
+            interaction=interaction,  # type: ignore[arg-type]
+            contributor=contributor,  # type: ignore[arg-type]
+            mentor=mentor,  # type: ignore[arg-type]
+            view=view,
+        )
+    )
+    assert "DM" in status
+    assert hasattr(contributor, "last_dm")
+    assert interaction.channel.messages == []
+
+
+def test_deliver_help_link_falls_back_to_channel() -> None:
+    contributor = _ForbiddenMember(42)
+    mentor = _FakeMember(7, mention="<@7>")
+    channel = _FakeChannel()
+    interaction = SimpleNamespace(channel=channel)
+    store = HelpLinkSessionStore()
+    store.create(mentor_discord_id="7", target_discord_id="42")
+    view = HelpLinkStartView(
+        service=SimpleNamespace(),
+        storage=SimpleNamespace(),
+        target_discord_id="42",
+        mentor_discord_id="7",
+        profile_settings_url="https://github.com/settings/profile",
+        verification_view_factory=IdentityVerificationView,
+        build_verification_embed=build_identity_verification_embed,
+        session_store=store,
+    )
+
+    status = asyncio.run(
+        deliver_help_link_prompt(
+            interaction=interaction,  # type: ignore[arg-type]
+            contributor=contributor,  # type: ignore[arg-type]
+            mentor=mentor,  # type: ignore[arg-type]
+            view=view,
+        )
+    )
+    assert "channel" in status.lower()
+    assert len(channel.messages) == 1
+    assert "Only you can use the button" in channel.messages[0]["content"]
+
+
+def test_help_link_permission_key_uses_command_permissions() -> None:
+    config = SimpleNamespace(
+        discord=DiscordConfig(
+            guild_id="1",
+            token="t",
+            unrestricted_slash_commands=False,
+            command_permissions={
+                HELP_LINK_COMMAND_NAME: SlashCommandPermissionRule(
+                    role_names=["Mentor"],
+                    allow_discord_administrators=True,
+                )
+            },
+        ),
+        assignments=None,
+    )
+    mentor = SimpleNamespace(
+        roles=[SimpleNamespace(id=1, name="Mentor")],
+        guild_permissions=SimpleNamespace(administrator=False),
+    )
+    student = SimpleNamespace(
+        roles=[SimpleNamespace(id=2, name="Student")],
+        guild_permissions=SimpleNamespace(administrator=False),
+    )
+    assert (
+        slash_command_allowed(SimpleNamespace(user=mentor), config, HELP_LINK_COMMAND_NAME)
+        is True
+    )
+    assert (
+        slash_command_allowed(SimpleNamespace(user=student), config, HELP_LINK_COMMAND_NAME)
+        is False
+    )

--- a/tests/test_help_link.py
+++ b/tests/test_help_link.py
@@ -9,7 +9,6 @@ from types import SimpleNamespace
 from typing import Any
 
 import discord
-import pytest
 
 from ghdcbot.adapters.github.identity import VerificationMatch
 from ghdcbot.adapters.storage.sqlite import SqliteStorage
@@ -99,10 +98,31 @@ class _FakeChannel:
         self.messages.append(kwargs)
 
 
+def _make_view(
+    *,
+    store: HelpLinkSessionStore,
+    session: HelpLinkSession,
+    service: Any = None,
+    storage: Any = None,
+) -> HelpLinkStartView:
+    return HelpLinkStartView(
+        service=service if service is not None else SimpleNamespace(),
+        storage=storage if storage is not None else SimpleNamespace(),
+        target_discord_id=session.target_discord_id,
+        mentor_discord_id=session.mentor_discord_id,
+        session_id=session.session_id,
+        profile_settings_url="https://github.com/settings/profile",
+        verification_view_factory=IdentityVerificationView,
+        build_verification_embed=build_identity_verification_embed,
+        session_store=store,
+    )
+
+
 def test_help_link_session_store_expires() -> None:
     store = HelpLinkSessionStore(ttl=timedelta(minutes=20))
     now = datetime.now(timezone.utc)
     store._by_target["t1"] = HelpLinkSession(
+        session_id="old",
         mentor_discord_id="m1",
         target_discord_id="t1",
         created_at=now - timedelta(minutes=30),
@@ -117,7 +137,27 @@ def test_help_link_session_replaces_previous_for_same_target() -> None:
     first = store.create(mentor_discord_id="m1", target_discord_id="t1")
     second = store.create(mentor_discord_id="m2", target_discord_id="t1")
     assert store.get_active("t1") is second
-    assert first is not second
+    assert first.session_id != second.session_id
+
+
+def test_older_view_timeout_does_not_clear_replacement_session() -> None:
+    store = HelpLinkSessionStore()
+    first = store.create(mentor_discord_id="m1", target_discord_id="t1")
+    first_view = _make_view(store=store, session=first)
+    second = store.create(mentor_discord_id="m2", target_discord_id="t1")
+    second_view = _make_view(store=store, session=second)
+
+    asyncio.run(first_view.on_timeout())
+
+    active = store.get_active("t1")
+    assert active is second
+    assert active.session_id == second.session_id
+    assert store.get_active_matching("t1", first.session_id) is None
+    assert store.get_active_matching("t1", second.session_id) is second
+
+    # Replacement view timeout still clears its own session.
+    asyncio.run(second_view.on_timeout())
+    assert store.get_active("t1") is None
 
 
 def test_help_link_prompt_embed_mentions_mentor() -> None:
@@ -131,17 +171,8 @@ def test_start_view_rejects_other_users(tmp_path: Path) -> None:
     storage.init_schema()
     svc = IdentityLinkService(storage=storage, github_identity=_GitHubIdentityAlways(False))
     store = HelpLinkSessionStore()
-    store.create(mentor_discord_id="m1", target_discord_id="t1")
-    view = HelpLinkStartView(
-        service=svc,
-        storage=storage,
-        target_discord_id="t1",
-        mentor_discord_id="m1",
-        profile_settings_url="https://github.com/settings/profile",
-        verification_view_factory=IdentityVerificationView,
-        build_verification_embed=build_identity_verification_embed,
-        session_store=store,
-    )
+    session = store.create(mentor_discord_id="m1", target_discord_id="t1")
+    view = _make_view(store=store, session=session, service=svc, storage=storage)
     interaction = _FakeButtonInteraction("someone-else")
     asyncio.run(view.start_linking(interaction))
     assert interaction.response.modals == []
@@ -153,16 +184,14 @@ def test_start_view_rejects_expired_session(tmp_path: Path) -> None:
     storage.init_schema()
     svc = IdentityLinkService(storage=storage, github_identity=_GitHubIdentityAlways(False))
     store = HelpLinkSessionStore()
-    view = HelpLinkStartView(
-        service=svc,
-        storage=storage,
-        target_discord_id="t1",
+    orphan = HelpLinkSession(
+        session_id="missing",
         mentor_discord_id="m1",
-        profile_settings_url="https://github.com/settings/profile",
-        verification_view_factory=IdentityVerificationView,
-        build_verification_embed=build_identity_verification_embed,
-        session_store=store,
+        target_discord_id="t1",
+        created_at=datetime.now(timezone.utc),
+        expires_at=datetime.now(timezone.utc) + timedelta(minutes=20),
     )
+    view = _make_view(store=store, session=orphan, service=svc, storage=storage)
     interaction = _FakeButtonInteraction("t1")
     asyncio.run(view.start_linking(interaction))
     assert interaction.response.modals == []
@@ -174,21 +203,14 @@ def test_start_view_opens_modal_for_target(tmp_path: Path) -> None:
     storage.init_schema()
     svc = IdentityLinkService(storage=storage, github_identity=_GitHubIdentityAlways(False))
     store = HelpLinkSessionStore()
-    store.create(mentor_discord_id="m1", target_discord_id="t1")
-    view = HelpLinkStartView(
-        service=svc,
-        storage=storage,
-        target_discord_id="t1",
-        mentor_discord_id="m1",
-        profile_settings_url="https://github.com/settings/profile",
-        verification_view_factory=IdentityVerificationView,
-        build_verification_embed=build_identity_verification_embed,
-        session_store=store,
-    )
+    session = store.create(mentor_discord_id="m1", target_discord_id="t1")
+    view = _make_view(store=store, session=session, service=svc, storage=storage)
     interaction = _FakeButtonInteraction("t1")
     asyncio.run(view.start_linking(interaction))
     assert len(interaction.response.modals) == 1
-    assert isinstance(interaction.response.modals[0], HelpLinkUsernameModal)
+    modal = interaction.response.modals[0]
+    assert isinstance(modal, HelpLinkUsernameModal)
+    assert modal.session_id == session.session_id
 
 
 def test_modal_creates_claim_and_sends_verify_ui(tmp_path: Path) -> None:
@@ -196,11 +218,12 @@ def test_modal_creates_claim_and_sends_verify_ui(tmp_path: Path) -> None:
     storage.init_schema()
     svc = IdentityLinkService(storage=storage, github_identity=_GitHubIdentityAlways(False))
     store = HelpLinkSessionStore()
-    store.create(mentor_discord_id="m1", target_discord_id="t1")
+    session = store.create(mentor_discord_id="m1", target_discord_id="t1")
     modal = HelpLinkUsernameModal(
         service=svc,
         storage=storage,
         target_discord_id="t1",
+        session_id=session.session_id,
         profile_settings_url="https://github.com/settings/profile",
         verification_view_factory=IdentityVerificationView,
         build_verification_embed=build_identity_verification_embed,
@@ -228,17 +251,8 @@ def test_deliver_help_link_prefers_dm() -> None:
     mentor = _FakeMember(7, mention="<@7>")
     interaction = SimpleNamespace(channel=_FakeChannel())
     store = HelpLinkSessionStore()
-    store.create(mentor_discord_id="7", target_discord_id="42")
-    view = HelpLinkStartView(
-        service=SimpleNamespace(),
-        storage=SimpleNamespace(),
-        target_discord_id="42",
-        mentor_discord_id="7",
-        profile_settings_url="https://github.com/settings/profile",
-        verification_view_factory=IdentityVerificationView,
-        build_verification_embed=build_identity_verification_embed,
-        session_store=store,
-    )
+    session = store.create(mentor_discord_id="7", target_discord_id="42")
+    view = _make_view(store=store, session=session)
 
     status = asyncio.run(
         deliver_help_link_prompt(
@@ -259,17 +273,8 @@ def test_deliver_help_link_falls_back_to_channel() -> None:
     channel = _FakeChannel()
     interaction = SimpleNamespace(channel=channel)
     store = HelpLinkSessionStore()
-    store.create(mentor_discord_id="7", target_discord_id="42")
-    view = HelpLinkStartView(
-        service=SimpleNamespace(),
-        storage=SimpleNamespace(),
-        target_discord_id="42",
-        mentor_discord_id="7",
-        profile_settings_url="https://github.com/settings/profile",
-        verification_view_factory=IdentityVerificationView,
-        build_verification_embed=build_identity_verification_embed,
-        session_store=store,
-    )
+    session = store.create(mentor_discord_id="7", target_discord_id="42")
+    view = _make_view(store=store, session=session)
 
     status = asyncio.run(
         deliver_help_link_prompt(
@@ -280,6 +285,7 @@ def test_deliver_help_link_falls_back_to_channel() -> None:
         )
     )
     assert "channel" in status.lower()
+    assert "visible" in status.lower()
     assert len(channel.messages) == 1
     assert "Only you can use the button" in channel.messages[0]["content"]
 


### PR DESCRIPTION
## Summary
- Add mentor-only `/help-link @contributor` to help stuck users link GitHub ↔ Discord
- Tagged user gets **Start linking** (DM preferred; channel fallback if DMs closed)
- Username modal → same `IdentityLinkService` + verify UI as `/link`
- Sessions expire in 20 minutes; wrong users cannot use the button; mentor cooldown applied
- Documented in README / quick start / identity docs; example remote configs include `help-link` mentor permission

## Test plan
- [x] `pytest tests/test_help_link.py tests/test_identity_linking.py tests/test_discord_command_permissions.py` (58 passed)
- [x] Full suite mostly green (432 passed; 1 unrelated `test_readme_setup` env failure for missing `/secrets/gitcordapp.pem`)
- [ ] After merge: add `help-link` under `discord.command_permissions` in live org `gitcord.yaml` if not using example defaults
- [ ] Discord smoke: mentor runs `/help-link @user` → user Start linking → modal → verify


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a mentor-only `/help-link `@member`` Discord command to guide contributors through GitHub identity linking.
  - Prompts are delivered privately when possible, with a channel fallback if direct messages are unavailable.
  - Only the tagged contributor can start the linking flow.

- **Configuration**
  - Added example permission settings for the `Mentor` role and Discord administrators.
  - Updated `/sync` and `/help-link` requirements to require a configured mentor role.

- **Documentation**
  - Updated the quick-start guide, README, and identity verification documentation with `/help-link` instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->