### PR TITLE
fix: handle pr_reopened event for PR channel announcements

### DIFF
--- a/src/ghdcbot/engine/notifications.py
+++ b/src/ghdcbot/engine/notifications.py
@@ -313,7 +313,7 @@ def update_pr_channel_announcement_for_event(
     """
     if not config.enabled or not getattr(config, "update_pr_channel_on_lifecycle", True):
         return False
-    if event.event_type not in {"pr_merged", "pr_closed"}:
+    if event.event_type not in {"pr_merged", "pr_closed", "pr_reopened"}:
         return False
     if not policy.allow_discord_mutations:
         return False
@@ -338,26 +338,47 @@ def update_pr_channel_announcement_for_event(
         # Pre-feature / untracked opens: do not invent edits for old Discord messages.
         return False
 
-    status = "merged" if event.event_type == "pr_merged" else "closed"
+    if event.event_type == "pr_merged":
+        status = "merged"
+    elif event.event_type == "pr_closed":
+        status = "closed"
+    else:
+        status = "open"
+
     if tracked.get("status") == status:
         return False
 
-    actor = _pr_lifecycle_actor(event)
-    built = _build_pr_lifecycle_channel_message(
-        event,
-        github_org,
-        status=status,
-        actor_github=actor or "",
-        tracked=tracked,
-    )
-    if not built:
-        return False
-    message, embeds = built
+    if status == "open":
+        author_github = tracked.get("author_github") or event.github_user or ""
+        discord_user_id = _resolve_github_to_discord(storage, author_github)
+        
+        # event payload might not have 'title' for pr_reopened depending on adapter, so fallback to tracked
+        if not event.payload.get("title") and tracked.get("pr_title"):
+            event.payload["title"] = tracked["pr_title"]
+            
+        message = _build_pr_opened_channel_message(
+            event, github_org, author_github, discord_user_id
+        )
+        if not message:
+            return False
+        embeds = []
+    else:
+        actor = _pr_lifecycle_actor(event)
+        built = _build_pr_lifecycle_channel_message(
+            event,
+            github_org,
+            status=status,
+            actor_github=actor or "",
+            tracked=tracked,
+        )
+        if not built:
+            return False
+        message, embeds = built
 
     dedupe_key = f"pr_channel_lifecycle:{event.repo}:{pr_number}:{status}"
     try:
         claimed = _claim_notification_sent(
-            storage, dedupe_key, event, "", tracked.get("channel_id"), actor or ""
+            storage, dedupe_key, event, "", tracked.get("channel_id"), actor if status != "open" else author_github
         )
     except Exception as exc:
         logger.warning(
@@ -445,7 +466,8 @@ def update_pr_channel_announcement_for_event(
                 extra={"error": str(exc), "repo": event.repo, "pr_number": pr_number},
             )
             return False
-    _audit_notification(storage, event, "", tracked.get("channel_id"), actor or "")
+    actor_name = author_github if status == "open" else (actor or "")
+    _audit_notification(storage, event, "", tracked.get("channel_id"), actor_name)
     return True
 
 

--- a/src/ghdcbot/engine/notifications.py
+++ b/src/ghdcbot/engine/notifications.py
@@ -468,6 +468,7 @@ def update_pr_channel_announcement_for_event(
             return False
     actor_name = author_github if status == "open" else (actor or "")
     _audit_notification(storage, event, "", tracked.get("channel_id"), actor_name)
+    _release_notification_claim(storage, dedupe_key)
     return True
 
 

--- a/src/ghdcbot/engine/orchestrator.py
+++ b/src/ghdcbot/engine/orchestrator.py
@@ -355,7 +355,7 @@ def _send_notifications_for_new_events(
                         "pr_author": event.payload.get("pr_author"),
                     },
                 )
-            if event.event_type in {"pr_merged", "pr_closed"}:
+            if event.event_type in {"pr_merged", "pr_closed", "pr_reopened"}:
                 try:
                     if update_pr_channel_announcement_for_event(
                         event, storage, discord_writer, policy, config, github_org

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1446,6 +1446,83 @@ def test_update_pr_channel_announcement_reopened() -> None:
     assert "<@d-bob>" in edited_msg
 
 
+def test_update_pr_channel_announcement_reopened_fallback() -> None:
+    storage = MockStorage()
+    discord_writer = MockDiscordWriter()
+    storage.save_pr_channel_announcement(
+        repo="MiniChain",
+        pr_number=7,
+        channel_id="chan-2",
+        message_id="msg-2",
+        pr_title="TrackedTitle",
+        author_github="bob",
+        status="closed",
+    )
+    config = NotificationConfig(enabled=True, update_pr_channel_on_lifecycle=True)
+    policy = MutationPolicy(mode=RunMode.ACTIVE, github_write_allowed=True, discord_write_allowed=True)
+    event = ContributionEvent(
+        github_user="bob",
+        event_type="pr_reopened",
+        repo="MiniChain",
+        created_at=datetime.now(UTC),
+        payload={"pr_number": 7},  # No title here
+    )
+
+    assert update_pr_channel_announcement_for_event(
+        event, storage, discord_writer, policy, config, "StabilityNexus"
+    )
+    assert len(discord_writer.messages_edited) == 1
+    edited_msg = discord_writer.messages_edited[0][2]
+    assert "TrackedTitle" in edited_msg
+
+
+def test_update_pr_channel_announcement_close_reopen_close() -> None:
+    storage = MockStorage()
+    discord_writer = MockDiscordWriter()
+    storage.save_pr_channel_announcement(
+        repo="MiniChain",
+        pr_number=7,
+        channel_id="chan-2",
+        message_id="msg-2",
+        pr_title="WIP",
+        author_github="bob",
+        status="open",
+    )
+    config = NotificationConfig(enabled=True, update_pr_channel_on_lifecycle=True)
+    policy = MutationPolicy(mode=RunMode.ACTIVE, github_write_allowed=True, discord_write_allowed=True)
+
+    close_event1 = ContributionEvent(
+        github_user="bob",
+        event_type="pr_closed",
+        repo="MiniChain",
+        created_at=datetime.now(UTC),
+        payload={"pr_number": 7, "closed_by": "bob"},
+    )
+    assert update_pr_channel_announcement_for_event(close_event1, storage, discord_writer, policy, config, "test")
+    storage.mark_pr_channel_announcement_status("MiniChain", 7, "closed")
+    
+    reopen_event = ContributionEvent(
+        github_user="bob",
+        event_type="pr_reopened",
+        repo="MiniChain",
+        created_at=datetime.now(UTC),
+        payload={"pr_number": 7},
+    )
+    assert update_pr_channel_announcement_for_event(reopen_event, storage, discord_writer, policy, config, "test")
+    storage.mark_pr_channel_announcement_status("MiniChain", 7, "open")
+
+    close_event2 = ContributionEvent(
+        github_user="bob",
+        event_type="pr_closed",
+        repo="MiniChain",
+        created_at=datetime.now(UTC),
+        payload={"pr_number": 7, "closed_by": "bob"},
+    )
+    assert update_pr_channel_announcement_for_event(close_event2, storage, discord_writer, policy, config, "test")
+    
+    assert len(discord_writer.messages_edited) == 3
+
+
 def test_update_pr_channel_announcement_skips_untracked_old_messages() -> None:
     storage = MockStorage()
     discord_writer = MockDiscordWriter()

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1499,7 +1499,7 @@ def test_update_pr_channel_announcement_close_reopen_close() -> None:
         payload={"pr_number": 7, "closed_by": "bob"},
     )
     assert update_pr_channel_announcement_for_event(close_event1, storage, discord_writer, policy, config, "test")
-    storage.mark_pr_channel_announcement_status("MiniChain", 7, "closed")
+    assert storage.get_pr_channel_announcement("MiniChain", 7)["status"] == "closed"
     
     reopen_event = ContributionEvent(
         github_user="bob",
@@ -1509,7 +1509,7 @@ def test_update_pr_channel_announcement_close_reopen_close() -> None:
         payload={"pr_number": 7},
     )
     assert update_pr_channel_announcement_for_event(reopen_event, storage, discord_writer, policy, config, "test")
-    storage.mark_pr_channel_announcement_status("MiniChain", 7, "open")
+    assert storage.get_pr_channel_announcement("MiniChain", 7)["status"] == "open"
 
     close_event2 = ContributionEvent(
         github_user="bob",
@@ -1519,6 +1519,7 @@ def test_update_pr_channel_announcement_close_reopen_close() -> None:
         payload={"pr_number": 7, "closed_by": "bob"},
     )
     assert update_pr_channel_announcement_for_event(close_event2, storage, discord_writer, policy, config, "test")
+    assert storage.get_pr_channel_announcement("MiniChain", 7)["status"] == "closed"
     
     assert len(discord_writer.messages_edited) == 3
 

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1411,6 +1411,41 @@ def test_update_pr_channel_announcement_edits_on_close() -> None:
     assert "Closed by @bob" in embeds[0]["description"]
 
 
+def test_update_pr_channel_announcement_reopened() -> None:
+    storage = MockStorage()
+    discord_writer = MockDiscordWriter()
+    storage.verified_mappings = [{"github_user": "bob", "discord_user_id": "d-bob"}]
+    storage.save_pr_channel_announcement(
+        repo="MiniChain",
+        pr_number=7,
+        channel_id="chan-2",
+        message_id="msg-2",
+        pr_title="WIP",
+        author_github="bob",
+        status="closed",
+    )
+    config = NotificationConfig(enabled=True, update_pr_channel_on_lifecycle=True)
+    policy = MutationPolicy(mode=RunMode.ACTIVE, github_write_allowed=True, discord_write_allowed=True)
+    event = ContributionEvent(
+        github_user="bob",
+        event_type="pr_reopened",
+        repo="MiniChain",
+        created_at=datetime.now(UTC),
+        payload={"pr_number": 7, "title": "WIP"},
+    )
+
+    assert update_pr_channel_announcement_for_event(
+        event, storage, discord_writer, policy, config, "StabilityNexus"
+    )
+    assert len(discord_writer.messages_edited) == 1
+    edited_msg = discord_writer.messages_edited[0][2]
+    embeds = discord_writer.messages_edited[0][3]
+    assert not embeds
+    assert "New PR:" in edited_msg
+    assert "WIP" in edited_msg
+    assert "<@d-bob>" in edited_msg
+
+
 def test_update_pr_channel_announcement_skips_untracked_old_messages() -> None:
     storage = MockStorage()
     discord_writer = MockDiscordWriter()


### PR DESCRIPTION
Fixes #70. Ensures that when a closed PR is reopened, the Discord channel announcement has its Closed/Merged styling cleared and reverts to the standard Open styling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Reopened pull requests now restore their channel announcements to the open state, including the original title and verified author mention.
  - Pull request announcements continue to display appropriate lifecycle information when merged or closed.

- **Bug Fixes**
  - Audit records now attribute reopened events to the pull request author and other lifecycle events to the relevant actor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

https://github.com/user-attachments/assets/8b15d836-940a-4064-a011-239dabc8ab5a

