### PR TITLE
fix: attribute PR channel merges to merged_by, not author

### DIFF
--- a/src/ghdcbot/adapters/github/rest.py
+++ b/src/ghdcbot/adapters/github/rest.py
@@ -907,7 +907,14 @@ class GitHubRestAdapter:
                         "title": pr.get("title"),
                         "merged_at": pr.get("merged_at"),
                     }
+                    # List-PRs omits merged_by; only GET /pulls/{n} includes it.
                     merged_by = ((pr.get("merged_by") or {}).get("login") or "").strip()
+                    if not merged_by:
+                        detail = self.get_pull_request(owner, repo, int(pr["number"]))
+                        if isinstance(detail, dict):
+                            merged_by = (
+                                (detail.get("merged_by") or {}).get("login") or ""
+                            ).strip()
                     if merged_by:
                         payload["merged_by"] = merged_by
                     if base_branch:

--- a/src/ghdcbot/engine/notifications.py
+++ b/src/ghdcbot/engine/notifications.py
@@ -347,7 +347,7 @@ def update_pr_channel_announcement_for_event(
         event,
         github_org,
         status=status,
-        actor_github=actor,
+        actor_github=actor or "",
         tracked=tracked,
     )
     if not built:
@@ -357,7 +357,7 @@ def update_pr_channel_announcement_for_event(
     dedupe_key = f"pr_channel_lifecycle:{event.repo}:{pr_number}:{status}"
     try:
         claimed = _claim_notification_sent(
-            storage, dedupe_key, event, "", tracked.get("channel_id"), actor
+            storage, dedupe_key, event, "", tracked.get("channel_id"), actor or ""
         )
     except Exception as exc:
         logger.warning(
@@ -445,18 +445,29 @@ def update_pr_channel_announcement_for_event(
                 extra={"error": str(exc), "repo": event.repo, "pr_number": pr_number},
             )
             return False
-    _audit_notification(storage, event, "", tracked.get("channel_id"), actor)
+    _audit_notification(storage, event, "", tracked.get("channel_id"), actor or "")
     return True
 
 
-def _pr_lifecycle_actor(event: ContributionEvent) -> str:
-    """Prefer explicit merged_by/closed_by; fall back to event github_user."""
+def _pr_lifecycle_actor(event: ContributionEvent) -> str | None:
+    """Return the merge/close actor when known.
+
+    For merges, never fall back to the PR author (`event.github_user`) — that is
+    often wrong (maintainer merges contributor PRs). List-PRs omits ``merged_by``;
+    ingestion should fetch the single PR. If still missing, omit the name.
+    """
     payload = event.payload or {}
     if event.event_type == "pr_merged":
-        actor = payload.get("merged_by") or event.github_user
-    else:
-        actor = payload.get("closed_by") or payload.get("pr_author") or event.github_user
-    return (actor or "unknown").strip() or "unknown"
+        actor = (payload.get("merged_by") or "").strip()
+        return actor or None
+    actor = (
+        payload.get("closed_by")
+        or payload.get("pr_author")
+        or event.github_user
+        or ""
+    )
+    actor = str(actor).strip()
+    return actor or None
 
 
 # GitHub Primer status colors (match PR badge hues in the GitHub UI).
@@ -489,14 +500,14 @@ def _build_pr_lifecycle_channel_message(
     pr_title = _sanitize_discord_pr_title(title_raw)
     repo = event.repo
     raw_url = f"https://github.com/{github_org}/{repo}/pull/{pr_number}"
-    actor = (actor_github or "unknown").lstrip("@")
+    actor = (actor_github or "").lstrip("@").strip()
     if status == "merged":
         label = "Merged"
-        status_line = f"**Status:** Merged by @{actor}"
+        status_line = f"**Status:** Merged by @{actor}" if actor else "**Status:** Merged"
         color = _GITHUB_MERGED_PURPLE
     else:
         label = "Closed"
-        status_line = f"**Status:** Closed by @{actor}"
+        status_line = f"**Status:** Closed by @{actor}" if actor else "**Status:** Closed"
         color = _GITHUB_CLOSED_RED
     # Discord embed titles are plain text (no markdown links); put the link in url.
     title = f"{label}: {repo} #{pr_number} — {pr_title}"

--- a/tests/test_github_ingestion_lifecycle_events.py
+++ b/tests/test_github_ingestion_lifecycle_events.py
@@ -13,7 +13,7 @@ from ghdcbot.adapters.github.rest import (
 
 
 class _MockClient:
-    def __init__(self, routes: dict[str, list]) -> None:
+    def __init__(self, routes: dict[str, object]) -> None:
         self._routes = routes
 
     def request(
@@ -37,7 +37,7 @@ def _adapter_with_repo(monkeypatch, pulls: list[dict]) -> GitHubRestAdapter:
             }
         ],
     )
-    routes = {
+    routes: dict[str, object] = {
         "/repos/owner/repo/issues": [],
         "/repos/owner/repo/pulls": pulls,
     }
@@ -46,6 +46,11 @@ def _adapter_with_repo(monkeypatch, pulls: list[dict]) -> GitHubRestAdapter:
         routes[f"/repos/owner/repo/pulls/{number}/reviews"] = []
         routes[f"/repos/owner/repo/pulls/{number}/comments"] = []
         routes[f"/repos/owner/repo/issues/{number}/comments"] = []
+        # List-PRs omits merged_by; GET single PR includes it (unless explicitly null).
+        detail = dict(pr)
+        if pr.get("merged_at") and "merged_by" not in pr:
+            detail["merged_by"] = {"login": "detail-merger"}
+        routes[f"/repos/owner/repo/pulls/{number}"] = detail
         closed_at = pr.get("closed_at")
         merged_at = pr.get("merged_at")
         timeline: list[dict] = []
@@ -54,8 +59,44 @@ def _adapter_with_repo(monkeypatch, pulls: list[dict]) -> GitHubRestAdapter:
         if merged_at:
             timeline.append({"event": "merged", "created_at": merged_at})
         routes[f"/repos/owner/repo/issues/{number}/timeline"] = timeline
-    adapter._client = _MockClient(routes)
+    adapter._client = _MockClient(routes)  # type: ignore[arg-type]
     return adapter
+
+
+def test_pr_merged_fetches_merged_by_from_single_pr(monkeypatch) -> None:
+    """List-PRs leaves merged_by null; ingestion must GET /pulls/{n} for the merger."""
+    adapter = _adapter_with_repo(
+        monkeypatch,
+        [
+            {
+                "number": 214,
+                "state": "closed",
+                "created_at": "2024-01-02T00:00:00Z",
+                "updated_at": "2024-01-09T00:00:00Z",
+                "closed_at": "2024-01-09T00:00:00Z",
+                "merged_at": "2024-01-09T00:00:00Z",
+                "title": "feat: org filter",
+                "html_url": "https://github.com/owner/repo/pull/214",
+                "user": {"login": "jikrana1"},
+                # Intentionally no merged_by on list payload (GitHub list behavior).
+            }
+        ],
+    )
+    # Override detail route with the real merger (not the author).
+    adapter._client._routes["/repos/owner/repo/pulls/214"] = {
+        "number": 214,
+        "merged_at": "2024-01-09T00:00:00Z",
+        "user": {"login": "jikrana1"},
+        "merged_by": {"login": "Ri1tik"},
+        "base": {"ref": "main"},
+    }
+
+    since = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    events = list(adapter.list_contributions(since))
+    merged = [event for event in events if event.event_type == "pr_merged"]
+    assert len(merged) == 1
+    assert merged[0].github_user == "jikrana1"
+    assert merged[0].payload.get("merged_by") == "Ri1tik"
 
 
 def test_pr_closed_emitted_when_closed_without_merge(monkeypatch) -> None:
@@ -117,6 +158,7 @@ def test_pr_merged_emitted_not_pr_closed_when_merged(monkeypatch) -> None:
     assert len(merged) == 1
     assert merged[0].payload["pr_number"] == 21
     assert merged[0].payload["base_branch"] == "dev"
+    assert merged[0].payload.get("merged_by") == "detail-merger"
     assert len(closed) == 0
 
 

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1283,6 +1283,39 @@ def test_update_pr_channel_announcement_edits_on_merge() -> None:
     assert storage.get_pr_channel_announcement("Gitcord-GithubDiscordBot", 42)["status"] == "merged"
 
 
+def test_update_pr_channel_announcement_merge_does_not_blame_author() -> None:
+    """Missing merged_by must not attribute the merge to the PR author."""
+    storage = MockStorage()
+    discord_writer = MockDiscordWriter()
+    storage.save_pr_channel_announcement(
+        repo="OrgExplorer",
+        pr_number=214,
+        channel_id="chan-org",
+        message_id="msg-org",
+        pr_title="feat: add organization filter",
+        author_github="jikrana1",
+        status="open",
+    )
+    config = NotificationConfig(enabled=True, update_pr_channel_on_lifecycle=True)
+    policy = MutationPolicy(mode=RunMode.ACTIVE, github_write_allowed=True, discord_write_allowed=True)
+    event = ContributionEvent(
+        github_user="jikrana1",
+        event_type="pr_merged",
+        repo="OrgExplorer",
+        created_at=datetime.now(UTC),
+        payload={"pr_number": 214, "title": "feat: add organization filter"},
+    )
+
+    assert update_pr_channel_announcement_for_event(
+        event, storage, discord_writer, policy, config, "AOSSIE-Org"
+    )
+    embeds = discord_writer.messages_edited[0][3]
+    assert embeds
+    assert embeds[0]["description"] == "**Status:** Merged"
+    assert "jikrana1" not in embeds[0]["description"]
+    assert "Merged by" not in embeds[0]["description"]
+
+
 def test_update_pr_channel_announcement_edits_on_close() -> None:
     storage = MockStorage()
     discord_writer = MockDiscordWriter()


### PR DESCRIPTION
## Summary
- GitHub **list PRs** does not include `merged_by`, so Discord channel edits fell back to the PR **author** (e.g. OrgExplorer #214 showed `@jikrana1` instead of `Ri1tik`).
- On `pr_merged` ingestion, if list payload lacks `merged_by`, fetch `GET /pulls/{n}` and store the real merger.
- Channel status line never falls back to the author: show `Merged by @user` only when known, otherwise just `Merged`.

## Test plan
- [x] `pytest tests/test_notifications.py tests/test_github_ingestion_lifecycle_events.py` (68 passed)
- [ ] CI green
- [ ] After merge + deploy: next mentor-merged PR should show the merger login, not the author


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Merged pull requests now preserve the actual merger’s name when available, even if it is missing from the initial results.
  * Merge and close announcements no longer display an incorrect or unknown actor when attribution is unavailable.
  * Merge announcements no longer attribute the action to the pull request author by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->