### PR TITLE
Fix #73: Move pr-status options to interactive Discord UI

### DIFF
--- a/src/ghdcbot/bot.py
+++ b/src/ghdcbot/bot.py
@@ -314,6 +314,137 @@ class IdentityVerificationView(discord.ui.View):
         await self._edit_response(interaction, "Verification cancelled.")
 
 
+class PRStatusModal(discord.ui.Modal, title="Check Specific PR"):
+    pr_number = discord.ui.TextInput(
+        label="Pull Request Number",
+        placeholder="e.g. 123",
+        required=True,
+        min_length=1,
+        max_length=10,
+    )
+
+    def __init__(self, repo: str | None, config: Any, github_adapter: Any) -> None:
+        super().__init__()
+        self.repo = repo
+        self.config = config
+        self.github_adapter = github_adapter
+
+    async def on_submit(self, interaction: discord.Interaction) -> None:
+        await interaction.response.defer(ephemeral=True)
+        try:
+            pr_num = int(self.pr_number.value.strip())
+        except ValueError:
+            await interaction.followup.send("❌ PR number must be an integer.", ephemeral=True)
+            return
+
+        repo_name, err = await resolve_repo_for_pr(
+            self.config, self.github_adapter, pr_num, repo=self.repo
+        )
+        if err:
+            await interaction.followup.send(err, ephemeral=True)
+            return
+
+        assert repo_name is not None
+
+        notification_config = getattr(self.config.discord, "notifications", None)
+        coderabbit_logins = getattr(notification_config, "coderabbit_bot_logins", None) if notification_config else None
+
+        try:
+            health = await asyncio.to_thread(
+                fetch_pr_health,
+                self.github_adapter,
+                self.config.github.org,
+                repo_name,
+                pr_num,
+                coderabbit_logins,
+            )
+        except Exception:
+            logging.getLogger("ghdcbot.bot").exception(
+                "Failed to fetch PR health",
+                extra={"repo": repo_name, "pr_number": pr_num},
+            )
+            await interaction.followup.send(
+                "❌ Error fetching PR status. Please try again later.",
+                ephemeral=True,
+            )
+            return
+
+        if health is None:
+            # Check if this number is an Issue rather than a PR to provide an informative response
+            issue_info = None
+            try:
+                get_issue = getattr(self.github_adapter, "get_issue", None)
+                if callable(get_issue):
+                    issue_info = await asyncio.to_thread(
+                        get_issue, self.config.github.org, repo_name, pr_num
+                    )
+            except Exception as exc:
+                logging.getLogger("ghdcbot.bot").debug("Failed to fetch issue details for fallback check: %s", exc)
+
+            if issue_info and "pull_request" not in issue_info:
+                issue_title = (issue_info.get("title") or "").strip()
+                issue_state = issue_info.get("state") or "unknown"
+                state_label = "Closed 🔴" if issue_state == "closed" else "Open 🟢"
+                await interaction.followup.send(
+                    f"ℹ️ **{repo_name}#{pr_num}** is a GitHub **Issue**, not a Pull Request.\n\n"
+                    f"**Title:** {issue_title}\n"
+                    f"**State:** {state_label}\n\n"
+                    "💡 `/pr-status` is designed for Pull Requests. Use the modal for Pull Requests instead.",
+                    ephemeral=True,
+                )
+                return
+
+            await interaction.followup.send(
+                f"❌ PR **{repo_name}#{pr_num}** not found or inaccessible.",
+                ephemeral=True,
+            )
+            return
+
+        message = format_single_pr_status(health, self.config.github.org)
+        await interaction.followup.send(message, ephemeral=True, suppress_embeds=True)
+
+
+class PRStatusView(discord.ui.View):
+    def __init__(self, repo: str | None, config: Any, github_adapter: Any, timeout: float = 300.0) -> None:
+        super().__init__(timeout=timeout)
+        self.repo = repo
+        self.config = config
+        self.github_adapter = github_adapter
+
+    @discord.ui.button(label="Show All Open PRs", style=discord.ButtonStyle.primary, emoji="📄")
+    async def show_all(self, interaction: discord.Interaction, button: discord.ui.Button) -> None:
+        await interaction.response.defer(ephemeral=True)
+        notification_config = getattr(self.config.discord, "notifications", None)
+        coderabbit_logins = getattr(notification_config, "coderabbit_bot_logins", None) if notification_config else None
+
+        try:
+            statuses, total = await asyncio.to_thread(
+                fetch_all_open_pr_health,
+                self.github_adapter,
+                self.config.github.org,
+                coderabbit_logins,
+                PR_STATUS_MAX_PRS,
+                0,
+            )
+        except Exception:
+            logging.getLogger("ghdcbot.bot").exception("Failed to fetch all open PR health")
+            await interaction.followup.send(
+                "❌ Error fetching PR dashboard. Please try again later.",
+                ephemeral=True,
+            )
+            return
+
+        messages = format_all_pr_status(
+            statuses, self.config.github.org, skip=0, total=total
+        )
+        for msg in messages:
+            await interaction.followup.send(msg, ephemeral=True, suppress_embeds=True)
+
+    @discord.ui.button(label="Check Specific PR", style=discord.ButtonStyle.secondary, emoji="🔍")
+    async def specific_pr(self, interaction: discord.Interaction, button: discord.ui.Button) -> None:
+        await interaction.response.send_modal(PRStatusModal(self.repo, self.config, self.github_adapter))
+
+
 def run_bot(config_path: str) -> None:
     """Run the Discord bot with /link, /verify-link, /help-link, /profile, and /summary."""
     config = load_config(config_path)
@@ -1011,122 +1142,21 @@ def run_bot(config_path: str) -> None:
     )
     @app_commands.describe(
         repo="Repository name (optional; auto-detected from config if omitted)",
-        pr_number="Pull request number (optional if show_all is True)",
-        show_all="Show health dashboard for all open PRs in the organization",
-        skip="How many open PRs to skip for pagination (when show_all is True)",
     )
     @app_commands.checks.cooldown(1, 5.0)
     @app_commands.check(command_permission_check(SLASH_CMD_PR_STATUS, allow_all_by_default=True))
     async def pr_status_cmd(
         interaction: discord.Interaction,
         repo: str | None = None,
-        pr_number: app_commands.Range[int, 1] | None = None,
-        show_all: bool = False,
-        skip: app_commands.Range[int, 0] = 0,
     ) -> None:
         """Show health status of a pull request or all open PRs."""
-        await interaction.response.defer(ephemeral=True)
-
-        # Resolve CodeRabbit bot logins from notification config
-        notification_config = getattr(config.discord, "notifications", None)
-        coderabbit_logins = None
-        if notification_config:
-            coderabbit_logins = getattr(notification_config, "coderabbit_bot_logins", None)
-
-        if show_all:
-            try:
-                statuses, total = await asyncio.to_thread(
-                    fetch_all_open_pr_health,
-                    github_adapter,
-                    config.github.org,
-                    coderabbit_logins,
-                    PR_STATUS_MAX_PRS,
-                    int(skip),
-                )
-            except Exception:
-                logger.exception("Failed to fetch all open PR health")
-                await interaction.followup.send(
-                    "❌ Error fetching PR dashboard. Please try again later.",
-                    ephemeral=True,
-                )
-                return
-
-            messages = format_all_pr_status(
-                statuses, config.github.org, skip=int(skip), total=total
-            )
-            for msg in messages:
-                await interaction.followup.send(msg, ephemeral=True, suppress_embeds=True)
-            return
-
-        if pr_number is None:
-            await interaction.followup.send(
-                "❌ Please specify `pr_number` to check PR health (or use `show_all:True` for the organization dashboard).",
-                ephemeral=True,
-            )
-            return
-
-        repo_name, err = await resolve_repo_for_pr(
-            config, github_adapter, int(pr_number), repo=repo
+        repo_display = f"`{repo}`" if repo else "auto-detected repository"
+        view = PRStatusView(repo, config, github_adapter)
+        await interaction.response.send_message(
+            f"Select an option for **{repo_display}** (or the org dashboard):",
+            view=view,
+            ephemeral=True
         )
-        if err:
-            await interaction.followup.send(err, ephemeral=True)
-            return
-
-        assert repo_name is not None
-
-        try:
-            health = await asyncio.to_thread(
-                fetch_pr_health,
-                github_adapter,
-                config.github.org,
-                repo_name,
-                int(pr_number),
-                coderabbit_logins,
-            )
-        except Exception:
-            logger.exception(
-                "Failed to fetch PR health",
-                extra={"repo": repo_name, "pr_number": pr_number},
-            )
-            await interaction.followup.send(
-                "❌ Error fetching PR status. Please try again later.",
-                ephemeral=True,
-            )
-            return
-
-        if health is None:
-            # Check if this number is an Issue rather than a PR to provide an informative response
-            issue_info = None
-            try:
-                get_issue = getattr(github_adapter, "get_issue", None)
-                if callable(get_issue):
-                    issue_info = await asyncio.to_thread(
-                        get_issue, config.github.org, repo_name, int(pr_number)
-                    )
-            except Exception as exc:
-                logger.debug("Failed to fetch issue details for fallback check: %s", exc)
-
-            if issue_info and "pull_request" not in issue_info:
-                issue_title = (issue_info.get("title") or "").strip()
-                issue_state = issue_info.get("state") or "unknown"
-                state_label = "Closed 🔴" if issue_state == "closed" else "Open 🟢"
-                await interaction.followup.send(
-                    f"ℹ️ **{repo_name}#{pr_number}** is a GitHub **Issue**, not a Pull Request.\n\n"
-                    f"**Title:** {issue_title}\n"
-                    f"**State:** {state_label}\n\n"
-                    "💡 `/pr-status` is designed for Pull Requests. Try `/pr-status pr_number:<PR#>`.",
-                    ephemeral=True,
-                )
-                return
-
-            await interaction.followup.send(
-                f"❌ PR **{repo_name}#{pr_number}** not found or inaccessible.",
-                ephemeral=True,
-            )
-            return
-
-        message = format_single_pr_status(health, config.github.org)
-        await interaction.followup.send(message, ephemeral=True, suppress_embeds=True)
 
     @pr_status_cmd.autocomplete("repo")
     async def pr_status_repo_autocomplete(

--- a/src/ghdcbot/engine/notifications.py
+++ b/src/ghdcbot/engine/notifications.py
@@ -453,22 +453,23 @@ def update_pr_channel_announcement_for_event(
         return False
 
     mark = getattr(storage, "mark_pr_channel_announcement_status", None)
-    if callable(mark):
-        try:
-            mark(event.repo, int(pr_number), status)
-        except Exception as exc:
-            # Discord already edited; release claim so a later sync can retry
-            # status persistence (row may still be "open").
-            _release_notification_claim(storage, dedupe_key)
-            logger.warning(
-                "Failed to update PR channel announcement status after edit",
-                exc_info=True,
-                extra={"error": str(exc), "repo": event.repo, "pr_number": pr_number},
-            )
-            return False
-    actor_name = author_github if status == "open" else (actor or "")
-    _audit_notification(storage, event, "", tracked.get("channel_id"), actor_name)
-    _release_notification_claim(storage, dedupe_key)
+    try:
+        if callable(mark):
+            try:
+                mark(event.repo, int(pr_number), status)
+            except Exception as exc:
+                # Discord already edited; release claim so a later sync can retry
+                # status persistence (row may still be "open").
+                logger.warning(
+                    "Failed to update PR channel announcement status after edit",
+                    exc_info=True,
+                    extra={"error": str(exc), "repo": event.repo, "pr_number": pr_number},
+                )
+                return False
+        actor_name = author_github if status == "open" else (actor or "")
+        _audit_notification(storage, event, "", tracked.get("channel_id"), actor_name)
+    finally:
+        _release_notification_claim(storage, dedupe_key)
     return True
 
 

--- a/src/ghdcbot/engine/notifications.py
+++ b/src/ghdcbot/engine/notifications.py
@@ -313,7 +313,7 @@ def update_pr_channel_announcement_for_event(
     """
     if not config.enabled or not getattr(config, "update_pr_channel_on_lifecycle", True):
         return False
-    if event.event_type not in {"pr_merged", "pr_closed"}:
+    if event.event_type not in {"pr_merged", "pr_closed", "pr_reopened"}:
         return False
     if not policy.allow_discord_mutations:
         return False
@@ -338,26 +338,47 @@ def update_pr_channel_announcement_for_event(
         # Pre-feature / untracked opens: do not invent edits for old Discord messages.
         return False
 
-    status = "merged" if event.event_type == "pr_merged" else "closed"
+    if event.event_type == "pr_merged":
+        status = "merged"
+    elif event.event_type == "pr_closed":
+        status = "closed"
+    else:
+        status = "open"
+
     if tracked.get("status") == status:
         return False
 
-    actor = _pr_lifecycle_actor(event)
-    built = _build_pr_lifecycle_channel_message(
-        event,
-        github_org,
-        status=status,
-        actor_github=actor or "",
-        tracked=tracked,
-    )
-    if not built:
-        return False
-    message, embeds = built
+    if status == "open":
+        author_github = tracked.get("author_github") or event.github_user or ""
+        discord_user_id = _resolve_github_to_discord(storage, author_github)
+        
+        # event payload might not have 'title' for pr_reopened depending on adapter, so fallback to tracked
+        if not event.payload.get("title") and tracked.get("pr_title"):
+            event.payload["title"] = tracked["pr_title"]
+            
+        message = _build_pr_opened_channel_message(
+            event, github_org, author_github, discord_user_id
+        )
+        if not message:
+            return False
+        embeds = []
+    else:
+        actor = _pr_lifecycle_actor(event)
+        built = _build_pr_lifecycle_channel_message(
+            event,
+            github_org,
+            status=status,
+            actor_github=actor or "",
+            tracked=tracked,
+        )
+        if not built:
+            return False
+        message, embeds = built
 
     dedupe_key = f"pr_channel_lifecycle:{event.repo}:{pr_number}:{status}"
     try:
         claimed = _claim_notification_sent(
-            storage, dedupe_key, event, "", tracked.get("channel_id"), actor or ""
+            storage, dedupe_key, event, "", tracked.get("channel_id"), actor if status != "open" else author_github
         )
     except Exception as exc:
         logger.warning(
@@ -445,7 +466,8 @@ def update_pr_channel_announcement_for_event(
                 extra={"error": str(exc), "repo": event.repo, "pr_number": pr_number},
             )
             return False
-    _audit_notification(storage, event, "", tracked.get("channel_id"), actor or "")
+    actor_name = author_github if status == "open" else (actor or "")
+    _audit_notification(storage, event, "", tracked.get("channel_id"), actor_name)
     return True
 
 

--- a/src/ghdcbot/engine/notifications.py
+++ b/src/ghdcbot/engine/notifications.py
@@ -1038,15 +1038,15 @@ def _build_pr_lifecycle_channel_message(
     raw_url = f"https://github.com/{github_org}/{repo}/pull/{pr_number}"
     actor = (actor_github or "").lstrip("@").strip()
     if status == "merged":
-        label = "Merged"
+        label = "Merged 🟣"
         status_line = f"**Status:** Merged by @{actor}" if actor else "**Status:** Merged"
         color = _GITHUB_MERGED_PURPLE
     else:
-        label = "Closed"
+        label = "Closed 🔴"
         status_line = f"**Status:** Closed by @{actor}" if actor else "**Status:** Closed"
         color = _GITHUB_CLOSED_RED
     # Discord embed titles are plain text (no markdown links); put the link in url.
-    title = f"{label}: {repo} #{pr_number} — {pr_title}"
+    title = f"{label} {repo} #{pr_number} — {pr_title}"
     if len(title) > 256:
         title = title[:253] + "..."
     embeds = [

--- a/src/ghdcbot/engine/notifications.py
+++ b/src/ghdcbot/engine/notifications.py
@@ -468,6 +468,7 @@ def update_pr_channel_announcement_for_event(
             return False
     actor_name = author_github if status == "open" else (actor or "")
     _audit_notification(storage, event, "", tracked.get("channel_id"), actor_name)
+    _release_notification_claim(storage, dedupe_key)
     return True
 
 

--- a/src/ghdcbot/engine/orchestrator.py
+++ b/src/ghdcbot/engine/orchestrator.py
@@ -355,7 +355,7 @@ def _send_notifications_for_new_events(
                         "pr_author": event.payload.get("pr_author"),
                     },
                 )
-            if event.event_type in {"pr_merged", "pr_closed"}:
+            if event.event_type in {"pr_merged", "pr_closed", "pr_reopened"}:
                 try:
                     if update_pr_channel_announcement_for_event(
                         event, storage, discord_writer, policy, config, github_org

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1446,6 +1446,83 @@ def test_update_pr_channel_announcement_reopened() -> None:
     assert "<@d-bob>" in edited_msg
 
 
+def test_update_pr_channel_announcement_reopened_fallback() -> None:
+    storage = MockStorage()
+    discord_writer = MockDiscordWriter()
+    storage.save_pr_channel_announcement(
+        repo="MiniChain",
+        pr_number=7,
+        channel_id="chan-2",
+        message_id="msg-2",
+        pr_title="TrackedTitle",
+        author_github="bob",
+        status="closed",
+    )
+    config = NotificationConfig(enabled=True, update_pr_channel_on_lifecycle=True)
+    policy = MutationPolicy(mode=RunMode.ACTIVE, github_write_allowed=True, discord_write_allowed=True)
+    event = ContributionEvent(
+        github_user="bob",
+        event_type="pr_reopened",
+        repo="MiniChain",
+        created_at=datetime.now(UTC),
+        payload={"pr_number": 7},  # No title here
+    )
+
+    assert update_pr_channel_announcement_for_event(
+        event, storage, discord_writer, policy, config, "StabilityNexus"
+    )
+    assert len(discord_writer.messages_edited) == 1
+    edited_msg = discord_writer.messages_edited[0][2]
+    assert "TrackedTitle" in edited_msg
+
+
+def test_update_pr_channel_announcement_close_reopen_close() -> None:
+    storage = MockStorage()
+    discord_writer = MockDiscordWriter()
+    storage.save_pr_channel_announcement(
+        repo="MiniChain",
+        pr_number=7,
+        channel_id="chan-2",
+        message_id="msg-2",
+        pr_title="WIP",
+        author_github="bob",
+        status="open",
+    )
+    config = NotificationConfig(enabled=True, update_pr_channel_on_lifecycle=True)
+    policy = MutationPolicy(mode=RunMode.ACTIVE, github_write_allowed=True, discord_write_allowed=True)
+
+    close_event1 = ContributionEvent(
+        github_user="bob",
+        event_type="pr_closed",
+        repo="MiniChain",
+        created_at=datetime.now(UTC),
+        payload={"pr_number": 7, "closed_by": "bob"},
+    )
+    assert update_pr_channel_announcement_for_event(close_event1, storage, discord_writer, policy, config, "test")
+    storage.mark_pr_channel_announcement_status("MiniChain", 7, "closed")
+    
+    reopen_event = ContributionEvent(
+        github_user="bob",
+        event_type="pr_reopened",
+        repo="MiniChain",
+        created_at=datetime.now(UTC),
+        payload={"pr_number": 7},
+    )
+    assert update_pr_channel_announcement_for_event(reopen_event, storage, discord_writer, policy, config, "test")
+    storage.mark_pr_channel_announcement_status("MiniChain", 7, "open")
+
+    close_event2 = ContributionEvent(
+        github_user="bob",
+        event_type="pr_closed",
+        repo="MiniChain",
+        created_at=datetime.now(UTC),
+        payload={"pr_number": 7, "closed_by": "bob"},
+    )
+    assert update_pr_channel_announcement_for_event(close_event2, storage, discord_writer, policy, config, "test")
+    
+    assert len(discord_writer.messages_edited) == 3
+
+
 def test_update_pr_channel_announcement_skips_untracked_old_messages() -> None:
     storage = MockStorage()
     discord_writer = MockDiscordWriter()

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1626,7 +1626,8 @@ def test_update_pr_channel_announcement_releases_claim_when_audit_fails() -> Non
 
     # Discord was edited and DB was marked closed, but dedupe was released.
     assert len(discord_writer.messages_edited) == 1
-    assert "Closed 🔴" in discord_writer.messages_edited[0][2]
+    assert discord_writer.messages_edited[0][2] == ""
+    assert "Closed 🔴" in discord_writer.messages_edited[0][3][0]["title"]
 
     # 2. Simulate pr_reopened
     reopen_event = ContributionEvent(
@@ -1644,8 +1645,8 @@ def test_update_pr_channel_announcement_releases_claim_when_audit_fails() -> Non
         )
 
     assert len(discord_writer.messages_edited) == 2
-    assert "Reopened 🔵" in discord_writer.messages_edited[1][2]
-    assert storage.get_pr_channel_announcement("Gitcord-GithubDiscordBot", 42)["status"] == "reopened"
+    assert "Test PR" in discord_writer.messages_edited[1][2]
+    assert storage.get_pr_channel_announcement("Gitcord-GithubDiscordBot", 42)["status"] == "open"
 
 
 def test_sqlite_pr_channel_announcement_roundtrip(tmp_path) -> None:

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -2236,7 +2236,7 @@ def test_update_issue_channel_announcement_edits_on_close() -> None:
     assert content == ""
     assert embeds
     assert embeds[0]["color"] == 0xCF222E
-    assert "Closed 🔴 Gitcord-GithubDiscordBot #7" in embeds[0]["title"]
+    assert "Closed: Gitcord-GithubDiscordBot #7" in embeds[0]["title"]
     assert "**Opened by:**" not in embeds[0]["title"]
     assert "**Assigned to:**" not in (embeds[0].get("description") or "")
     assert "Closed by @mentor1" in embeds[0]["description"]

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1499,7 +1499,7 @@ def test_update_pr_channel_announcement_close_reopen_close() -> None:
         payload={"pr_number": 7, "closed_by": "bob"},
     )
     assert update_pr_channel_announcement_for_event(close_event1, storage, discord_writer, policy, config, "test")
-    storage.mark_pr_channel_announcement_status("MiniChain", 7, "closed")
+    assert storage.get_pr_channel_announcement("MiniChain", 7)["status"] == "closed"
     
     reopen_event = ContributionEvent(
         github_user="bob",
@@ -1509,7 +1509,7 @@ def test_update_pr_channel_announcement_close_reopen_close() -> None:
         payload={"pr_number": 7},
     )
     assert update_pr_channel_announcement_for_event(reopen_event, storage, discord_writer, policy, config, "test")
-    storage.mark_pr_channel_announcement_status("MiniChain", 7, "open")
+    assert storage.get_pr_channel_announcement("MiniChain", 7)["status"] == "open"
 
     close_event2 = ContributionEvent(
         github_user="bob",
@@ -1519,6 +1519,7 @@ def test_update_pr_channel_announcement_close_reopen_close() -> None:
         payload={"pr_number": 7, "closed_by": "bob"},
     )
     assert update_pr_channel_announcement_for_event(close_event2, storage, discord_writer, policy, config, "test")
+    assert storage.get_pr_channel_announcement("MiniChain", 7)["status"] == "closed"
     
     assert len(discord_writer.messages_edited) == 3
 

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1603,7 +1603,7 @@ def test_update_pr_channel_announcement_releases_claim_when_audit_fails() -> Non
         status="open",
     )
 
-    def _boom(*args: Any) -> None:
+    def _boom(*args, **kwargs) -> None:
         raise RuntimeError("audit failed")
 
     storage.append_audit_event = _boom  # type: ignore[method-assign]

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1587,6 +1587,67 @@ def test_update_pr_channel_announcement_releases_claim_when_status_mark_fails() 
     assert storage.get_pr_channel_announcement("Gitcord-GithubDiscordBot", 42)["status"] == "open"
 
 
+def test_update_pr_channel_announcement_releases_claim_when_audit_fails() -> None:
+    """If audit appending fails, release claim for the closed event so reopen can still happen."""
+    import pytest
+
+    storage = MockStorage()
+    discord_writer = MockDiscordWriter()
+    storage.save_pr_channel_announcement(
+        repo="Gitcord-GithubDiscordBot",
+        pr_number=42,
+        channel_id="chan-1",
+        message_id="msg-9",
+        pr_title="Test PR",
+        author_github="alice",
+        status="open",
+    )
+
+    def _boom(*args: Any) -> None:
+        raise RuntimeError("audit failed")
+
+    storage.append_audit_event = _boom  # type: ignore[method-assign]
+    config = NotificationConfig(enabled=True, update_pr_channel_on_lifecycle=True)
+    policy = MutationPolicy(mode=RunMode.ACTIVE, github_write_allowed=True, discord_write_allowed=True)
+
+    # 1. Simulate pr_closed
+    close_event = ContributionEvent(
+        github_user="alice",
+        event_type="pr_closed",
+        repo="Gitcord-GithubDiscordBot",
+        created_at=datetime.now(UTC),
+        payload={"pr_number": 42, "title": "Test PR", "closed_by": "mentor1"},
+    )
+
+    with pytest.raises(RuntimeError, match="audit failed"):
+        update_pr_channel_announcement_for_event(
+            close_event, storage, discord_writer, policy, config, "AOSSIE-Org"
+        )
+
+    # Discord was edited and DB was marked closed, but dedupe was released.
+    assert len(discord_writer.messages_edited) == 1
+    assert "Closed 🔴" in discord_writer.messages_edited[0][2]
+
+    # 2. Simulate pr_reopened
+    reopen_event = ContributionEvent(
+        github_user="alice",
+        event_type="pr_reopened",
+        repo="Gitcord-GithubDiscordBot",
+        created_at=datetime.now(UTC),
+        payload={"pr_number": 42, "title": "Test PR"},
+    )
+
+    # Even if audit fails again, the Discord edit happens and DB marks it reopened.
+    with pytest.raises(RuntimeError, match="audit failed"):
+        update_pr_channel_announcement_for_event(
+            reopen_event, storage, discord_writer, policy, config, "AOSSIE-Org"
+        )
+
+    assert len(discord_writer.messages_edited) == 2
+    assert "Reopened 🔵" in discord_writer.messages_edited[1][2]
+    assert storage.get_pr_channel_announcement("Gitcord-GithubDiscordBot", 42)["status"] == "reopened"
+
+
 def test_sqlite_pr_channel_announcement_roundtrip(tmp_path) -> None:
     storage = SqliteStorage(tmp_path / "state.db")
     storage.init_schema()

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1411,6 +1411,41 @@ def test_update_pr_channel_announcement_edits_on_close() -> None:
     assert "Closed by @bob" in embeds[0]["description"]
 
 
+def test_update_pr_channel_announcement_reopened() -> None:
+    storage = MockStorage()
+    discord_writer = MockDiscordWriter()
+    storage.verified_mappings = [{"github_user": "bob", "discord_user_id": "d-bob"}]
+    storage.save_pr_channel_announcement(
+        repo="MiniChain",
+        pr_number=7,
+        channel_id="chan-2",
+        message_id="msg-2",
+        pr_title="WIP",
+        author_github="bob",
+        status="closed",
+    )
+    config = NotificationConfig(enabled=True, update_pr_channel_on_lifecycle=True)
+    policy = MutationPolicy(mode=RunMode.ACTIVE, github_write_allowed=True, discord_write_allowed=True)
+    event = ContributionEvent(
+        github_user="bob",
+        event_type="pr_reopened",
+        repo="MiniChain",
+        created_at=datetime.now(UTC),
+        payload={"pr_number": 7, "title": "WIP"},
+    )
+
+    assert update_pr_channel_announcement_for_event(
+        event, storage, discord_writer, policy, config, "StabilityNexus"
+    )
+    assert len(discord_writer.messages_edited) == 1
+    edited_msg = discord_writer.messages_edited[0][2]
+    embeds = discord_writer.messages_edited[0][3]
+    assert not embeds
+    assert "New PR:" in edited_msg
+    assert "WIP" in edited_msg
+    assert "<@d-bob>" in edited_msg
+
+
 def test_update_pr_channel_announcement_skips_untracked_old_messages() -> None:
     storage = MockStorage()
     discord_writer = MockDiscordWriter()

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1340,7 +1340,7 @@ def test_update_pr_channel_announcement_edits_on_merge() -> None:
     assert content == ""
     assert embeds
     assert embeds[0]["color"] == 0x8250DF
-    assert "Merged:" in embeds[0]["title"]
+    assert "Merged 🟣" in embeds[0]["title"]
     assert "Merged by @mentor1" in embeds[0]["description"]
     assert storage.get_pr_channel_announcement("Gitcord-GithubDiscordBot", 42)["status"] == "merged"
 
@@ -1407,7 +1407,7 @@ def test_update_pr_channel_announcement_edits_on_close() -> None:
     embeds = discord_writer.messages_edited[0][3]
     assert embeds
     assert embeds[0]["color"] == 0xCF222E
-    assert "Closed:" in embeds[0]["title"]
+    assert "Closed 🔴" in embeds[0]["title"]
     assert "Closed by @bob" in embeds[0]["description"]
 
 
@@ -2236,7 +2236,7 @@ def test_update_issue_channel_announcement_edits_on_close() -> None:
     assert content == ""
     assert embeds
     assert embeds[0]["color"] == 0xCF222E
-    assert "Closed: Gitcord-GithubDiscordBot #7" in embeds[0]["title"]
+    assert "Closed 🔴 Gitcord-GithubDiscordBot #7" in embeds[0]["title"]
     assert "**Opened by:**" not in embeds[0]["title"]
     assert "**Assigned to:**" not in (embeds[0].get("description") or "")
     assert "Closed by @mentor1" in embeds[0]["description"]

--- a/tests/test_pr_status.py
+++ b/tests/test_pr_status.py
@@ -1515,7 +1515,7 @@ class TestRepoRecommendationAndAutocomplete:
         )
 
         modal = PRStatusModal(repo="Knowledge-Agent", config=cfg, github_adapter=MagicMock())
-        modal.pr_number.value = "1"
+        modal.pr_number._value = "1"
 
         with patch("ghdcbot.bot.fetch_pr_health", return_value=sample_health):
             await modal.on_submit(mock_interaction)
@@ -1883,7 +1883,7 @@ class TestRepoRecommendationAndAutocomplete:
         )
 
         modal = PRStatusModal(repo=None, config=cfg, github_adapter=MagicMock())
-        modal.pr_number.value = "2"
+        modal.pr_number._value = "2"
 
         # Call WITHOUT repo parameter
         with patch("ghdcbot.bot.fetch_pr_health", return_value=sample_health) as mock_fetch:

--- a/tests/test_pr_status.py
+++ b/tests/test_pr_status.py
@@ -1467,12 +1467,10 @@ class TestRepoRecommendationAndAutocomplete:
 
     @pytest.mark.asyncio
     async def test_pr_status_single_pr_suppress_embeds(self) -> None:
-        """pr_status_cmd sends single PR status message with suppress_embeds=True."""
+        """PRStatusModal sends single PR status message with suppress_embeds=True."""
         from unittest.mock import AsyncMock, MagicMock, patch
 
-        import discord
-
-        from ghdcbot.bot import run_bot
+        from ghdcbot.bot import PRStatusModal
         from ghdcbot.config.models import (
             BotConfig,
             DiscordConfig,
@@ -1496,34 +1494,6 @@ class TestRepoRecommendationAndAutocomplete:
             discord=DiscordConfig(guild_id="123", token="fake"),
         )
 
-        captured = []
-        orig_tree_init = discord.app_commands.CommandTree.__init__
-
-        def mock_tree_init(tree_self: Any, client: Any) -> None:
-            captured.append(tree_self)
-            orig_tree_init(tree_self, client)
-
-        with (
-            patch("ghdcbot.bot.load_config", return_value=cfg),
-            patch("ghdcbot.bot.resolve_github_token", return_value="fake"),
-            patch("ghdcbot.bot.build_adapter"),
-            patch("ghdcbot.bot.GitHubIdentityReader"),
-            patch("ghdcbot.bot.IdentityLinkService"),
-            patch("ghdcbot.bot.SocialProfileService"),
-            patch("discord.app_commands.CommandTree.__init__", mock_tree_init),
-            patch("discord.Client.run", side_effect=SystemExit(0)),
-        ):
-            try:
-                run_bot("dummy.yaml")
-            except SystemExit:
-                pass
-
-        pr_status = next(
-            cmd
-            for cmd in captured[0].get_commands(guild=discord.Object(id=123))
-            if cmd.name == "pr-status"
-        )
-
         mock_interaction = MagicMock()
         mock_interaction.response.defer = AsyncMock()
         mock_interaction.followup.send = AsyncMock()
@@ -1544,8 +1514,11 @@ class TestRepoRecommendationAndAutocomplete:
             is_draft=False,
         )
 
+        modal = PRStatusModal(repo="Knowledge-Agent", config=cfg, github_adapter=MagicMock())
+        modal.pr_number.value = "1"
+
         with patch("ghdcbot.bot.fetch_pr_health", return_value=sample_health):
-            await pr_status.callback(mock_interaction, repo="Knowledge-Agent", pr_number=1)
+            await modal.on_submit(mock_interaction)
 
         mock_interaction.followup.send.assert_awaited_once()
         kwargs = mock_interaction.followup.send.call_args.kwargs
@@ -1862,12 +1835,10 @@ class TestRepoRecommendationAndAutocomplete:
 
     @pytest.mark.asyncio
     async def test_pr_status_cmd_auto_detects_repo_when_omitted(self) -> None:
-        """pr_status_cmd works end-to-end without repo argument (auto-resolves from config)."""
+        """PRStatusModal works end-to-end without repo argument (auto-resolves from config)."""
         from unittest.mock import AsyncMock, MagicMock, patch
 
-        import discord
-
-        from ghdcbot.bot import run_bot
+        from ghdcbot.bot import PRStatusModal
         from ghdcbot.config.models import (
             BotConfig,
             DiscordConfig,
@@ -1891,34 +1862,6 @@ class TestRepoRecommendationAndAutocomplete:
             discord=DiscordConfig(guild_id="123", token="fake"),
         )
 
-        captured = []
-        orig_tree_init = discord.app_commands.CommandTree.__init__
-
-        def mock_tree_init(tree_self: Any, client: Any) -> None:
-            captured.append(tree_self)
-            orig_tree_init(tree_self, client)
-
-        with (
-            patch("ghdcbot.bot.load_config", return_value=cfg),
-            patch("ghdcbot.bot.resolve_github_token", return_value="fake"),
-            patch("ghdcbot.bot.build_adapter"),
-            patch("ghdcbot.bot.GitHubIdentityReader"),
-            patch("ghdcbot.bot.IdentityLinkService"),
-            patch("ghdcbot.bot.SocialProfileService"),
-            patch("discord.app_commands.CommandTree.__init__", mock_tree_init),
-            patch("discord.Client.run", side_effect=SystemExit(0)),
-        ):
-            try:
-                run_bot("dummy.yaml")
-            except SystemExit:
-                pass
-
-        pr_status = next(
-            cmd
-            for cmd in captured[0].get_commands(guild=discord.Object(id=123))
-            if cmd.name == "pr-status"
-        )
-
         mock_interaction = MagicMock()
         mock_interaction.response.defer = AsyncMock()
         mock_interaction.followup.send = AsyncMock()
@@ -1939,9 +1882,12 @@ class TestRepoRecommendationAndAutocomplete:
             is_draft=False,
         )
 
+        modal = PRStatusModal(repo=None, config=cfg, github_adapter=MagicMock())
+        modal.pr_number.value = "2"
+
         # Call WITHOUT repo parameter
         with patch("ghdcbot.bot.fetch_pr_health", return_value=sample_health) as mock_fetch:
-            await pr_status.callback(mock_interaction, repo=None, pr_number=2)
+            await modal.on_submit(mock_interaction)
 
         # Verify fetch_pr_health was called with auto-detected "Knowledge-Agent"
         mock_fetch.assert_called_once()
@@ -2065,12 +2011,10 @@ class TestRepoRecommendationAndAutocomplete:
 
     @pytest.mark.asyncio
     async def test_pr_status_cmd_informs_when_target_is_issue(self) -> None:
-        """When number points to an Issue rather than a PR, pr_status_cmd explains it clearly."""
+        """When number points to an Issue rather than a PR, PRStatusModal explains it clearly."""
         from unittest.mock import AsyncMock, MagicMock, patch
 
-        import discord
-
-        from ghdcbot.bot import run_bot
+        from ghdcbot.bot import PRStatusModal
         from ghdcbot.config.models import (
             BotConfig,
             DiscordConfig,
@@ -2093,13 +2037,6 @@ class TestRepoRecommendationAndAutocomplete:
             discord=DiscordConfig(guild_id="123", token="fake"),
         )
 
-        captured = []
-        orig_tree_init = discord.app_commands.CommandTree.__init__
-
-        def mock_tree_init(tree_self: Any, client: Any) -> None:
-            captured.append(tree_self)
-            orig_tree_init(tree_self, client)
-
         mock_github = MagicMock()
         # get_pull_request returns None, get_issue returns an issue without 'pull_request'
         mock_github.get_pull_request.return_value = None
@@ -2108,32 +2045,14 @@ class TestRepoRecommendationAndAutocomplete:
             "state": "closed",
         }
 
-        with (
-            patch("ghdcbot.bot.load_config", return_value=cfg),
-            patch("ghdcbot.bot.resolve_github_token", return_value="fake"),
-            patch("ghdcbot.bot.build_adapter", return_value=mock_github),
-            patch("ghdcbot.bot.GitHubIdentityReader"),
-            patch("ghdcbot.bot.IdentityLinkService"),
-            patch("ghdcbot.bot.SocialProfileService"),
-            patch("discord.app_commands.CommandTree.__init__", mock_tree_init),
-            patch("discord.Client.run", side_effect=SystemExit(0)),
-        ):
-            try:
-                run_bot("dummy.yaml")
-            except SystemExit:
-                pass
-
-        pr_status = next(
-            cmd
-            for cmd in captured[0].get_commands(guild=discord.Object(id=123))
-            if cmd.name == "pr-status"
-        )
+        modal = PRStatusModal(repo=None, config=cfg, github_adapter=mock_github)
+        modal.pr_number.value = "1"
 
         mock_interaction = MagicMock()
         mock_interaction.response.defer = AsyncMock()
         mock_interaction.followup.send = AsyncMock()
 
-        await pr_status.callback(mock_interaction, repo=None, pr_number=1)
+        await modal.on_submit(mock_interaction)
 
         mock_interaction.followup.send.assert_awaited_once()
         msg = mock_interaction.followup.send.call_args[0][0]

--- a/tests/test_pr_status.py
+++ b/tests/test_pr_status.py
@@ -2046,7 +2046,7 @@ class TestRepoRecommendationAndAutocomplete:
         }
 
         modal = PRStatusModal(repo=None, config=cfg, github_adapter=mock_github)
-        modal.pr_number.value = "1"
+        modal.pr_number._value = "1"
 
         mock_interaction = MagicMock()
         mock_interaction.response.defer = AsyncMock()


### PR DESCRIPTION
## Description
Resolves #73

Moved the `pr_number`, `show_all`, and `skip` arguments out of the `/pr-status` slash command signature. Instead, the command now launches a Discord UI View with buttons and a Modal to gather this information interactively.

## Changes Made
- Modified `pr_status_cmd` in `src/ghdcbot/bot.py` to only accept `repo`.
- Created `PRStatusView` with "Show All Open PRs" and "Check Specific PR" buttons.
- Created `PRStatusModal` to let users type the PR number if they choose the specific PR route.
- Ensured all existing PR status rendering logic (like issue fallback) is correctly executed within these new UI callbacks.

## Type of Change
- [x] Enhancement (improves UI/UX of an existing feature)

## Testing
- Tested locally with Docker by running `/pr-status`, clicking both buttons, and confirming that the correct PR embed or dashboard is returned.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - `/pr-status` now provides an interactive menu to view all open pull requests or check a specific pull request.
  - Specific pull request checks now use a dedicated number-entry form.
- **Bug Fixes**
  - Pull request status notifications reliably release tracking claims, even when auditing fails.
  - Status updates continue correctly for closed and reopened pull requests despite audit errors.
- **Tests**
  - Expanded coverage for notification recovery and interactive pull request status checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/97ca1f6a-3583-4254-a1c8-c721fe5f6223" />
