### PR TITLE
fix: remove duplicate imports in bot.py

### DIFF
--- a/src/ghdcbot/bot.py
+++ b/src/ghdcbot/bot.py
@@ -6,9 +6,6 @@ import asyncio
 import logging
 
 from datetime import datetime, timedelta, timezone
-from typing import Any
-
-from datetime import datetime
 from typing import Any, Optional
 
 


### PR DESCRIPTION
## What changed

Removed duplicate imports from `src/ghdcbot/bot.py`.

## Why

Cleans up redundant imports without changing functionality.

## Testing

Ran Ruff on `src/ghdcbot/bot.py`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal imports without changing user-visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->